### PR TITLE
Implement Method For Getting Country Stats

### DIFF
--- a/backend/services/implementations/__tests__/statisticService.test.ts
+++ b/backend/services/implementations/__tests__/statisticService.test.ts
@@ -1,0 +1,81 @@
+import StatisticService from "../statisticService";
+
+import db from "../../../testUtils/testDb";
+
+import { GradingStatus } from "../../../models/testSession.model";
+import { createTestSessionWithSchoolAndResults } from "../../../testUtils/testSession";
+import { mockTestWithId } from "../../../testUtils/tests";
+import { createSchoolWithCountry } from "../../../testUtils/school";
+import { TestStatistic } from "../../interfaces/statisticService";
+
+describe("mongo statisticService", (): void => {
+  let statisticService: StatisticService;
+
+  beforeAll(async () => {
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  beforeEach(async () => {
+    statisticService = new StatisticService();
+  });
+
+  afterEach(async () => {
+    await db.clear();
+  });
+
+  it("testing stats service", async () => {
+    // insert school with given country
+    const school = await createSchoolWithCountry("Canada");
+    // create mock results
+    // average of two results is (100 + 0) / 2 = 50
+    // average for single question is (100 + 0) / 2 = 50
+    const results = [
+      {
+        student: "student-1",
+        score: 0,
+        answers: [10.5],
+        breakdown: [false],
+        gradingStatus: GradingStatus.GRADED,
+      },
+      {
+        student: "some-student-name",
+        score: 100,
+        answers: [11.5],
+        breakdown: [true],
+        gradingStatus: GradingStatus.GRADED,
+      },
+      // ungraded results get filtered out
+      {
+        student: "some-student-name",
+        score: 0,
+        answers: [],
+        breakdown: [],
+        gradingStatus: GradingStatus.UNGRADED,
+      },
+    ];
+    // create test session with specified school and results
+    await createTestSessionWithSchoolAndResults(school.id, results);
+
+    const expectedResult = new Map<string, TestStatistic>([
+      [
+        "Canada",
+        {
+          averageScore: 50,
+          averageQuestionScores: [
+            {
+              averageScore: 50,
+            },
+          ],
+        },
+      ],
+    ]);
+    const actualResult = await statisticService.getTestGradeStatisticsByCountry(
+      mockTestWithId.id,
+    );
+    expect(actualResult).toEqual(expectedResult);
+  });
+});

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -1,3 +1,4 @@
+import { Types } from "mongoose";
 import MgTestSession from "../../models/testSession.model";
 import {
   IStatisticService,
@@ -12,7 +13,7 @@ class StatisticService implements IStatisticService {
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
       // Stage 1: filter out tests that have the requested testId
-      { $match: { test: { $eq: testId } } },
+      { $match: { test: { $eq: Types.ObjectId(testId) } } },
 
       // Stage 2: unwind on the results field so that there is a document for each student result
       { $unwind: "$results" },

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -15,6 +15,7 @@ class StatisticService implements IStatisticService {
       // Stage 1: filter out tests that have the requested testId
       { $match: { test: { $eq: Types.ObjectId(testId) } } },
 
+      // Stage 2: filter out results that are not graded
       {
         $project: {
           results: {
@@ -33,10 +34,10 @@ class StatisticService implements IStatisticService {
         },
       },
 
-      // Stage 2: unwind on the results field so that there is a document for each student result
+      // Stage 3: unwind on the results field so that there is a document for each student result
       { $unwind: "$results" },
 
-      // Stage 3: get school documents corresponding to the school id
+      // Stage 4: get school documents corresponding to the school id
       {
         $lookup: {
           from: "schools",
@@ -46,7 +47,7 @@ class StatisticService implements IStatisticService {
         },
       },
 
-      // Stage 4: group together documents by the school country and keep track of the
+      // Stage 5: group together documents by the school country and keep track of the
       // result breakdown array so that the average grade per question can be computed
       {
         $group: {

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -79,7 +79,7 @@ class StatisticService implements IStatisticService {
         numCorrect += result[i] ? 1 : 0;
       });
 
-      const averageScore = +((numCorrect * 100) / numResults);
+      const averageScore = ((numCorrect * 100) / numResults);
       averageScorePerQuestion.push({ averageScore });
     }
 

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -1,18 +1,15 @@
-import MgTestSession, {
-  GradingStatus,
-  TestSession,
-} from "../../models/testSession.model";
+import MgTestSession from "../../models/testSession.model";
 import {
-  CountryStatistic,
   IStatisticService,
   QuestionStatistic,
+  TestStatistic,
 } from "../interfaces/statisticService";
 
 class StatisticService implements IStatisticService {
   /* eslint-disable class-methods-use-this */
   async getTestGradeStatisticsByCountry(
     testId: string,
-  ): Promise<Array<CountryStatistic>> {
+  ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
       // Stage 1: filter out tests that have the requested testId
       { $match: { test: { $eq: testId } } },
@@ -71,19 +68,16 @@ class StatisticService implements IStatisticService {
 
   private constructTestStatisticsByCountry(
     aggCursor: any[],
-  ): Array<CountryStatistic> {
-    const testStatistics: CountryStatistic[] = [];
+  ): Map<string, TestStatistic> {
+    const testStatistics = new Map<string, TestStatistic>();
 
     aggCursor.forEach((statistic: any) => {
-      testStatistics.push({
-        // eslint-disable-next-line no-underscore-dangle
-        country: statistic._id[0],
-        testStatistic: {
-          averageScore: statistic.averageScore,
-          averageQuestionScores: this.getAverageScorePerQuestion(
-            statistic.resultBreakdowns,
-          ),
-        },
+      // eslint-disable-next-line no-underscore-dangle
+      testStatistics.set(statistic._id[0], {
+        averageScore: statistic.averageScore,
+        averageQuestionScores: this.getAverageScorePerQuestion(
+          statistic.resultBreakdowns,
+        ),
       });
     });
 

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -1,0 +1,94 @@
+import MgTestSession, {
+  GradingStatus,
+  TestSession,
+} from "../../models/testSession.model";
+import {
+  CountryStatistic,
+  IStatisticService,
+  QuestionStatistic,
+} from "../interfaces/statisticService";
+
+class StatisticService implements IStatisticService {
+  /* eslint-disable class-methods-use-this */
+  async getTestGradeStatisticsByCountry(
+    testId: string,
+  ): Promise<Array<CountryStatistic>> {
+    const pipeline = [
+      // Stage 1: filter out tests that have the requested testId
+      { $match: { test: { $eq: testId } } },
+
+      // Stage 2: unwind on the results field so that there is a document for each student result
+      { $unwind: "$results" },
+
+      // Stage 3: get school documents corresponding to the school id
+      {
+        $lookup: {
+          from: "schools",
+          localField: "school",
+          foreignField: "_id",
+          as: "school",
+        },
+      },
+
+      // Stage 4: group together documents by the school country and keep track of the
+      // result breakdown array so that the average grade per question can be computed
+      {
+        $group: {
+          _id: "$school.country",
+          averageScore: { $avg: "$results.score" },
+          resultBreakdowns: {
+            $push: "$results.breakdown",
+          },
+        },
+      },
+    ];
+
+    const aggCursor = await MgTestSession.aggregate(pipeline);
+
+    return this.constructTestStatisticsByCountry(aggCursor);
+  }
+
+  private getAverageScorePerQuestion(
+    resultBreakdowns: boolean[][],
+  ): QuestionStatistic[] {
+    const averageScorePerQuestion: QuestionStatistic[] = [];
+    const numQuestions = resultBreakdowns[0].length;
+    const numResults = resultBreakdowns.length;
+
+    for (let i = 0; i < numQuestions; i += 1) {
+      let numCorrect = 0;
+
+      resultBreakdowns.forEach((result: boolean[]) => {
+        numCorrect += result[i] ? 1 : 0;
+      });
+
+      const averageScore = +((numCorrect * 100) / numResults).toFixed(2);
+      averageScorePerQuestion.push({ averageScore });
+    }
+
+    return averageScorePerQuestion;
+  }
+
+  private constructTestStatisticsByCountry(
+    aggCursor: any[],
+  ): Array<CountryStatistic> {
+    const testStatistics: CountryStatistic[] = [];
+
+    aggCursor.forEach((statistic: any) => {
+      testStatistics.push({
+        // eslint-disable-next-line no-underscore-dangle
+        country: statistic._id[0],
+        testStatistic: {
+          averageScore: statistic.averageScore,
+          averageQuestionScores: this.getAverageScorePerQuestion(
+            statistic.resultBreakdowns,
+          ),
+        },
+      });
+    });
+
+    return testStatistics;
+  }
+}
+
+export default StatisticService;

--- a/backend/services/interfaces/statisticService.ts
+++ b/backend/services/interfaces/statisticService.ts
@@ -15,13 +15,8 @@ export interface TestStatistic {
   averageQuestionScores: QuestionStatistic[];
 }
 
-export interface CountryStatistic {
-  country: string;
-  testStatistic: TestStatistic;
-}
-
 export interface IStatisticService {
   getTestGradeStatisticsByCountry(
     testId: string,
-  ): Promise<Array<CountryStatistic>>;
+  ): Promise<Map<string, TestStatistic>>;
 }

--- a/backend/services/interfaces/statisticService.ts
+++ b/backend/services/interfaces/statisticService.ts
@@ -1,4 +1,7 @@
 export interface QuestionStatistic {
+  /**
+   * The average score obtained by the students for a given question.
+   */
   averageScore: number;
 }
 
@@ -16,6 +19,13 @@ export interface TestStatistic {
 }
 
 export interface IStatisticService {
+  /**
+   * This method returns the statistics grouped by country for a given test. The
+   * return value is a map with a key of the country and the value contains information
+   * about the stats for the country.
+   *
+   * @param testId The unique identifier of the test to obtain statistics for
+   */
   getTestGradeStatisticsByCountry(
     testId: string,
   ): Promise<Map<string, TestStatistic>>;

--- a/backend/services/interfaces/statisticService.ts
+++ b/backend/services/interfaces/statisticService.ts
@@ -1,0 +1,27 @@
+export interface QuestionStatistic {
+  averageScore: number;
+}
+
+export interface TestStatistic {
+  /**
+   * The average score obtained by the students for a test.
+   */
+  averageScore: number;
+  /**
+   * A list containing the average scores for each question on the test.
+   * The ordering of elements in the list corresponds with the ordering
+   * of questions in the `Test` collection.
+   */
+  averageQuestionScores: QuestionStatistic[];
+}
+
+export interface CountryStatistic {
+  country: string;
+  testStatistic: TestStatistic;
+}
+
+export interface IStatisticService {
+  getTestGradeStatisticsByCountry(
+    testId: string,
+  ): Promise<Array<CountryStatistic>>;
+}

--- a/backend/testUtils/school.ts
+++ b/backend/testUtils/school.ts
@@ -3,6 +3,7 @@ import {
   SchoolResponseDTO,
 } from "../services/interfaces/schoolService";
 import { testUsers } from "./users";
+import MgSchool, { School } from "../models/school.model";
 
 // set up test schools
 export const testSchools = [
@@ -96,4 +97,17 @@ export const assertResponseMatchesExpected = (
   expect(result.city).toEqual(expected.city);
   expect(result.address).toEqual(expected.address);
   expect(result.teachers).toEqual(testUsers);
+};
+
+export const createSchoolWithCountry = async (
+  country: string,
+): Promise<School> => {
+  return MgSchool.create({
+    name: "school1",
+    country,
+    subRegion: "some-region1",
+    city: "some-city",
+    address: "some-address",
+    teachers: [testUsers[0].id, testUsers[1].id],
+  });
 };

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -1,4 +1,4 @@
-import { GradingStatus } from "../models/testSession.model";
+import MgTestSession, { GradingStatus } from "../models/testSession.model";
 import {
   ResultRequestDTO,
   ResultResponseDTO,
@@ -102,4 +102,19 @@ export const assertResultsResponseMatchesExpected = (
     ),
   ).toEqual(expectedResults?.breakdown);
   expect(actualResults?.score).toEqual(expectedResults?.score);
+};
+
+export const createTestSessionWithSchoolAndResults = async (
+  schoolId: string,
+  results: ResultRequestDTO[],
+): Promise<void> => {
+  await MgTestSession.create({
+    test: mockTestWithId.id,
+    teacher: mockTeacher.id,
+    school: schoolId,
+    gradeLevel: 4,
+    results,
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  });
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement functionality to query for country averages](https://www.notion.so/uwblueprintexecs/Implement-functionality-to-query-for-country-averages-5776b6d66b444e328a9d14495ab2f3c0)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created a MongoDB aggregate pipeline to query data for country averages
* Added a test case for the new service method


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
