### PR TITLE
Setup code coverage reporting tools

### DIFF
--- a/backend/typescript/jest.config.ts
+++ b/backend/typescript/jest.config.ts
@@ -20,24 +20,33 @@ export default {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ["**/*.{ts,tsx}", "!**/*.{config,test,d}.ts", "!/node_modules/**", "!*.{ts,tsx}" ], 
+  collectCoverageFrom: [
+    "**/*.{ts,tsx}",
+    "!**/*.{config,test,d}.ts",
+    "!/node_modules/**",
+    "!*.{ts,tsx}",
+  ],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
   coveragePathIgnorePatterns: [
-    "/node_modules/", "/graphql/", "/models/", "/testUtils/", "/utilities/", "/services/implementations/__tests__/", "/services/interfaces/",
-    "/middlewares/", 
+    "/node_modules/",
+    "/graphql/",
+    "/models/",
+    "/testUtils/",
+    "/utilities/",
+    "/services/implementations/__tests__/",
+    "/services/interfaces/",
+    "/middlewares/",
   ],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: "babel",
 
   // A list of reporter names that Jest uses when writing coverage reports
-  coverageReporters: [
-    "text"
-  ],
+  coverageReporters: ["text"],
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {

--- a/backend/typescript/jest.config.ts
+++ b/backend/typescript/jest.config.ts
@@ -41,12 +41,12 @@ export default {
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
-    "global": {
-      "branches": 80,
-      "functions": 80,
-      "lines": 80,
-      "statements": -10
-    }
+    // "global": {
+    //   "branches": 80,
+    //   "functions": 80,
+    //   "lines": 80,
+    //   "statements": -10
+    // }
   },
 
   // A path to a custom dependency extractor

--- a/backend/typescript/jest.config.ts
+++ b/backend/typescript/jest.config.ts
@@ -17,32 +17,37 @@ export default {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: false,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  collectCoverageFrom: ["**/*.{ts,tsx}", "!**/*.{config,test,d}.ts", "!/node_modules/**", "!*.{ts,tsx}" ], 
 
   // The directory where Jest should output its coverage files
-  // coverageDirectory: "coverage",
+  coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/", "/graphql/", "/models/", "/testUtils/", "/utilities/", "/services/implementations/__tests__/", "/services/interfaces/",
+    "/middlewares/", 
+  ],
 
   // Indicates which provider should be used to instrument code for coverage
-  // coverageProvider: "babel",
+  coverageProvider: "babel",
 
   // A list of reporter names that Jest uses when writing coverage reports
-  // coverageReporters: [
-  //   "json",
-  //   "text",
-  //   "lcov",
-  //   "clover"
-  // ],
+  coverageReporters: [
+    "text"
+  ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    "global": {
+      "branches": 80,
+      "functions": 80,
+      "lines": 80,
+      "statements": -10
+    }
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Setup code coverage reporting tools](https://www.notion.so/uwblueprintexecs/Setup-code-coverage-reporting-tools-adeee3d2f348406b81114754f679484d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* edited values in `jest.config.ts` in `backend/typescript`
* modified code coverage to exclude test files, config files, interfaces, and any pre-written code that aren't part of the services
* every time yarn test is run now, it will show the code coverage % as well as the lines missing code coverage in each file


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. run `yarn test` in `backend/typescript`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* `jest.config.ts`, particularly making sure the globs are representative of what we want to check for code coverage


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
