### PR TITLE
Implement functionality to query for school averages

### DIFF
--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -39,7 +39,6 @@ const ResultSchema: Schema = new Schema({
   },
   score: {
     type: Number,
-    required: true,
   },
   answers: {
     type: [Number],

--- a/backend/services/implementations/__tests__/statisticService.test.ts
+++ b/backend/services/implementations/__tests__/statisticService.test.ts
@@ -2,11 +2,17 @@ import StatisticService from "../statisticService";
 
 import db from "../../../testUtils/testDb";
 
-import { GradingStatus } from "../../../models/testSession.model";
-import { createTestSessionWithSchoolAndResults } from "../../../testUtils/testSession";
+import MgTestSession, {
+  GradingStatus,
+} from "../../../models/testSession.model";
+import {
+  createTestSessionWithSchoolAndResults,
+  mockTestSessions,
+} from "../../../testUtils/testSession";
 import { mockTestWithId } from "../../../testUtils/tests";
 import { createSchoolWithCountry } from "../../../testUtils/school";
 import { TestStatistic } from "../../interfaces/statisticService";
+import mockTestStatisticsBySchool from "../../../testUtils/statistics";
 
 describe("mongo statisticService", (): void => {
   let statisticService: StatisticService;
@@ -77,5 +83,21 @@ describe("mongo statisticService", (): void => {
       mockTestWithId.id,
     );
     expect(actualResult).toEqual(expectedResult);
+  });
+
+  it("getTestGradeStatisticsBySchool", async () => {
+    await MgTestSession.insertMany(mockTestSessions);
+
+    const actualResult = await statisticService.getTestGradeStatisticsBySchool(
+      mockTestWithId.id,
+    );
+    expect(actualResult).toEqual(mockTestStatisticsBySchool);
+  });
+
+  it("getAverageScoresBySchool for invalid test id", async () => {
+    const res = await statisticService.getTestGradeStatisticsBySchool(
+      "62c248c0f79d6c3c9ebbea90",
+    );
+    expect(res).toEqual(new Map<string, TestStatistic>());
   });
 });

--- a/backend/services/interfaces/statisticService.ts
+++ b/backend/services/interfaces/statisticService.ts
@@ -29,4 +29,15 @@ export interface IStatisticService {
   getTestGradeStatisticsByCountry(
     testId: string,
   ): Promise<Map<string, TestStatistic>>;
+
+  /**
+   * This method returns the statistics grouped by school for a given test. The
+   * return value is a map with a key of the school id and the value contains information
+   * about the stats for the school.
+   *
+   * @param testId The unique identifier of the test to obtain statistics for
+   */
+  getTestGradeStatisticsBySchool(
+    testId: string,
+  ): Promise<Map<string, TestStatistic>>;
 }

--- a/backend/testUtils/school.ts
+++ b/backend/testUtils/school.ts
@@ -86,6 +86,11 @@ export const mockSchoolWithId = {
   teachers: [testUsers[0], testUsers[1]],
 };
 
+export const mockSchoolWithId2 = {
+  ...mockSchoolWithId,
+  id: "62c248c0f79d6c3c9ebbea92",
+};
+
 export const assertResponseMatchesExpected = (
   expected: SchoolRequestDTO,
   result: SchoolResponseDTO,

--- a/backend/testUtils/statistics.ts
+++ b/backend/testUtils/statistics.ts
@@ -1,0 +1,47 @@
+import { TestStatistic } from "../services/interfaces/statisticService";
+import { mockSchoolWithId, mockSchoolWithId2 } from "./school";
+
+const mockTestStatisticsBySchool = new Map<string, TestStatistic>([
+  [
+    mockSchoolWithId.id,
+    {
+      averageScore: 200 / 3,
+      averageQuestionScores: [
+        {
+          averageScore: 100,
+        },
+        {
+          averageScore: 50,
+        },
+        {
+          averageScore: 200 / 3,
+        },
+        {
+          averageScore: 50,
+        },
+      ],
+    },
+  ],
+  [
+    mockSchoolWithId2.id,
+    {
+      averageScore: 3800 / 56,
+      averageQuestionScores: [
+        {
+          averageScore: 100.0,
+        },
+        {
+          averageScore: 400 / 7,
+        },
+        {
+          averageScore: 400 / 7,
+        },
+        {
+          averageScore: 400 / 7,
+        },
+      ],
+    },
+  ],
+]);
+
+export default mockTestStatisticsBySchool;

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -5,7 +5,7 @@ import {
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
-import { mockSchoolWithId } from "./school";
+import { mockSchoolWithId, mockSchoolWithId2 } from "./school";
 import { mockTestWithId } from "./tests";
 import { mockTeacher } from "./users";
 
@@ -24,6 +24,30 @@ export const mockGradedTestResult: ResultResponseDTO = {
   student: "some-student-name",
   score: 50.0,
   answers: [10.5, 11, 1, null],
+  breakdown: [true, false, true, false],
+  gradingStatus: GradingStatus.GRADED,
+};
+
+export const mockGradedTestResult2: ResultResponseDTO = {
+  student: "some-student-name-2",
+  score: 75.0,
+  answers: [10.5, 0, 2, 14],
+  breakdown: [true, true, false, true],
+  gradingStatus: GradingStatus.GRADED,
+};
+
+export const mockGradedTestResult3: ResultResponseDTO = {
+  student: "some-student-name-3",
+  score: 100.0,
+  answers: [10.5, 0, 1, 14],
+  breakdown: [true, true, true, true],
+  gradingStatus: GradingStatus.GRADED,
+};
+
+export const mockGradedTestResult4: ResultResponseDTO = {
+  student: "some-student-name-3",
+  score: 50.0,
+  answers: [10.5, 1, 1, 13],
   breakdown: [true, false, true, false],
   gradingStatus: GradingStatus.GRADED,
 };
@@ -72,6 +96,73 @@ export const mockTestSessionWithId: TestSessionResponseDTO = {
   accessCode: "1234",
   startTime: new Date("2021-09-01T09:00:00.000Z"),
 };
+
+export const mockTestSessions: TestSessionRequestDTO[] = [
+  {
+    test: mockTestWithId.id,
+    teacher: mockTeacher.id,
+    school: mockSchoolWithId.id,
+    gradeLevel: 4,
+    results: [
+      mockGradedTestResult,
+      mockGradedTestResult2,
+      mockGradedTestResult3,
+      mockUngradedTestResult,
+    ],
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+  {
+    test: mockTestWithId.id,
+    teacher: mockTeacher.id,
+    school: mockSchoolWithId.id,
+    gradeLevel: 4,
+    results: [
+      mockGradedTestResult2,
+      mockGradedTestResult4,
+      mockGradedTestResult,
+    ],
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+  {
+    test: mockTestWithId.id,
+    teacher: mockTeacher.id,
+    school: mockSchoolWithId2.id,
+    gradeLevel: 4,
+    results: [
+      mockGradedTestResult3,
+      mockUngradedTestResult,
+      mockGradedTestResult4,
+      mockGradedTestResult,
+    ],
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+  {
+    test: mockTestWithId.id,
+    teacher: mockTeacher.id,
+    school: mockSchoolWithId2.id,
+    gradeLevel: 4,
+    results: [
+      mockGradedTestResult4,
+      mockGradedTestResult2,
+      mockGradedTestResult2,
+      mockGradedTestResult2,
+    ],
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+  {
+    test: "62c248c0f79d6c3c9ebbea94",
+    teacher: mockTeacher.id,
+    school: mockSchoolWithId.id,
+    gradeLevel: 4,
+    results: [mockGradedTestResult],
+    accessCode: "1234",
+    startTime: new Date("2021-09-01T09:00:00.000Z"),
+  },
+];
 
 export const assertResponseMatchesExpected = (
   expected: TestSessionRequestDTO,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement functionality to query for school averages](https://www.notion.so/uwblueprintexecs/Implement-functionality-to-query-for-school-averages-08591015e61f4156a54ebda26f28c009)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add getTestGradeStatisticsBySchool
* Add tests for valid and invalid test ids


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. yarn test


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
