### PR TITLE
Implement Method to Get Test Session by Test Id

### DIFF
--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -1,6 +1,5 @@
 import TestSessionService from "../testSessionService";
 
-
 import db from "../../../testUtils/testDb";
 import MgTestSession from "../../../models/testSession.model";
 import {
@@ -69,16 +68,21 @@ describe("mongo testSessionService", (): void => {
 
     const res = await testSessionService.getTestSessionsByTestId(testId);
     expect(res.length).toEqual(0);
+  });
 
   it("deleteTestSession", async () => {
-    const savedTestSession = await MgTestSession.create(mockTestSession);;
+    const savedTestSession = await MgTestSession.create(mockTestSession);
 
-    const deletedTestSessionId = await testSessionService.deleteTestSession(savedTestSession.id);
+    const deletedTestSessionId = await testSessionService.deleteTestSession(
+      savedTestSession.id,
+    );
     expect(deletedTestSessionId).toBe(savedTestSession.id);
   });
 
   it("deleteTestSession not found", async () => {
     const notFoundId = "62cf26998b7308f775a572aa";
-    expect(testSessionService.deleteTestSession(notFoundId)).rejects.toThrowError(`Test Session id ${notFoundId} not found`);
+    expect(
+      testSessionService.deleteTestSession(notFoundId),
+    ).rejects.toThrowError(`Test Session id ${notFoundId} not found`);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -8,6 +8,7 @@ import {
   mockTestSession,
   mockTestSessionsWithSameTestId,
 } from "../../../testUtils/testSession";
+import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
@@ -49,17 +50,20 @@ describe("mongo testSessionService", (): void => {
 
     const res = await testSessionService.getTestSessionsByTestId(testId);
     expect(res.length).toEqual(mockTestSessionsWithSameTestId.length);
-    for (let i = 0; i < res.length; i += 1) {
-      assertResponseMatchesExpected(mockTestSessionsWithSameTestId[i], res[i]);
+    res.forEach((testSession: TestSessionResponseDTO, i) => {
+      assertResponseMatchesExpected(
+        mockTestSessionsWithSameTestId[i],
+        testSession,
+      );
       assertResultsResponseMatchesExpected(
         mockTestSessionsWithSameTestId[i],
-        res[i],
+        testSession,
       );
-    }
+    });
   });
 
   it("getTestSessionsByTestId for non-existing id", async () => {
-    await MgTestSession.insertMany(mockTestSession);
+    await MgTestSession.create(mockTestSession);
     const testId = "62c248c0f79d6c3c9ebbea96";
 
     const res = await testSessionService.getTestSessionsByTestId(testId);

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -30,7 +30,6 @@ describe("mongo testSessionService", (): void => {
   it("createTestSession", async () => {
     const res = await testSessionService.createTestSession(mockTestSession);
 
-    // TODO: uncomment when results are added to test session response object
     assertResponseMatchesExpected(mockTestSession, res);
     expect(res.results).toBeUndefined();
   });
@@ -41,5 +40,22 @@ describe("mongo testSessionService", (): void => {
     const res = await testSessionService.getAllTestSessions();
     assertResponseMatchesExpected(mockTestSession, res[0]);
     assertResultsResponseMatchesExpected(mockTestSession, res[0]);
+  });
+
+  it("getTestSessionsByTestId", async () => {
+    await MgTestSession.create(mockTestSession);
+    const testId = "62c248c0f79d6c3c9ebbea95";
+
+    const res = await testSessionService.getTestSessionsByTestId(testId);
+    assertResponseMatchesExpected(mockTestSession, res[0]);
+    assertResultsResponseMatchesExpected(mockTestSession, res[0]);
+  });
+
+  it("getTestSessionsByTestId for non-existing id", async () => {
+    await MgTestSession.create(mockTestSession);
+    const testId = "62c248c0f79d6c3c9ebbea96";
+
+    const res = await testSessionService.getTestSessionsByTestId(testId);
+    expect(res.length).toEqual(0);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -6,6 +6,7 @@ import {
   assertResponseMatchesExpected,
   assertResultsResponseMatchesExpected,
   mockTestSession,
+  mockTestSessionsWithSameTestId,
 } from "../../../testUtils/testSession";
 
 describe("mongo testSessionService", (): void => {
@@ -43,16 +44,22 @@ describe("mongo testSessionService", (): void => {
   });
 
   it("getTestSessionsByTestId", async () => {
-    await MgTestSession.create(mockTestSession);
+    await MgTestSession.create(mockTestSessionsWithSameTestId);
     const testId = "62c248c0f79d6c3c9ebbea95";
 
     const res = await testSessionService.getTestSessionsByTestId(testId);
-    assertResponseMatchesExpected(mockTestSession, res[0]);
-    assertResultsResponseMatchesExpected(mockTestSession, res[0]);
+    expect(res.length).toEqual(mockTestSessionsWithSameTestId.length);
+    for (let i = 0; i < res.length; i += 1) {
+      assertResponseMatchesExpected(mockTestSessionsWithSameTestId[i], res[i]);
+      assertResultsResponseMatchesExpected(
+        mockTestSessionsWithSameTestId[i],
+        res[i],
+      );
+    }
   });
 
   it("getTestSessionsByTestId for non-existing id", async () => {
-    await MgTestSession.create(mockTestSession);
+    await MgTestSession.insertMany(mockTestSession);
     const testId = "62c248c0f79d6c3c9ebbea96";
 
     const res = await testSessionService.getTestSessionsByTestId(testId);

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -57,6 +57,30 @@ class TestSessionService implements ITestSessionService {
     return testSessionDtos;
   }
 
+  async getTestSessionsByTestId(
+    testId: string,
+  ): Promise<Array<TestSessionResponseDTO>> {
+    let testSessionDtos: Array<TestSessionResponseDTO> = [];
+
+    try {
+      const testSessions: Array<TestSession> = await MgTestSession.find({
+        test: { $eq: testId },
+      });
+      testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(
+        testSessions,
+      );
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get test sessions by testId=${testId}. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+
+    return testSessionDtos;
+  }
+
   private async mapTestSessionsToTestSessionDTOs(
     testSessions: Array<TestSession>,
   ): Promise<Array<TestSessionResponseDTO>> {

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -100,6 +100,10 @@ export interface ITestSessionService {
    */
   getAllTestSessions(): Promise<Array<TestSessionResponseDTO>>;
 
+  /**
+   * This method fetches all the test sessions that have the provided test ID.
+   * @param testId The unique identifier of the test to query by
+   */
   getTestSessionsByTestId(
     testId: string,
   ): Promise<Array<TestSessionResponseDTO>>;

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -99,4 +99,8 @@ export interface ITestSessionService {
    * This method fetches all the test sessions from the database.
    */
   getAllTestSessions(): Promise<Array<TestSessionResponseDTO>>;
+
+  getTestSessionsByTestId(
+    testId: string,
+  ): Promise<Array<TestSessionResponseDTO>>;
 }

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -21,6 +21,27 @@ export const mockTestSession: TestSessionRequestDTO = {
   startTime: new Date("2021-09-01T09:00:00.000Z"),
 };
 
+export const mockTestSessionsWithSameTestId: Array<TestSessionRequestDTO> = [
+  {
+    test: "62c248c0f79d6c3c9ebbea95",
+    teacher: "62c248c0f79d6c3c9ebbea95",
+    school: "62c248c0f79d6c3c9ebbea97",
+    gradeLevel: 7,
+    results: [testResult],
+    accessCode: "789",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+  {
+    test: "62c248c0f79d6c3c9ebbea95",
+    teacher: "62c248c0f79d6c3c9ebbea94",
+    school: "62c248c0f79d6c3c9ebbea93",
+    gradeLevel: 4,
+    results: [testResult],
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+];
+
 export const assertResponseMatchesExpected = (
   expected: TestSessionRequestDTO,
   result: TestSessionResponseDTO,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Get test sessions by test id](https://www.notion.so/uwblueprintexecs/Get-test-sessions-by-test-id-d4972e435063498680ab31d208a866f8)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented a method to get test sessions based on the test ID
* Added unit tests for new method


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
