### PR TITLE
Implement Method to Get All Test Sessions

### DIFF
--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -4,7 +4,7 @@ import mongoose, { Schema, Document } from "mongoose";
  * This interface holds information about the result of a single student
  * on a test
  */
-export interface Result {
+export interface Result extends Document {
   /** the name of the student */
   student: string;
   /** the score of the student */
@@ -13,12 +13,12 @@ export interface Result {
    * a list corresponding to the question list with each field indicating
    * the student's answer
    */
-  answers: [number];
+  answers: number[];
   /**
    * a list corresponding to the question list with each fielding indicating
    * whether the student got the question right or not
    * */
-  breakdown: [boolean];
+  breakdown: boolean[];
 }
 
 const ResultSchema: Schema = new Schema({
@@ -58,7 +58,7 @@ export interface TestSession extends Document {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: [Result];
+  results?: Result[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -4,6 +4,7 @@ import db from "../../../testUtils/testDb";
 import MgTestSession from "../../../models/testSession.model";
 import {
   assertResponseMatchesExpected,
+  assertResultsResponseMatchesExpected,
   mockTestSession,
 } from "../../../testUtils/testSession";
 
@@ -30,7 +31,8 @@ describe("mongo testSessionService", (): void => {
     const res = await testSessionService.createTestSession(mockTestSession);
 
     // TODO: uncomment when results are added to test session response object
-    // assertResponseMatchesExpected(mockTestSession, res);
+    assertResponseMatchesExpected(mockTestSession, res);
+    expect(res.results).toBeUndefined();
   });
 
   it("getAllTestSessions", async () => {
@@ -38,5 +40,6 @@ describe("mongo testSessionService", (): void => {
 
     const res = await testSessionService.getAllTestSessions();
     assertResponseMatchesExpected(mockTestSession, res[0]);
+    assertResultsResponseMatchesExpected(mockTestSession, res[0]);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -1,7 +1,11 @@
 import TestSessionService from "../testSessionService";
 
-import mockTestSession from "../../../testUtils/testSession";
 import db from "../../../testUtils/testDb";
+import MgTestSession from "../../../models/testSession.model";
+import {
+  assertResponseMatchesExpected,
+  mockTestSession,
+} from "../../../testUtils/testSession";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
@@ -25,10 +29,14 @@ describe("mongo testSessionService", (): void => {
   it("createTestSession", async () => {
     const res = await testSessionService.createTestSession(mockTestSession);
 
-    expect(res.id).not.toBeNull();
-    expect(res).toMatchObject({
-      id: res.id,
-      ...mockTestSession,
-    });
+    // TODO: uncomment when results are added to test session response object
+    // assertResponseMatchesExpected(mockTestSession, res);
+  });
+
+  it("getAllTestSessions", async () => {
+    await MgTestSession.create(mockTestSession);
+
+    const res = await testSessionService.getAllTestSessions();
+    assertResponseMatchesExpected(mockTestSession, res[0]);
   });
 });

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -38,6 +38,53 @@ class TestSessionService implements ITestSessionService {
       startTime: newTestSession.startTime,
     };
   }
+
+  async getAllTestSessions(): Promise<Array<TestSessionResponseDTO>> {
+    let testSessionDtos: Array<TestSessionResponseDTO> = [];
+
+    try {
+      const testSessions: Array<TestSession> = await MgTestSession.find();
+      testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(
+        testSessions,
+      );
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get test sessions. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+
+    return testSessionDtos;
+  }
+
+  private async mapTestSessionsToTestSessionDTOs(
+    testSessions: Array<TestSession>,
+  ): Promise<Array<TestSessionResponseDTO>> {
+    const testSessionDtos: Array<TestSessionResponseDTO> = await Promise.all(
+      testSessions.map(async (testSession) => {
+        return {
+          id: testSession.id,
+          test: testSession.test,
+          teacher: testSession.teacher,
+          school: testSession.school,
+          gradeLevel: testSession.gradeLevel,
+          results: testSession.results?.map((testSessionResult) => {
+            return {
+              id: testSessionResult.id,
+              student: testSessionResult.student,
+              score: testSessionResult.score,
+              answers: testSessionResult.answers,
+              breakdown: testSessionResult.breakdown,
+            };
+          }),
+          accessCode: testSession.accessCode,
+          startTime: testSession.startTime,
+        };
+      }),
+    );
+
+    return testSessionDtos;
+  }
 }
 
 export default TestSessionService;

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -17,7 +17,7 @@ export interface TestSessionRequestDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: [Result];
+  results?: ResultRequestDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
@@ -43,11 +43,47 @@ export interface TestSessionResponseDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: [Result];
+  results?: ResultResponseDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
   startTime: Date;
+}
+
+export interface ResultRequestDTO {
+  /** the name of the student */
+  student: string;
+  /** the score of the student */
+  score: number;
+  /**
+   * a list corresponding to the question list with each field indicating
+   * the student's answer
+   */
+  answers: number[];
+  /**
+   * a list corresponding to the question list with each fielding indicating
+   * whether the student got the question right or not
+   * */
+  breakdown: boolean[];
+}
+
+export interface ResultResponseDTO {
+  /** the unique identifier of the response */
+  id: string;
+  /** the name of the student */
+  student: string;
+  /** the score of the student */
+  score: number;
+  /**
+   * a list corresponding to the question list with each field indicating
+   * the student's answer
+   */
+  answers: number[];
+  /**
+   * a list corresponding to the question list with each fielding indicating
+   * whether the student got the question right or not
+   * */
+  breakdown: boolean[];
 }
 
 export interface ITestSessionService {
@@ -60,4 +96,9 @@ export interface ITestSessionService {
   createTestSession(
     testSession: TestSessionRequestDTO,
   ): Promise<TestSessionResponseDTO>;
+
+  /**
+   * This method fetches all the test sessions from the database.
+   */
+  getAllTestSessions(): Promise<Array<TestSessionResponseDTO>>;
 }

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -8,7 +8,7 @@ export const testResult: ResultRequestDTO = {
   student: "some-student-name",
   score: 25,
   answers: [10, 11],
-  breakdown: [false, true, true],
+  breakdown: [false, true],
 };
 
 export const mockTestSession: TestSessionRequestDTO = {

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -1,10 +1,49 @@
-const mockTestSession = {
+import {
+  ResultRequestDTO,
+  TestSessionRequestDTO,
+  TestSessionResponseDTO,
+} from "../services/interfaces/testSessionService";
+
+export const testResult: ResultRequestDTO = {
+  student: "some-student-name",
+  score: 25,
+  answers: [10, 11],
+  breakdown: [false, true, true],
+};
+
+export const mockTestSession: TestSessionRequestDTO = {
   test: "62c248c0f79d6c3c9ebbea95",
   teacher: "62c248c0f79d6c3c9ebbea94",
   school: "62c248c0f79d6c3c9ebbea93",
   gradeLevel: 4,
+  results: [testResult],
   accessCode: "1234",
   startTime: new Date("2021-09-01T09:00:00.000Z"),
 };
 
-export default mockTestSession;
+export const assertResponseMatchesExpected = (
+  expected: TestSessionRequestDTO,
+  result: TestSessionResponseDTO,
+): void => {
+  expect(result.id).not.toBeNull();
+  expect(result.test.toString()).toEqual(expected.test);
+  expect(result.teacher.toString()).toEqual(expected.teacher);
+  expect(result.school.toString()).toEqual(expected.school);
+  expect(result.gradeLevel).toEqual(expected.gradeLevel);
+  expect(result.accessCode).toEqual(expected.accessCode);
+  expect(result.startTime).toEqual(expected.startTime);
+
+  const actualResults = result.results != null ? result.results[0] : null;
+  const expectedResults = expected.results != null ? expected.results[0] : null;
+
+  expect(actualResults?.id).not.toBeNull();
+  expect(
+    Array.from(actualResults != null ? Array.from(actualResults.answers) : []),
+  ).toEqual(expectedResults?.answers);
+  expect(
+    Array.from(
+      actualResults != null ? Array.from(actualResults.breakdown) : [],
+    ),
+  ).toEqual(expectedResults?.breakdown);
+  expect(actualResults?.score).toEqual(expectedResults?.score);
+};

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -32,7 +32,12 @@ export const assertResponseMatchesExpected = (
   expect(result.gradeLevel).toEqual(expected.gradeLevel);
   expect(result.accessCode).toEqual(expected.accessCode);
   expect(result.startTime).toEqual(expected.startTime);
+};
 
+export const assertResultsResponseMatchesExpected = (
+  expected: TestSessionRequestDTO,
+  result: TestSessionResponseDTO,
+): void => {
   const actualResults = result.results != null ? result.results[0] : null;
   const expectedResults = expected.results != null ? expected.results[0] : null;
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Get all test sessions](https://www.notion.so/uwblueprintexecs/Get-all-test-sessions-b77ba97e037341ac862deff161b65a53)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a new function `getAllTestSessions` to fetch all the test sessions from the database
* Fixed some bugs/syntax errors


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
