### PR TITLE
Updating Vault post-merge hook to use project path

### DIFF
--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -4,7 +4,7 @@
 branch=`git symbolic-ref HEAD`
 root_dir=`git rev-parse --show-toplevel`
 # must replace with actual vault_path and default_branch, can run setup.sh
-vault_path="kv/internal-tools"
+vault_path="kv/jump-math"
 default_branch="main"
 
 if [ $branch = "refs/heads/${default_branch}" ]; then


### PR DESCRIPTION
## Implementation description
* Updating post-merge hook to use our project's path `jump-math` (instead of `internal-tools`).