### PR TITLE
Feat: gradeTestResult

### DIFF
--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -164,24 +164,24 @@ describe("mongo testSessionService", (): void => {
     }).rejects.toThrowError(`Test ID ${invalidId} not found`);
   });
 
-  it("createTestResult", async () => {
+  it("gradeTestResult", async () => {
     testSessionService.getTestSessionById = jest
       .fn()
       .mockReturnValue(mockTestSessionWithId);
     testService.getTestById = jest.fn().mockReturnValue(mockTestWithId);
 
-    const res = await testSessionService.createTestResult(
+    const res = await testSessionService.gradeTestResult(
       mockUngradedTestResult,
       mockTestSessionWithId.test,
     );
     expect(res).toStrictEqual(mockGradedTestResult);
   });
 
-  it("createTestResult with invalid test session id", async () => {
+  it("gradeTestResult with invalid test session id", async () => {
     const invalidId = "62c248c0f79d6c3c9ebbea94";
 
     await expect(async () => {
-      await testSessionService.createTestResult(
+      await testSessionService.gradeTestResult(
         mockUngradedTestResult,
         invalidId,
       );

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -10,6 +10,7 @@ import {
   mockTestSessionsWithSameTestId,
   mockUngradedTestResult,
   mockGradedTestResult,
+  mockTestSessionWithId,
 } from "../../../testUtils/testSession";
 import { TestSessionResponseDTO } from "../../interfaces/testSessionService";
 import TestService from "../testService";
@@ -161,5 +162,29 @@ describe("mongo testSessionService", (): void => {
         invalidId,
       );
     }).rejects.toThrowError(`Test ID ${invalidId} not found`);
+  });
+
+  it("createTestResult", async () => {
+    testSessionService.getTestSessionById = jest
+      .fn()
+      .mockReturnValue(mockTestSessionWithId);
+    testService.getTestById = jest.fn().mockReturnValue(mockTestWithId);
+
+    const res = await testSessionService.createTestResult(
+      mockUngradedTestResult,
+      mockTestSessionWithId.test,
+    );
+    expect(res).toStrictEqual(mockGradedTestResult);
+  });
+
+  it("createTestResult with invalid test session id", async () => {
+    const invalidId = "62c248c0f79d6c3c9ebbea94";
+
+    await expect(async () => {
+      await testSessionService.createTestResult(
+        mockUngradedTestResult,
+        invalidId,
+      );
+    }).rejects.toThrowError(`Test Session id ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -210,7 +210,7 @@ class TestSessionService implements ITestSessionService {
   }
 
   /*
-   * gradeTestResult returns the ResultResponseDTO corresponding to the given ResultRequestDTO
+   * gradeTestResult takes in a ResultRequestDTO and returns the corresponding graded ResultResponseDTO
    */
   async gradeTestResult(
     result: ResultRequestDTO,

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -210,9 +210,9 @@ class TestSessionService implements ITestSessionService {
   }
 
   /*
-   * createTestResult returns the ResultResponseDTO corresponding to the given ResultRequestDTO
+   * gradeTestResult returns the ResultResponseDTO corresponding to the given ResultRequestDTO
    */
-  async createTestResult(
+  async gradeTestResult(
     result: ResultRequestDTO,
     testSessionId: string,
   ): Promise<ResultResponseDTO> {

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -1,4 +1,7 @@
-import MgTestSession, { GradingStatus, TestSession } from "../../models/testSession.model";
+import MgTestSession, {
+  GradingStatus,
+  TestSession,
+} from "../../models/testSession.model";
 import {
   ITestSessionService,
   ResultRequestDTO,
@@ -204,6 +207,30 @@ class TestSessionService implements ITestSessionService {
     }
 
     return testSessionDtos;
+  }
+
+  /*
+   * createTestResult returns the ResultResponseDTO corresponding to the given ResultRequestDTO
+   */
+  async createTestResult(
+    result: ResultRequestDTO,
+    testSessionId: string,
+  ): Promise<ResultResponseDTO> {
+    let newResult: ResultResponseDTO;
+
+    try {
+      const testSession: TestSessionResponseDTO = await this.getTestSessionById(
+        testSessionId,
+      );
+      newResult = await this.computeTestGrades(result, testSession.test);
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to create test result. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+
+    return newResult;
   }
 
   /*

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -5,6 +5,7 @@ import {
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
+import { mockTestWithId } from "./tests";
 
 /**
  * Mock Test Results
@@ -29,7 +30,7 @@ export const mockGradedTestResult: ResultResponseDTO = {
  * Mock Test Sessions
  */
 export const mockTestSession: TestSessionRequestDTO = {
-  test: "62c248c0f79d6c3c9ebbea95",
+  test: mockTestWithId.id,
   teacher: "62c248c0f79d6c3c9ebbea94",
   school: "62c248c0f79d6c3c9ebbea93",
   gradeLevel: 4,
@@ -58,6 +59,12 @@ export const mockTestSessionsWithSameTestId: Array<TestSessionRequestDTO> = [
     startTime: new Date("2021-09-01T09:00:00.000Z"),
   },
 ];
+
+export const mockTestSessionWithId: TestSessionResponseDTO = {
+  id: "62c248c0f79d6c3c9ebbea90",
+  ...mockTestSession,
+  results: [mockGradedTestResult],
+};
 
 export const assertResponseMatchesExpected = (
   expected: TestSessionRequestDTO,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Create test result](https://www.notion.so/uwblueprintexecs/Create-test-result-9d14ff4cee794102b74e5f2264cb48f9)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `gradeTestResult` which takes in a ResultRequestDTO and returns the corresponding ResultResponseDTO 
* Added 1 successful and 1 failing test
* Function will be called within `updateTestSession` to grade all ungraded results


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. run `yarn test`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I changed the function name from `createTestResult` to `gradeTestResult` because I think that fits better with the purpose of the function. Lmk if you have other thoughts!


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
