### PR TITLE
Fix: Remove stringification of ids

### DIFF
--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -24,7 +24,9 @@ describe("mongo testSessionService", (): void => {
 
   it("createTestSession", async () => {
     const res = await testSessionService.createTestSession(mockTestSession);
-
+    res.test = res.test.toString()
+    res.teacher = res.teacher.toString()
+    res.school = res.school.toString()
     expect(res.id).not.toBeNull();
     expect(res).toMatchObject({
       id: res.id,

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -30,9 +30,9 @@ class TestSessionService implements ITestSessionService {
 
     return {
       id: newTestSession.id,
-      test: String(newTestSession.test),
-      teacher: String(newTestSession.teacher),
-      school: String(newTestSession.school),
+      test: newTestSession.test,
+      teacher: newTestSession.teacher,
+      school: newTestSession.school,
       gradeLevel: newTestSession.gradeLevel,
       accessCode: newTestSession.accessCode,
       startTime: newTestSession.startTime,

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -1,5 +1,3 @@
-import { Result } from "../../models/testSession.model";
-
 /**
  * This interface contains the request object that is fed into
  * the school service to create or update the test session in the database.


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix createTestSession to not stringify](https://www.notion.so/uwblueprintexecs/Fix-createTestSession-to-not-stringify-8a39890880c64fdb84a1c2f9e07929e5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove `String()` to keep ids as ObjectIds and make the code consistent with the rest of the service
* Test code will be replaced by the helper function in https://github.com/uwblueprint/jump-math/pull/25


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
