### PR TITLE
Feat: Compute test grades

### DIFF
--- a/backend/models/school.model.ts
+++ b/backend/models/school.model.ts
@@ -17,7 +17,7 @@ export interface School extends Document {
   /** the address of the school */
   address: string;
   /** the teachers that teach at the school (reference to the IDs in the User table) */
-  teachers: [string];
+  teachers: string[];
 }
 
 const SchoolSchema: Schema = new Schema({

--- a/backend/models/test.model.ts
+++ b/backend/models/test.model.ts
@@ -26,7 +26,7 @@ export interface Question {
  */
 export interface MultipleChoiceMetadata {
   /** the options for the multiple choice question */
-  options: [string];
+  options: string[];
   /** the index of the options array which contains the correct answer (0-indexed) */
   answerIndex: number;
 }
@@ -71,7 +71,7 @@ export interface Test extends Document {
    */
   admin: string;
   /** A list of questions to be asked when students take the test */
-  questions: [Question];
+  questions: Question[];
   /** The intended grade the test was made for */
   grade: number;
 }

--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -1,6 +1,14 @@
 import mongoose, { Schema, Document } from "mongoose";
 
 /**
+ * An enum containing the grading status of a Result
+ */
+ export enum GradingStatus {
+  GRADED,
+  UNGRADED,
+}
+
+/**
  * This interface holds information about the result of a single student
  * on a test
  */
@@ -20,6 +28,8 @@ export interface Result extends Document {
    * whether the student got the question right or not
    * */
   breakdown: boolean[];
+  /** the grading status of the result */
+  gradingStatus: GradingStatus;
 }
 
 const ResultSchema: Schema = new Schema({
@@ -39,6 +49,12 @@ const ResultSchema: Schema = new Schema({
     type: [Boolean],
     required: true,
   },
+  gradingStatus: {
+    type: String,
+    required: true,
+    default: GradingStatus.UNGRADED,
+    enum: Object.keys(GradingStatus),
+  }
 });
 
 /**

--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -11,7 +11,7 @@ export interface Result extends Document {
   score: number;
   /**
    * a list corresponding to the question list with each field indicating
-   * the student's answer - either the numeric answer (for short answer) 
+   * the student's answer - either the numeric answer (for short answer)
    * or the option's corresponding index (for multiple choice)
    */
   answers: number[];

--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -11,7 +11,8 @@ export interface Result extends Document {
   score: number;
   /**
    * a list corresponding to the question list with each field indicating
-   * the student's answer
+   * the student's answer - either the numeric answer (for short answer) 
+   * or the option's corresponding index (for multiple choice)
    */
   answers: number[];
   /**

--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -3,7 +3,7 @@ import mongoose, { Schema, Document } from "mongoose";
 /**
  * An enum containing the grading status of a Result
  */
- export enum GradingStatus {
+export enum GradingStatus {
   GRADED,
   UNGRADED,
 }
@@ -54,7 +54,7 @@ const ResultSchema: Schema = new Schema({
     required: true,
     default: GradingStatus.UNGRADED,
     enum: Object.keys(GradingStatus),
-  }
+  },
 });
 
 /**

--- a/backend/services/implementations/__tests__/schoolService.test.ts
+++ b/backend/services/implementations/__tests__/schoolService.test.ts
@@ -145,7 +145,7 @@ describe("mongo schoolService", (): void => {
       await schoolService.updateSchool(notFoundId, updatedTestSchool);
     }).rejects.toThrowError(`School id ${notFoundId} not found`);
   });
-  
+
   it("getSchoolById for valid Id", async () => {
     // mock return value of user service
     userService.findAllUsersByIds = jest.fn().mockReturnValue(testUsers);

--- a/backend/services/implementations/__tests__/schoolService.test.ts
+++ b/backend/services/implementations/__tests__/schoolService.test.ts
@@ -99,7 +99,7 @@ describe("mongo schoolService", (): void => {
     // execute
     const res = await schoolService.getSchoolsByCountry(invalidCountry);
 
-    //assert
+    // assert
     expect(res).toEqual([]);
   });
 

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -3,11 +3,11 @@ import TestService from "../testService";
 import db from "../../../testUtils/testDb";
 import {
   assertResponseMatchesExpected,
-  mockAdmin,
   mockTest,
 } from "../../../testUtils/tests";
 import MgTest from "../../../models/test.model";
 import UserService from "../userService";
+import { mockAdmin } from "../../../testUtils/users";
 
 describe("mongo testService", (): void => {
   let testService: TestService;

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -9,8 +9,8 @@ import {
   mockTest,
   mockTestSession,
   mockTestSessionsWithSameTestId,
-  newTestResult,
-  testResult,
+  mockUngradedTestResult,
+  mockGradedTestResult,
 } from "../../../testUtils/testSession";
 import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
 import TestService from "../testService";
@@ -146,17 +146,17 @@ describe("mongo testSessionService", (): void => {
     testService.getTestById = jest.fn().mockReturnValue(mockTest);
 
     const res = await testSessionService.computeTestGrades(
-      newTestResult,
+      mockUngradedTestResult,
       mockTest.id,
     );
-    expect(res).toStrictEqual(testResult);
+    expect(res).toStrictEqual(mockGradedTestResult);
   });
 
   it("computeTestGrades with invalid test id", async () => {
     const invalidId = "62c248c0f79d6c3c9ebbea94";
 
     await expect(async () => {
-      await testSessionService.computeTestGrades(newTestResult, invalidId);
+      await testSessionService.computeTestGrades(mockUngradedTestResult, invalidId);
     }).rejects.toThrowError(`Test ID ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -57,11 +57,13 @@ describe("mongo testSessionService", (): void => {
 
   it("getTestSession", async () => {
     const savedTestSession = await MgTestSession.create(mockTestSession);
-    const res = await testSessionService.getTestSessionById(savedTestSession.id);
+    const res = await testSessionService.getTestSessionById(
+      savedTestSession.id,
+    );
     assertResponseMatchesExpected(mockTestSession, res);
     assertResultsResponseMatchesExpected(mockTestSession, res);
   });
-  
+
   it("get test sessions by school id for valid id", async () => {
     await MgTestSession.create(mockTestSession);
     const res = await testSessionService.getTestSessionsBySchoolId(
@@ -98,7 +100,7 @@ describe("mongo testSessionService", (): void => {
     const res = await testSessionService.getTestSessionsByTeacherId(invalidId);
     expect(res.length).toEqual(0);
   });
-  
+
   it("getTestSessionsByTestId", async () => {
     await MgTestSession.create(mockTestSessionsWithSameTestId);
     const testId = "62c248c0f79d6c3c9ebbea95";
@@ -144,7 +146,10 @@ describe("mongo testSessionService", (): void => {
   it("computeTestGrades", async () => {
     testService.getTestById = jest.fn().mockReturnValue(mockTest);
 
-    const res = await testSessionService.computeTestGrades(newTestResult, mockTest.id);
+    const res = await testSessionService.computeTestGrades(
+      newTestResult,
+      mockTest.id,
+    );
     expect(res).toStrictEqual(testResult);
   });
 
@@ -160,7 +165,12 @@ describe("mongo testSessionService", (): void => {
     testService.getTestById = jest.fn().mockReturnValue(mockTest);
 
     await expect(async () => {
-      await testSessionService.computeTestGrades(newTestResultMissingAnswer, mockTest.id);
-    }).rejects.toThrowError("One or more of the student's test answers was not found");
+      await testSessionService.computeTestGrades(
+        newTestResultMissingAnswer,
+        mockTest.id,
+      );
+    }).rejects.toThrowError(
+      "One or more of the student's test answers was not found",
+    );
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -10,7 +10,6 @@ import {
   mockTestSession,
   mockTestSessionsWithSameTestId,
   newTestResult,
-  newTestResultMissingAnswer,
   testResult,
 } from "../../../testUtils/testSession";
 import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
@@ -159,18 +158,5 @@ describe("mongo testSessionService", (): void => {
     await expect(async () => {
       await testSessionService.computeTestGrades(newTestResult, invalidId);
     }).rejects.toThrowError(`Test ID ${invalidId} not found`);
-  });
-
-  it("computeTestGrades with different number of answers to questions", async () => {
-    testService.getTestById = jest.fn().mockReturnValue(mockTest);
-
-    await expect(async () => {
-      await testSessionService.computeTestGrades(
-        newTestResultMissingAnswer,
-        mockTest.id,
-      );
-    }).rejects.toThrowError(
-      "One or more of the student's test answers was not found",
-    );
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -6,7 +6,6 @@ import MgTestSession from "../../../models/testSession.model";
 import {
   assertResponseMatchesExpected,
   assertResultsResponseMatchesExpected,
-  mockTest,
   mockTestSession,
   mockTestSessionsWithSameTestId,
   mockUngradedTestResult,
@@ -15,6 +14,7 @@ import {
 import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
 import TestService from "../testService";
 import UserService from "../userService";
+import { mockTestWithId } from "../../../testUtils/tests";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
@@ -143,11 +143,11 @@ describe("mongo testSessionService", (): void => {
   });
 
   it("computeTestGrades", async () => {
-    testService.getTestById = jest.fn().mockReturnValue(mockTest);
+    testService.getTestById = jest.fn().mockReturnValue(mockTestWithId);
 
     const res = await testSessionService.computeTestGrades(
       mockUngradedTestResult,
-      mockTest.id,
+      mockTestWithId.id,
     );
     expect(res).toStrictEqual(mockGradedTestResult);
   });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -156,7 +156,10 @@ describe("mongo testSessionService", (): void => {
     const invalidId = "62c248c0f79d6c3c9ebbea94";
 
     await expect(async () => {
-      await testSessionService.computeTestGrades(mockUngradedTestResult, invalidId);
+      await testSessionService.computeTestGrades(
+        mockUngradedTestResult,
+        invalidId,
+      );
     }).rejects.toThrowError(`Test ID ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -1,16 +1,26 @@
 import MgTestSession, { TestSession } from "../../models/testSession.model";
 import {
   ITestSessionService,
+  NewResultDTO,
+  ResultDTO,
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../interfaces/testSessionService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
+import { MultipleChoiceMetadata, NumericQuestionMetadata, Question, QuestionType } from "../../models/test.model";
+import { ITestService, TestResponseDTO } from "../interfaces/testService";
 
 const Logger = logger(__filename);
 
 class TestSessionService implements ITestSessionService {
   /* eslint-disable class-methods-use-this */
+  testService: ITestService;
+
+  constructor(testService: ITestService) {
+    this.testService = testService;
+  }
+
   async createTestSession(
     testSession: TestSessionRequestDTO,
   ): Promise<TestSessionResponseDTO> {
@@ -186,6 +196,69 @@ class TestSessionService implements ITestSessionService {
     }
 
     return testSessionDtos;
+  }
+
+  /*
+  * computeTestGrades computes the breakdown and score of a given result and returns the ResultDTO
+  */
+  async computeTestGrades(result: NewResultDTO, testId: string): Promise<ResultDTO> {
+    let resultDto: ResultDTO;
+    let questionsCorrect: number = 0; // the number of questions the student gets correct
+    let studentAnswers: number[] = result.answers; // the array of the student's raw answers
+    let updatedScore: number = 0.00; // the final score that will be returned
+    let updatedBreakdown: boolean[] = []; // the final breakdown that will be returned
+
+    try {
+      const test: TestResponseDTO = await this.testService.getTestById(testId);
+
+      // check if the number of test questions matches the number of student answers
+      if (test.questions.length != studentAnswers.length) {
+        throw new Error("One or more of the student's test answers was not found");
+      }
+
+      // check the correctness of each question and answer pair
+      test.questions.forEach((question: Question, i) => {
+        let actualAnswer: number;
+
+        if (question.questionType == QuestionType.MULTIPLE_CHOICE) {
+          // set the actualAnswer for the multiple choice question
+          const questionMetadata = question.questionMetadata as MultipleChoiceMetadata;
+          actualAnswer = Number(questionMetadata.options[questionMetadata.answerIndex]);
+        } else {
+          // set the actualAnswer for the numeric answer question
+          const questionMetadata = question.questionMetadata as NumericQuestionMetadata;
+          actualAnswer = questionMetadata.answer;
+        }
+
+        // check if the student's answer and the actual answer match
+        if (studentAnswers[i] == actualAnswer) {
+          questionsCorrect += 1; // update the counter
+          updatedBreakdown[i] = true;
+        } else {
+          updatedBreakdown[i] = false;
+        }
+      })
+
+      // compute student's score as a percentage to two decimal places (e.g. 1/3 => 33.33)
+      updatedScore = parseFloat((questionsCorrect * 100 / studentAnswers.length).toFixed(2));
+
+      resultDto = {
+        student: result.student,
+        score: updatedScore,
+        answers: result.answers,
+        breakdown: updatedBreakdown,
+      }
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to compute test grades for result=${result}. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+
+    // return Result with updated score and breakdown values
+    return resultDto;
   }
 }
 

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -8,7 +8,12 @@ import {
 } from "../interfaces/testSessionService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
-import { MultipleChoiceMetadata, NumericQuestionMetadata, Question, QuestionType } from "../../models/test.model";
+import {
+  MultipleChoiceMetadata,
+  NumericQuestionMetadata,
+  Question,
+  QuestionType,
+} from "../../models/test.model";
 import { ITestService, TestResponseDTO } from "../interfaces/testService";
 
 const Logger = logger(__filename);
@@ -57,12 +62,14 @@ class TestSessionService implements ITestSessionService {
         throw new Error(`Test Session id ${id} not found`);
       }
     } catch (error: unknown) {
-      Logger.error(`Failed to get Test Session. Reason = ${getErrorMessage(error)}`);
+      Logger.error(
+        `Failed to get Test Session. Reason = ${getErrorMessage(error)}`,
+      );
       throw error;
     }
     return (await this.mapTestSessionsToTestSessionDTOs([testSession]))[0];
   }
-  
+
   async deleteTestSession(id: string): Promise<string> {
     try {
       const deletedTestSession = await MgTestSession.findByIdAndDelete(id);
@@ -105,14 +112,14 @@ class TestSessionService implements ITestSessionService {
       const testSessions: Array<TestSession> = await MgTestSession.find({
         teacher: { $eq: teacherId },
       });
-      
+
       testSessionDtos = await this.mapTestSessionsToTestSessionDTOs(
         testSessions,
       );
     } catch (error: unknown) {
       Logger.error(
-         `Failed to get test sessions for teacherId=${teacherId}. Reason = ${getErrorMessage(
-              error,
+        `Failed to get test sessions for teacherId=${teacherId}. Reason = ${getErrorMessage(
+          error,
         )}`,
       );
       throw error;
@@ -120,7 +127,7 @@ class TestSessionService implements ITestSessionService {
 
     return testSessionDtos;
   }
-  
+
   async getTestSessionsByTestId(
     testId: string,
   ): Promise<Array<TestSessionResponseDTO>> {
@@ -199,31 +206,38 @@ class TestSessionService implements ITestSessionService {
   }
 
   /*
-  * computeTestGrades computes the breakdown and score of a given result and returns the ResultDTO
-  */
-  async computeTestGrades(result: NewResultDTO, testId: string): Promise<ResultDTO> {
+   * computeTestGrades computes the breakdown and score of a given result and returns the ResultDTO
+   */
+  async computeTestGrades(
+    result: NewResultDTO,
+    testId: string,
+  ): Promise<ResultDTO> {
     let resultDto: ResultDTO;
-    let questionsCorrect: number = 0; // the number of questions the student gets correct
-    let studentAnswers: number[] = result.answers; // the array of the student's raw answers
-    let updatedScore: number = 0.00; // the final score that will be returned
-    let updatedBreakdown: boolean[] = []; // the final breakdown that will be returned
+    let questionsCorrect = 0; // the number of questions the student gets correct
+    const studentAnswers: number[] = result.answers; // the array of the student's raw answers
+    let updatedScore = 0.0; // the final score that will be returned
+    const updatedBreakdown: boolean[] = []; // the final breakdown that will be returned
 
     try {
       const test: TestResponseDTO = await this.testService.getTestById(testId);
 
       // check if the number of test questions matches the number of student answers
-      if (test.questions.length != studentAnswers.length) {
-        throw new Error("One or more of the student's test answers was not found");
+      if (test.questions.length !== studentAnswers.length) {
+        throw new Error(
+          "One or more of the student's test answers was not found",
+        );
       }
 
       // check the correctness of each question and answer pair
       test.questions.forEach((question: Question, i) => {
         let actualAnswer: number;
 
-        if (question.questionType == QuestionType.MULTIPLE_CHOICE) {
+        if (question.questionType === QuestionType.MULTIPLE_CHOICE) {
           // set the actualAnswer for the multiple choice question
           const questionMetadata = question.questionMetadata as MultipleChoiceMetadata;
-          actualAnswer = Number(questionMetadata.options[questionMetadata.answerIndex]);
+          actualAnswer = Number(
+            questionMetadata.options[questionMetadata.answerIndex],
+          );
         } else {
           // set the actualAnswer for the numeric answer question
           const questionMetadata = question.questionMetadata as NumericQuestionMetadata;
@@ -231,23 +245,25 @@ class TestSessionService implements ITestSessionService {
         }
 
         // check if the student's answer and the actual answer match
-        if (studentAnswers[i] == actualAnswer) {
+        if (studentAnswers[i] === actualAnswer) {
           questionsCorrect += 1; // update the counter
           updatedBreakdown[i] = true;
         } else {
           updatedBreakdown[i] = false;
         }
-      })
+      });
 
       // compute student's score as a percentage to two decimal places (e.g. 1/3 => 33.33)
-      updatedScore = parseFloat((questionsCorrect * 100 / studentAnswers.length).toFixed(2));
+      updatedScore = parseFloat(
+        ((questionsCorrect * 100) / studentAnswers.length).toFixed(2),
+      );
 
       resultDto = {
         student: result.student,
         score: updatedScore,
         answers: result.answers,
         breakdown: updatedBreakdown,
-      }
+      };
     } catch (error: unknown) {
       Logger.error(
         `Failed to compute test grades for result=${result}. Reason = ${getErrorMessage(

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -206,7 +206,7 @@ class TestSessionService implements ITestSessionService {
   }
 
   /*
-   * computeTestGrades computes the breakdown and score of a given 
+   * computeTestGrades computes the breakdown and score of a given
    * UngradedResultDTO and returns the GradedResultResponseDTO
    */
   async computeTestGrades(
@@ -215,12 +215,12 @@ class TestSessionService implements ITestSessionService {
   ): Promise<GradedResultResponseDTO> {
     let gradedResultResponseDTO: GradedResultResponseDTO;
 
-    // the list of a student's answers with each field being either the 
+    // the list of a student's answers with each field being either the
     // numeric answer (for short answer) or index (for multiple choice)
     const studentAnswers: (number | null)[] = result.answers;
-   
+
     let computedScore = 0.00;
-    let computedBreakdown: boolean[] = [];
+    const computedBreakdown: boolean[] = [];
     let questionsCorrect = 0;
 
     try {

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -1,3 +1,5 @@
+import { GradingStatus } from "../../models/testSession.model";
+
 /**
  * This interface contains the request object that is fed into
  * the test session service to create or update the test session in the database.
@@ -15,7 +17,7 @@ export interface TestSessionRequestDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: GradedResultRequestDTO[];
+  results?: ResultRequestDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
@@ -41,7 +43,7 @@ export interface TestSessionResponseDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: GradedResultResponseDTO[];
+  results?: ResultResponseDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
@@ -49,20 +51,33 @@ export interface TestSessionResponseDTO {
 }
 
 /**
- * This interface contains the request object that is fed into the test session
- * service that represents a new test result that has not yet been graded
+ * This interface contains the request object that is fed into the test
+ * session service to create or update a result in a given test session
  */
-export interface UngradedResultDTO {
+export interface ResultRequestDTO {
   /** the name of the student */
   student: string;
+  /** the score of the student */
+  score: number | null;
   /**
    * a list corresponding to the question list with each field indicating
    * the student's answer
    */
   answers: (number | null)[];
+  /**
+   * a list corresponding to the question list with each fielding indicating
+   * whether the student got the question right or not
+   * */
+  breakdown: boolean[];
+  /** the grading status of a result - either graded or ungraded (default) */
+  gradingStatus: GradingStatus;
 }
 
-export interface GradedResultRequestDTO {
+/**
+ * This interface contains the response object that is returned by
+ * the test session service to represent a result in a given test session
+ */
+export interface ResultResponseDTO {
   /** the name of the student */
   student: string;
   /** the score of the student */
@@ -77,23 +92,8 @@ export interface GradedResultRequestDTO {
    * whether the student got the question right or not
    * */
   breakdown: boolean[];
-}
-
-export interface GradedResultResponseDTO {
-  /** the name of the student */
-  student: string;
-  /** the score of the student */
-  score: number;
-  /**
-   * a list corresponding to the question list with each field indicating
-   * the student's answer
-   */
-  answers: (number | null)[];
-  /**
-   * a list corresponding to the question list with each fielding indicating
-   * whether the student got the question right or not
-   * */
-  breakdown: boolean[];
+  /** the grading status of a result - either graded or ungraded (default) */
+  gradingStatus: GradingStatus;
 }
 
 export interface ITestSessionService {

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -120,8 +120,8 @@ export interface ITestSessionService {
    */
   getTestSessionsByTeacherId(
     teacherId: string,
-   ): Promise<Array<TestSessionResponseDTO>>;
- 
+  ): Promise<Array<TestSessionResponseDTO>>;
+
   /**
    * This method fetches all the test sessions that have the provided test ID.
    * @param testId The unique identifier of the test to query by

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -1,6 +1,6 @@
 /**
  * This interface contains the request object that is fed into
- * the school service to create or update the test session in the database.
+ * the test session service to create or update the test session in the database.
  */
 export interface TestSessionRequestDTO {
   /** the ID of the corresponding test from the Test collection */
@@ -15,7 +15,7 @@ export interface TestSessionRequestDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: ResultDTO[];
+  results?: GradedResultRequestDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
@@ -41,24 +41,28 @@ export interface TestSessionResponseDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: ResultDTO[];
+  results?: GradedResultResponseDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
   startTime: Date;
 }
 
-export interface NewResultDTO {
+/**
+ * This interface contains the request object that is fed into the test session
+ * service that represents a new test result that has not yet been graded
+ */
+export interface UngradedResultDTO {
   /** the name of the student */
   student: string;
   /**
    * a list corresponding to the question list with each field indicating
    * the student's answer
    */
-  answers: number[];
+  answers: (number | null)[];
 }
 
-export interface ResultDTO {
+export interface GradedResultRequestDTO {
   /** the name of the student */
   student: string;
   /** the score of the student */
@@ -67,7 +71,24 @@ export interface ResultDTO {
    * a list corresponding to the question list with each field indicating
    * the student's answer
    */
-  answers: number[];
+  answers: (number | null)[];
+  /**
+   * a list corresponding to the question list with each fielding indicating
+   * whether the student got the question right or not
+   * */
+  breakdown: boolean[];
+}
+
+export interface GradedResultResponseDTO {
+  /** the name of the student */
+  student: string;
+  /** the score of the student */
+  score: number;
+  /**
+   * a list corresponding to the question list with each field indicating
+   * the student's answer
+   */
+  answers: (number | null)[];
   /**
    * a list corresponding to the question list with each fielding indicating
    * whether the student got the question right or not

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -15,7 +15,7 @@ export interface TestSessionRequestDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: ResultRequestDTO[];
+  results?: ResultDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
@@ -41,33 +41,24 @@ export interface TestSessionResponseDTO {
    * the result of the test session
    * there should be one entry here per student
    * */
-  results?: ResultResponseDTO[];
+  results?: ResultDTO[];
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** the time when the test session is started by teacher */
   startTime: Date;
 }
 
-export interface ResultRequestDTO {
+export interface NewResultDTO {
   /** the name of the student */
   student: string;
-  /** the score of the student */
-  score: number;
   /**
    * a list corresponding to the question list with each field indicating
    * the student's answer
    */
   answers: number[];
-  /**
-   * a list corresponding to the question list with each fielding indicating
-   * whether the student got the question right or not
-   * */
-  breakdown: boolean[];
 }
 
-export interface ResultResponseDTO {
-  /** the unique identifier of the response */
-  id: string;
+export interface ResultDTO {
   /** the name of the student */
   student: string;
   /** the score of the student */

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -34,7 +34,6 @@ export const mockTest = {
   grade: 11,
 };
 
-
 /**
  * Mock Test Results
  */
@@ -54,7 +53,6 @@ export const newTestResultMissingAnswer: NewResultDTO = {
   student: "some-student-name",
   answers: [10],
 };
-
 
 /**
  * Mock Test Sessions

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -1,16 +1,64 @@
 import {
-  ResultRequestDTO,
+  ResultDTO,
+  NewResultDTO,
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
+import { QuestionType } from "../models/test.model";
 
-export const testResult: ResultRequestDTO = {
+/**
+ * Mock Tests
+ */
+export const mockTest = {
+  id: "62c248c0f79d6c3c9ebbea95",
+  name: "test",
+  duration: 300,
+  admin: "62c248c0f79d6c3c9ebbea94",
+  questions: [
+    {
+      questionType: QuestionType.NUMERIC_ANSWER,
+      questionPrompt: "Numeric answer question",
+      questionMetadata: {
+        answer: 20,
+      },
+    },
+    {
+      questionType: QuestionType.MULTIPLE_CHOICE,
+      questionPrompt: "Multiple Choice question",
+      questionMetadata: {
+        options: ["11", "12", "13", "14"],
+        answerIndex: 0,
+      },
+    },
+  ],
+  grade: 11,
+};
+
+
+/**
+ * Mock Test Results
+ */
+export const testResult: ResultDTO = {
   student: "some-student-name",
-  score: 25,
+  score: 50.00,
   answers: [10, 11],
   breakdown: [false, true],
 };
 
+export const newTestResult: NewResultDTO = {
+  student: "some-student-name",
+  answers: [10, 11],
+};
+
+export const newTestResultMissingAnswer: NewResultDTO = {
+  student: "some-student-name",
+  answers: [10],
+};
+
+
+/**
+ * Mock Test Sessions
+ */
 export const mockTestSession: TestSessionRequestDTO = {
   test: "62c248c0f79d6c3c9ebbea95",
   teacher: "62c248c0f79d6c3c9ebbea94",
@@ -62,7 +110,6 @@ export const assertResultsResponseMatchesExpected = (
   const actualResults = result.results != null ? result.results[0] : null;
   const expectedResults = expected.results != null ? expected.results[0] : null;
 
-  expect(actualResults?.id).not.toBeNull();
   expect(
     Array.from(actualResults != null ? Array.from(actualResults.answers) : []),
   ).toEqual(expectedResults?.answers);

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -1,67 +1,28 @@
+import { GradingStatus } from "../models/testSession.model";
 import {
-  GradedResultResponseDTO,
-  UngradedResultDTO,
+  ResultRequestDTO,
+  ResultResponseDTO,
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
-import { QuestionType } from "../models/test.model";
-
-/**
- * Mock Tests
- */
-export const mockTest = {
-  id: "62c248c0f79d6c3c9ebbea95",
-  name: "test",
-  duration: 300,
-  admin: "62c248c0f79d6c3c9ebbea94",
-  questions: [
-    {
-      questionType: QuestionType.NUMERIC_ANSWER,
-      questionPrompt: "Numeric answer question",
-      questionMetadata: {
-        answer: 10,
-      },
-    },
-    {
-      questionType: QuestionType.MULTIPLE_CHOICE,
-      questionPrompt: "Multiple Choice question",
-      questionMetadata: {
-        options: ["11", "12", "13", "14"],
-        answerIndex: 0,
-      },
-    },
-    {
-      questionType: QuestionType.MULTIPLE_CHOICE,
-      questionPrompt: "Multiple Choice question",
-      questionMetadata: {
-        options: ["11", "12", "13", "14"],
-        answerIndex: 1,
-      },
-    },
-    {
-      questionType: QuestionType.NUMERIC_ANSWER,
-      questionPrompt: "Numeric answer question",
-      questionMetadata: {
-        answer: 14,
-      },
-    },
-  ],
-  grade: 11,
-};
 
 /**
  * Mock Test Results
  */
-export const mockUngradedTestResult: UngradedResultDTO = {
+export const mockUngradedTestResult: ResultRequestDTO = {
   student: "some-student-name",
+  score: null,
   answers: [10, 11, 1, null],
+  breakdown: [],
+  gradingStatus: GradingStatus.UNGRADED,
 };
 
-export const mockGradedTestResult: GradedResultResponseDTO = {
+export const mockGradedTestResult: ResultResponseDTO = {
   student: "some-student-name",
   score: 50.00,
   answers: [10, 11, 1, null],
   breakdown: [true, false, true, false],
+  gradingStatus: GradingStatus.GRADED,
 };
 
 /**

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -12,7 +12,7 @@ import {
 export const mockUngradedTestResult: ResultRequestDTO = {
   student: "some-student-name",
   score: null,
-  answers: [10, 11, 1, null],
+  answers: [10.5, 11, 1, null],
   breakdown: [],
   gradingStatus: GradingStatus.UNGRADED,
 };
@@ -20,7 +20,7 @@ export const mockUngradedTestResult: ResultRequestDTO = {
 export const mockGradedTestResult: ResultResponseDTO = {
   student: "some-student-name",
   score: 50.00,
-  answers: [10, 11, 1, null],
+  answers: [10.5, 11, 1, null],
   breakdown: [true, false, true, false],
   gradingStatus: GradingStatus.GRADED,
 };

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -1,6 +1,6 @@
 import {
-  ResultDTO,
-  NewResultDTO,
+  GradedResultResponseDTO,
+  UngradedResultDTO,
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
@@ -19,7 +19,7 @@ export const mockTest = {
       questionType: QuestionType.NUMERIC_ANSWER,
       questionPrompt: "Numeric answer question",
       questionMetadata: {
-        answer: 20,
+        answer: 10,
       },
     },
     {
@@ -30,6 +30,21 @@ export const mockTest = {
         answerIndex: 0,
       },
     },
+    {
+      questionType: QuestionType.MULTIPLE_CHOICE,
+      questionPrompt: "Multiple Choice question",
+      questionMetadata: {
+        options: ["11", "12", "13", "14"],
+        answerIndex: 1,
+      },
+    },
+    {
+      questionType: QuestionType.NUMERIC_ANSWER,
+      questionPrompt: "Numeric answer question",
+      questionMetadata: {
+        answer: 14,
+      },
+    },
   ],
   grade: 11,
 };
@@ -37,21 +52,16 @@ export const mockTest = {
 /**
  * Mock Test Results
  */
-export const testResult: ResultDTO = {
+export const testResult: GradedResultResponseDTO = {
   student: "some-student-name",
   score: 50.00,
-  answers: [10, 11],
-  breakdown: [false, true],
+  answers: [10, 11, 1, null],
+  breakdown: [true, false, true, false],
 };
 
-export const newTestResult: NewResultDTO = {
+export const newTestResult: UngradedResultDTO = {
   student: "some-student-name",
-  answers: [10, 11],
-};
-
-export const newTestResultMissingAnswer: NewResultDTO = {
-  student: "some-student-name",
-  answers: [10],
+  answers: [10, 11, 1, null],
 };
 
 /**

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -52,16 +52,16 @@ export const mockTest = {
 /**
  * Mock Test Results
  */
-export const testResult: GradedResultResponseDTO = {
+export const mockUngradedTestResult: UngradedResultDTO = {
+  student: "some-student-name",
+  answers: [10, 11, 1, null],
+};
+
+export const mockGradedTestResult: GradedResultResponseDTO = {
   student: "some-student-name",
   score: 50.00,
   answers: [10, 11, 1, null],
   breakdown: [true, false, true, false],
-};
-
-export const newTestResult: UngradedResultDTO = {
-  student: "some-student-name",
-  answers: [10, 11, 1, null],
 };
 
 /**
@@ -72,7 +72,7 @@ export const mockTestSession: TestSessionRequestDTO = {
   teacher: "62c248c0f79d6c3c9ebbea94",
   school: "62c248c0f79d6c3c9ebbea93",
   gradeLevel: 4,
-  results: [testResult],
+  results: [mockGradedTestResult],
   accessCode: "1234",
   startTime: new Date("2021-09-01T09:00:00.000Z"),
 };
@@ -83,7 +83,7 @@ export const mockTestSessionsWithSameTestId: Array<TestSessionRequestDTO> = [
     teacher: "62c248c0f79d6c3c9ebbea95",
     school: "62c248c0f79d6c3c9ebbea97",
     gradeLevel: 7,
-    results: [testResult],
+    results: [mockGradedTestResult],
     accessCode: "789",
     startTime: new Date("2021-09-01T09:00:00.000Z"),
   },
@@ -92,7 +92,7 @@ export const mockTestSessionsWithSameTestId: Array<TestSessionRequestDTO> = [
     teacher: "62c248c0f79d6c3c9ebbea94",
     school: "62c248c0f79d6c3c9ebbea93",
     gradeLevel: 4,
-    results: [testResult],
+    results: [mockGradedTestResult],
     accessCode: "1234",
     startTime: new Date("2021-09-01T09:00:00.000Z"),
   },

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -3,18 +3,42 @@ import {
   CreateTestRequestDTO,
   TestResponseDTO,
 } from "../services/interfaces/testService";
+import { mockAdmin } from "./users";
 
-const questions = [
+const questions: Array<Question> = [
   {
     questionType: QuestionType.NUMERIC_ANSWER,
-    questionPrompt: "Question",
+    questionPrompt: "Numeric answer question",
     questionMetadata: {
-      answer: 3,
+      answer: 10.00,
+    },
+  },
+  {
+    questionType: QuestionType.MULTIPLE_CHOICE,
+    questionPrompt: "Multiple Choice question",
+    questionMetadata: {
+      options: ["11", "12", "13", "14"],
+      answerIndex: 0,
+    },
+  },
+  {
+    questionType: QuestionType.MULTIPLE_CHOICE,
+    questionPrompt: "Multiple Choice question",
+    questionMetadata: {
+      options: ["11", "12", "13", "14"],
+      answerIndex: 1,
+    },
+  },
+  {
+    questionType: QuestionType.NUMERIC_ANSWER,
+    questionPrompt: "Numeric answer question",
+    questionMetadata: {
+      answer: 14,
     },
   },
 ];
 
-export const mockTest = {
+export const mockTest: CreateTestRequestDTO = {
   name: "test",
   duration: 300,
   admin: "62c248c0f79d6c3c9ebbea94",
@@ -22,12 +46,10 @@ export const mockTest = {
   grade: 11,
 };
 
-export const mockAdmin = {
-  id: "62c248c0f79d6c3c9ebbea94",
-  firstName: "Admin",
-  lastName: "One",
-  authId: "123",
-  role: "Admin",
+ export const mockTestWithId: TestResponseDTO = {
+  id: "62c248c0f79d6c3c9ebbea95",
+  ...mockTest,
+  admin: mockAdmin,
 };
 
 export const assertResponseMatchesExpected = (

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -10,7 +10,7 @@ const questions: Array<Question> = [
     questionType: QuestionType.NUMERIC_ANSWER,
     questionPrompt: "Numeric answer question",
     questionMetadata: {
-      answer: 10.00,
+      answer: 10.5,
     },
   },
   {
@@ -46,7 +46,7 @@ export const mockTest: CreateTestRequestDTO = {
   grade: 11,
 };
 
- export const mockTestWithId: TestResponseDTO = {
+export const mockTestWithId: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea95",
   ...mockTest,
   admin: mockAdmin,

--- a/backend/testUtils/users.ts
+++ b/backend/testUtils/users.ts
@@ -1,9 +1,9 @@
 import { UserDTO } from "../types";
 
 export const mockAdmin: UserDTO = {
-    id: "62c248c0f79d6c3c9ebbea94",
-    firstName: "Admin",
-    lastName: "One",
-    email: "admin@gmail.com",
-    role: "Admin",
+  id: "62c248c0f79d6c3c9ebbea94",
+  firstName: "Admin",
+  lastName: "One",
+  email: "admin@gmail.com",
+  role: "Admin",
 };

--- a/backend/testUtils/users.ts
+++ b/backend/testUtils/users.ts
@@ -1,0 +1,9 @@
+import { UserDTO } from "../types";
+
+export const mockAdmin: UserDTO = {
+    id: "62c248c0f79d6c3c9ebbea94",
+    firstName: "Admin",
+    lastName: "One",
+    email: "admin@gmail.com",
+    role: "Admin",
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Compute test grades](https://www.notion.so/uwblueprintexecs/Compute-test-grades-4c7b0c281b7b4e02be33b55bd500a5c5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* computeTestGrades takes in a `UngradedResultDTO` and its associated test id, and returns a `GradedResultResponseDTO` with the calculated score and breakdown
* Will be called within `updateTestSession` > `createTestResult`
   * Can look here https://github.com/uwblueprint/jump-math/pull/36/files for full picture of how this function intends to be used
* Wrote tests
   * Successful case
   * Invalid test id 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
