### PR TITLE
Feat: add getTestSessionsByTeacherId

### DIFF
--- a/backend/services/implementations/__tests__/schoolService.test.ts
+++ b/backend/services/implementations/__tests__/schoolService.test.ts
@@ -73,9 +73,8 @@ describe("mongo schoolService", (): void => {
     const invalidRegion = "fake-region";
 
     // execute and assert
-    await expect(async () => {
-      await schoolService.getSchoolsBySubregion(invalidRegion);
-    }).rejects.toThrowError(`Sub region ${invalidRegion} not found`);
+    const res = await schoolService.getSchoolsBySubregion(invalidRegion);
+    expect(res.length).toEqual(0);
   });
 
   it("create school for valid teachers", async () => {

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -2,7 +2,6 @@ import TestSessionService from "../testSessionService";
 
 import db from "../../../testUtils/testDb";
 import MgTestSession from "../../../models/testSession.model";
-import TestSessionModel from "../../../models/testSession.model";
 import {
   assertResponseMatchesExpected,
   assertResultsResponseMatchesExpected,
@@ -48,7 +47,9 @@ describe("mongo testSessionService", (): void => {
     await MgTestSession.create(mockTestSession);
 
     // execute
-    const res = await testSessionService.getTestSessionsByTeacherId(mockTestSession.teacher);
+    const res = await testSessionService.getTestSessionsByTeacherId(
+      mockTestSession.teacher,
+    );
 
     // assert
     assertResponseMatchesExpected(mockTestSession, res[0]);
@@ -60,6 +61,8 @@ describe("mongo testSessionService", (): void => {
 
     await expect(async () => {
       await testSessionService.getTestSessionsByTeacherId(invalidId);
-    }).rejects.toThrowError(`Test session for teacher id ${invalidId} not found`);
+    }).rejects.toThrowError(
+      `Test session for teacher id ${invalidId} not found`,
+    );
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -63,6 +63,7 @@ describe("mongo testSessionService", (): void => {
 
     const res = await testSessionService.getTestSessionsByTeacherId(invalidId);
     expect(res.length).toEqual(0);
+  });
 
   it("deleteTestSession", async () => {
     const savedTestSession = await MgTestSession.create(mockTestSession);;

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -62,6 +62,7 @@ describe("mongo testSessionService", (): void => {
     const invalidId = "56cb91bdc3464f14678934ca";
 
     const res = await testSessionService.getTestSessionsByTeacherId(invalidId);
+    expect(res.length).toEqual(0);
   });
   
   it("getTestSessionsByTestId", async () => {

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -57,12 +57,10 @@ describe("mongo testSessionService", (): void => {
   });
 
   it("getTestSessionsByTeacherId for invalid teacher id", async () => {
+    await MgTestSession.create(mockTestSession);
     const invalidId = "56cb91bdc3464f14678934ca";
 
-    await expect(async () => {
-      await testSessionService.getTestSessionsByTeacherId(invalidId);
-    }).rejects.toThrowError(
-      `Test session for teacher id ${invalidId} not found`,
-    );
+    const res = await testSessionService.getTestSessionsByTeacherId(invalidId);
+    expect(res.length).toEqual(0);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -2,14 +2,18 @@ import TestSessionService from "../testSessionService";
 
 import db from "../../../testUtils/testDb";
 import MgTestSession from "../../../models/testSession.model";
+import TestSessionModel from "../../../models/testSession.model";
 import {
   assertResponseMatchesExpected,
   assertResultsResponseMatchesExpected,
   mockTestSession,
 } from "../../../testUtils/testSession";
+import UserService from "../userService";
+import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
+  let userService: UserService;
 
   beforeAll(async () => {
     await db.connect();
@@ -20,7 +24,8 @@ describe("mongo testSessionService", (): void => {
   });
 
   beforeEach(async () => {
-    testSessionService = new TestSessionService();
+    userService = new UserService();
+    testSessionService = new TestSessionService(userService);
   });
 
   afterEach(async () => {
@@ -41,5 +46,26 @@ describe("mongo testSessionService", (): void => {
     const res = await testSessionService.getAllTestSessions();
     assertResponseMatchesExpected(mockTestSession, res[0]);
     assertResultsResponseMatchesExpected(mockTestSession, res[0]);
+  });
+
+  it("getTestSessionsByTeacherId for valid teacher id", async () => {
+    await TestSessionModel.insertMany(mockTestSession);
+    // execute
+    const res = await testSessionService.getTestSessionsByTeacherId(mockTestSession.teacher);
+
+    // assert
+    res.forEach((testSession: TestSessionResponseDTO, i) => {
+      assertResponseMatchesExpected(testSession, res[i]);
+    });
+  });
+
+  it("getTestSessionsByTeacherId for invalid teacher id", async () => {
+    userService.findAllUsersByIds = jest.fn().mockReturnValue([]);
+    const invalidId = "1234";
+
+    // execute and assert
+    await expect(async () => {
+      testSessionService.getTestSessionsByTeacherId(invalidId);
+    }).rejects.toThrowError(`Test session for teacher id ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -8,12 +8,9 @@ import {
   assertResultsResponseMatchesExpected,
   mockTestSession,
 } from "../../../testUtils/testSession";
-import UserService from "../userService";
-import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
-  let userService: UserService;
 
   beforeAll(async () => {
     await db.connect();
@@ -24,8 +21,7 @@ describe("mongo testSessionService", (): void => {
   });
 
   beforeEach(async () => {
-    userService = new UserService();
-    testSessionService = new TestSessionService(userService);
+    testSessionService = new TestSessionService();
   });
 
   afterEach(async () => {
@@ -49,23 +45,21 @@ describe("mongo testSessionService", (): void => {
   });
 
   it("getTestSessionsByTeacherId for valid teacher id", async () => {
-    await TestSessionModel.insertMany(mockTestSession);
+    await MgTestSession.create(mockTestSession);
+
     // execute
     const res = await testSessionService.getTestSessionsByTeacherId(mockTestSession.teacher);
 
     // assert
-    res.forEach((testSession: TestSessionResponseDTO, i) => {
-      assertResponseMatchesExpected(testSession, res[i]);
-    });
+    assertResponseMatchesExpected(mockTestSession, res[0]);
+    assertResultsResponseMatchesExpected(mockTestSession, res[0]);
   });
 
   it("getTestSessionsByTeacherId for invalid teacher id", async () => {
-    userService.findAllUsersByIds = jest.fn().mockReturnValue([]);
-    const invalidId = "1234";
+    const invalidId = "56cb91bdc3464f14678934ca";
 
-    // execute and assert
     await expect(async () => {
-      testSessionService.getTestSessionsByTeacherId(invalidId);
+      await testSessionService.getTestSessionsByTeacherId(invalidId);
     }).rejects.toThrowError(`Test session for teacher id ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -35,14 +35,20 @@ class SchoolService implements ISchoolService {
    * This method gets all schools with the given sub-region from the database.
    */
   async getSchoolsBySubregion(subRegion: string): Promise<SchoolResponseDTO[]> {
-    let schoolDtos: Array<SchoolResponseDTO>  = [];
+    let schoolDtos: Array<SchoolResponseDTO> = [];
 
     try {
-      const schools: Array<School> = await MgSchool.find({ subRegion: { $eq: subRegion } });
+      const schools: Array<School> = await MgSchool.find({
+        subRegion: { $eq: subRegion },
+      });
 
       schoolDtos = await this.mapSchoolsToSchoolResponseDTOs(schools);
     } catch (error: unknown) {
-      Logger.error(`Failed to get schools for sub-region ${subRegion}. Reason = ${getErrorMessage(error)}`);
+      Logger.error(
+        `Failed to get schools for sub-region ${subRegion}. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
       throw error;
     }
 

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -35,21 +35,18 @@ class SchoolService implements ISchoolService {
    * This method gets all schools with the given sub-region from the database.
    */
   async getSchoolsBySubregion(subRegion: string): Promise<SchoolResponseDTO[]> {
-    let schools: Array<School> | null;
+    let schoolDtos: Array<SchoolResponseDTO>  = [];
 
     try {
-      schools = await MgSchool.find({ subRegion: { $eq: subRegion } });
+      const schools: Array<School> = await MgSchool.find({ subRegion: { $eq: subRegion } });
 
-      // check if no schools match the given sub-region
-      if (!schools || !schools.length) {
-        throw new Error(`Sub region ${subRegion} not found`);
-      }
-
-      return await this.mapSchoolsToSchoolResponseDTOs(schools);
+      schoolDtos = await this.mapSchoolsToSchoolResponseDTOs(schools);
     } catch (error: unknown) {
-      Logger.error(`Failed to get schools. Reason = ${getErrorMessage(error)}`);
+      Logger.error(`Failed to get schools for sub-region ${subRegion}. Reason = ${getErrorMessage(error)}`);
       throw error;
     }
+
+    return schoolDtos;
   }
 
   private async mapSchoolsToSchoolResponseDTOs(

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -41,7 +41,7 @@ class SchoolService implements ISchoolService {
       schools = await MgSchool.find({ subRegion: { $eq: subRegion } });
 
       // check if no schools match the given sub-region
-      if (!schools.length) {
+      if (!schools || !schools.length) {
         throw new Error(`Sub region ${subRegion} not found`);
       }
 

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -39,22 +39,21 @@ class TestSessionService implements ITestSessionService {
     };
   }
 
-  async deleteTestSession(
-    id: string
-  ): Promise<string> {
-    try{
+  async deleteTestSession(id: string): Promise<string> {
+    try {
       const deletedTestSession = await MgTestSession.findByIdAndDelete(id);
-      if(!deletedTestSession){
+      if (!deletedTestSession) {
         throw new Error(`Test Session id ${id} not found`);
       }
       return id;
-    } catch (error: unknown){
+    } catch (error: unknown) {
       Logger.error(
         `Failed to delete entity. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }
   }
+
   async getAllTestSessions(): Promise<Array<TestSessionResponseDTO>> {
     let testSessionDtos: Array<TestSessionResponseDTO> = [];
 

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -6,17 +6,10 @@ import {
 } from "../interfaces/testSessionService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
-import IUserService from "../interfaces/userService";
 
 const Logger = logger(__filename);
 
 class TestSessionService implements ITestSessionService {
-  userService: IUserService;
-
-  constructor(userService: IUserService) {
-    this.userService = userService;
-  }
-
   /* eslint-disable class-methods-use-this */
   async createTestSession(
     testSession: TestSessionRequestDTO,
@@ -67,20 +60,19 @@ class TestSessionService implements ITestSessionService {
   async getTestSessionsByTeacherId(
     teacherId: string,
   ): Promise<Array<TestSessionResponseDTO>> {
-    let testSessions: Array<TestSession> | null;
+    let testSessionDtos: Array<TestSession> | null;
 
     try {
-      testSessions = await MgTestSession.find({
-        teacherId: { $eq: teacherId },
+      testSessionDtos = await MgTestSession.find({
+        teacher: { $eq: teacherId },
       });
 
       // check if no testSessions are associated with the given teacherId
-      if (!testSessions.length) {
-        console.log(testSessions.length);
+      if (!testSessionDtos || !testSessionDtos.length) {
         throw new Error(`Test session for teacher id ${teacherId} not found`);
       }
 
-      return await this.mapTestSessionsToTestSessionDTOs(testSessions);
+      return await this.mapTestSessionsToTestSessionDTOs(testSessionDtos);
     } catch (error: unknown) {
       Logger.error(
         `Failed to get test sessions. Reason = ${getErrorMessage(error)}`,

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -61,10 +61,10 @@ class TestSessionService implements ITestSessionService {
     teacherId: string,
   ): Promise<Array<TestSessionResponseDTO>> {
     let testSessionDtos: Array<TestSessionResponseDTO> = [];
-    const field = "teacher";
+
     try {
       const testSessions: Array<TestSession> = await MgTestSession.find({
-        [field]: { $eq: teacherId },
+        teacher: { $eq: teacherId },
       });
 
       testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(
@@ -72,7 +72,7 @@ class TestSessionService implements ITestSessionService {
       );
     } catch (error: unknown) {
       Logger.error(
-        `Failed to get test sessions for ${field}Id=${teacherId}. Reason = ${getErrorMessage(
+        `Failed to get test sessions for teacherId=${teacherId}. Reason = ${getErrorMessage(
           error,
         )}`,
       );

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -6,10 +6,17 @@ import {
 } from "../interfaces/testSessionService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
+import IUserService from "../interfaces/userService";
 
 const Logger = logger(__filename);
 
 class TestSessionService implements ITestSessionService {
+  userService: IUserService;
+
+  constructor(userService: IUserService) {
+    this.userService = userService;
+  }
+
   /* eslint-disable class-methods-use-this */
   async createTestSession(
     testSession: TestSessionRequestDTO,
@@ -55,6 +62,31 @@ class TestSessionService implements ITestSessionService {
     }
 
     return testSessionDtos;
+  }
+
+  async getTestSessionsByTeacherId(
+    teacherId: string,
+  ): Promise<Array<TestSessionResponseDTO>> {
+    let testSessions: Array<TestSession> | null;
+
+    try {
+      testSessions = await MgTestSession.find({
+        teacherId: { $eq: teacherId },
+      });
+
+      // check if no testSessions are associated with the given teacherId
+      if (!testSessions.length) {
+        console.log(testSessions.length);
+        throw new Error(`Test session for teacher id ${teacherId} not found`);
+      }
+
+      return await this.mapTestSessionsToTestSessionDTOs(testSessions);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get test sessions. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
   }
 
   private async mapTestSessionsToTestSessionDTOs(

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -61,16 +61,20 @@ class TestSessionService implements ITestSessionService {
     teacherId: string,
   ): Promise<Array<TestSessionResponseDTO>> {
     let testSessionDtos: Array<TestSessionResponseDTO> = [];
-    let field = "teacher";
+    const field = "teacher";
     try {
-      const testSessions: Array<TestSession>  = await MgTestSession.find({
+      const testSessions: Array<TestSession> = await MgTestSession.find({
         [field]: { $eq: teacherId },
       });
 
-      testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(testSessions);
+      testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(
+        testSessions,
+      );
     } catch (error: unknown) {
       Logger.error(
-        `Failed to get test sessions for ${field}Id=${teacherId}. Reason = ${getErrorMessage(error)}`,
+        `Failed to get test sessions for ${field}Id=${teacherId}. Reason = ${getErrorMessage(
+          error,
+        )}`,
       );
       throw error;
     }

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -60,25 +60,22 @@ class TestSessionService implements ITestSessionService {
   async getTestSessionsByTeacherId(
     teacherId: string,
   ): Promise<Array<TestSessionResponseDTO>> {
-    let testSessionDtos: Array<TestSession> | null;
-
+    let testSessionDtos: Array<TestSessionResponseDTO> = [];
+    let field = "teacher";
     try {
-      testSessionDtos = await MgTestSession.find({
-        teacher: { $eq: teacherId },
+      const testSessions: Array<TestSession>  = await MgTestSession.find({
+        [field]: { $eq: teacherId },
       });
 
-      // check if no testSessions are associated with the given teacherId
-      if (!testSessionDtos || !testSessionDtos.length) {
-        throw new Error(`Test session for teacher id ${teacherId} not found`);
-      }
-
-      return await this.mapTestSessionsToTestSessionDTOs(testSessionDtos);
+      testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(testSessions);
     } catch (error: unknown) {
       Logger.error(
-        `Failed to get test sessions. Reason = ${getErrorMessage(error)}`,
+        `Failed to get test sessions for ${field}Id=${teacherId}. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }
+
+    return testSessionDtos;
   }
 
   private async mapTestSessionsToTestSessionDTOs(

--- a/backend/services/interfaces/schoolService.ts
+++ b/backend/services/interfaces/schoolService.ts
@@ -54,7 +54,7 @@ export interface ISchoolService {
   getAllSchools(): Promise<Array<SchoolResponseDTO>>;
 
   /**
-   * This method retrieve all Schools with the given subregion
+   * This method retrieves all Schools with the given subregion
    * @param subRegion the sub-region the school is located in
    * @returns returns array of requested SchoolResponseDTO
    * @throws Error if retrieval fails

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -106,5 +106,7 @@ export interface ITestSessionService {
    * @returns returns array of requested TestSessionResponseDTO
    * @throws Error if retrieval fails
    */
-  getTestSessionsByTeacherId(teacherId: string): Promise<Array<TestSessionResponseDTO>>;
+  getTestSessionsByTeacherId(
+    teacherId: string,
+  ): Promise<Array<TestSessionResponseDTO>>;
 }

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -1,5 +1,3 @@
-import { Result } from "../../models/testSession.model";
-
 /**
  * This interface contains the request object that is fed into
  * the school service to create or update the test session in the database.
@@ -101,4 +99,12 @@ export interface ITestSessionService {
    * This method fetches all the test sessions from the database.
    */
   getAllTestSessions(): Promise<Array<TestSessionResponseDTO>>;
+
+  /**
+   * This method retrieves all TestSessions associated with the given teacherId
+   * @param teacherId the teacher id associated with the test session
+   * @returns returns array of requested TestSessionResponseDTO
+   * @throws Error if retrieval fails
+   */
+  getTestSessionsByTeacherId(teacherId: string): Promise<Array<TestSessionResponseDTO>>;
 }

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -95,15 +95,13 @@ export interface ITestSessionService {
     testSession: TestSessionRequestDTO,
   ): Promise<TestSessionResponseDTO>;
 
-  /** 
+  /**
    * delete a TestSession with the given id, return deleted id
    * @param id id to delete
    * @returns deleted id
    * @throws Error if deletion fails
    */
-  deleteTestSession(
-    id: string
-  ): Promise<string>;
+  deleteTestSession(id: string): Promise<string>;
   /**
    * This method fetches all the test sessions from the database.
    */


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Get test sessions by teacher id](https://www.notion.so/uwblueprintexecs/Get-test-sessions-by-teacher-id-b214d531a91b4a56aecd64288246855d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated interface and implementation for `getTestSessionsByTeacherId` which retrieves all TestSessions associated with the given `teacher` id and returns an array of `TestSessionResponseDTO`
* Update implementation and tests for `getTestSessionsByTeacherId` and `getSchoolsBySubregion` to return empty array instead of error when no records match the given query
* Wrote 1 success and 1 failing test case

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
