### PR TITLE
Feat: add QuestionCard component

### DIFF
--- a/frontend/src/components/common/QuestionCard.tsx
+++ b/frontend/src/components/common/QuestionCard.tsx
@@ -86,6 +86,7 @@ const QuestionCard = ({
                 padding="4px 16px"
                 whiteSpace="nowrap"
                 minWidth="fitContent"
+                borderRadius="40px"
               >
                 <Text textStyle="paragraph">{tag}</Text>
               </Tag>

--- a/frontend/src/components/common/QuestionCard.tsx
+++ b/frontend/src/components/common/QuestionCard.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import {
+  Box,
+  Container,
+  Flex,
+  Image,
+  Spacer,
+  HStack,
+  Tag,
+  Text,
+} from "@chakra-ui/react";
+
+type QuestionCardProps = {
+  date: Date;
+  questionTitle: string;
+  image: string;
+  text: string;
+  tags: string[];
+};
+
+const QuestionCard = ({
+  date,
+  questionTitle,
+  image,
+  text,
+  tags,
+}: QuestionCardProps): React.ReactElement => {
+  return (
+    <Container
+      borderRadius="22px"
+      padding="24px"
+      maxWidth="xl"
+      background="#fff"
+    >
+      <Flex>
+        <Text fontSize="16px" lineHeight="21px" align="left">
+          {`${date.getFullYear()} / ${String(date.getMonth() + 1).padStart(
+            2,
+            "0",
+          )} / ${String(date.getDate()).padStart(2, "0")}`}
+        </Text>
+        <Spacer />
+        <HStack display={["none", "block"]}>
+          <Text
+            as="button"
+            fontWeight="700"
+            fontSize="16px"
+            align="right"
+            marginRight="24px"
+          >
+            Edit
+          </Text>
+          <Text
+            as="button"
+            color="#CC4949"
+            fontWeight="700"
+            fontSize="16px"
+            align="right"
+          >
+            Delete
+          </Text>
+        </HStack>
+      </Flex>
+      <Box fontWeight="500" fontSize="24px" marginBottom="12px">
+        <Text lineHeight="31px" align="left">
+          {questionTitle}
+        </Text>
+      </Box>
+      <Flex justifyContent="left">
+        <Image src={image} alt="IMAGE" />
+      </Flex>
+      <Box fontWeight="400" marginBottom="24px">
+        <Text noOfLines={[1, 3]} fontSize="18px" lineHeight="23px" align="left">
+          {text}
+        </Text>
+      </Box>
+      <Box overflow="hidden">
+        <HStack minWidth="sm">
+          {tags.map((tag, key) => (
+            <Tag
+              key={key}
+              color="#467826"
+              bgColor="#F0F5ED"
+              fontWeight="400"
+              padding="4px 16px"
+              whiteSpace="nowrap"
+              minWidth="fitContent"
+            >
+              <Text fontSize="18px">{tag}</Text>
+            </Tag>
+          ))}
+          ;
+        </HStack>
+      </Box>
+      <Flex display={["block", "none"]}>
+        <HStack marginTop="24px">
+          <Text
+            as="button"
+            fontWeight="700"
+            fontSize="16px"
+            align="left"
+            marginRight="24px"
+          >
+            Edit
+          </Text>
+          <Text
+            as="button"
+            color="#CC4949"
+            fontWeight="700"
+            fontSize="16px"
+            align="left"
+          >
+            Delete
+          </Text>
+        </HStack>
+      </Flex>
+    </Container>
+  );
+};
+
+export default QuestionCard;

--- a/frontend/src/components/common/QuestionCard.tsx
+++ b/frontend/src/components/common/QuestionCard.tsx
@@ -4,8 +4,7 @@ import {
   Container,
   Flex,
   Image,
-  Spacer,
-  HStack,
+  Stack,
   Tag,
   Text,
 } from "@chakra-ui/react";
@@ -25,95 +24,78 @@ const QuestionCard = ({
   text,
   tags,
 }: QuestionCardProps): React.ReactElement => {
+  const buttons: React.ReactElement = (
+    <>
+      <Text
+        as="button"
+        fontWeight="700"
+        fontSize="16px"
+        align="right"
+        marginRight="24px"
+      >
+        Edit
+      </Text>
+      <Text
+        as="button"
+        color="#CC4949"
+        fontWeight="700"
+        fontSize="16px"
+        align="right"
+      >
+        Delete
+      </Text>
+    </>
+  );
   return (
     <Container
       borderRadius="22px"
       padding="24px"
-      maxWidth="xl"
+      maxWidth="2xl"
       background="#fff"
     >
-      <Flex>
-        <Text fontSize="16px" lineHeight="21px" align="left">
-          {`${date.getFullYear()} / ${String(date.getMonth() + 1).padStart(
-            2,
-            "0",
-          )} / ${String(date.getDate()).padStart(2, "0")}`}
-        </Text>
-        <Spacer />
-        <HStack display={["none", "block"]}>
-          <Text
-            as="button"
-            fontWeight="700"
-            fontSize="16px"
-            align="right"
-            marginRight="24px"
-          >
-            Edit
+      <Stack direction={["column", "row"]}>
+        <Box>
+          <Text textStyle="eyebrow" align="left">
+            {`${String(date.getDate()).padStart(2, "0")} / ${String(
+              date.getMonth() + 1,
+            ).padStart(2, "0")} / ${String(date.getFullYear()).substring(
+              2,
+              4,
+            )}`}
           </Text>
-          <Text
-            as="button"
-            color="#CC4949"
-            fontWeight="700"
-            fontSize="16px"
-            align="right"
-          >
-            Delete
+          <Text marginBottom="12px" textStyle="subtitle1" align="left">
+            {questionTitle}
           </Text>
-        </HStack>
-      </Flex>
-      <Box fontWeight="500" fontSize="24px" marginBottom="12px">
-        <Text lineHeight="31px" align="left">
-          {questionTitle}
-        </Text>
-      </Box>
-      <Flex justifyContent="left">
-        <Image src={image} alt="IMAGE" />
-      </Flex>
-      <Box fontWeight="400" marginBottom="24px">
-        <Text noOfLines={[1, 3]} fontSize="18px" lineHeight="23px" align="left">
-          {text}
-        </Text>
-      </Box>
-      <Box overflow="hidden">
-        <HStack minWidth="sm">
-          {tags.map((tag, key) => (
-            <Tag
-              key={key}
-              color="#467826"
-              bgColor="#F0F5ED"
-              fontWeight="400"
-              padding="4px 16px"
-              whiteSpace="nowrap"
-              minWidth="fitContent"
-            >
-              <Text fontSize="18px">{tag}</Text>
-            </Tag>
-          ))}
-          ;
-        </HStack>
-      </Box>
-      <Flex display={["block", "none"]}>
-        <HStack marginTop="24px">
+          <Flex justifyContent="left">
+            <Image src={image} alt="IMAGE" />
+          </Flex>
           <Text
-            as="button"
-            fontWeight="700"
-            fontSize="16px"
-            align="left"
-            marginRight="24px"
-          >
-            Edit
-          </Text>
-          <Text
-            as="button"
-            color="#CC4949"
-            fontWeight="700"
-            fontSize="16px"
+            marginBottom="24px"
+            noOfLines={[1, 3]}
+            textStyle="paragraph"
             align="left"
           >
-            Delete
+            {text}
           </Text>
-        </HStack>
-      </Flex>
+          <Stack overflow="hidden" minWidth="sm" direction="row">
+            {tags.map((tag, key) => (
+              <Tag
+                key={key}
+                color="green.400"
+                bgColor="green.50"
+                padding="4px 16px"
+                whiteSpace="nowrap"
+                minWidth="fitContent"
+              >
+                <Text textStyle="paragraph">{tag}</Text>
+              </Tag>
+            ))}
+          </Stack>
+        </Box>
+        <Stack direction="row" alignItems="start">
+          {buttons}
+        </Stack>
+      </Stack>
     </Container>
   );
 };

--- a/frontend/src/components/common/QuestionCard.tsx
+++ b/frontend/src/components/common/QuestionCard.tsx
@@ -24,34 +24,13 @@ const QuestionCard = ({
   text,
   tags,
 }: QuestionCardProps): React.ReactElement => {
-  const buttons: React.ReactElement = (
-    <>
-      <Text
-        as="button"
-        fontWeight="700"
-        fontSize="16px"
-        align="right"
-        marginRight="24px"
-      >
-        Edit
-      </Text>
-      <Text
-        as="button"
-        color="#CC4949"
-        fontWeight="700"
-        fontSize="16px"
-        align="right"
-      >
-        Delete
-      </Text>
-    </>
-  );
   return (
     <Container
       borderRadius="22px"
       padding="24px"
       maxWidth="2xl"
-      background="#fff"
+      background="white"
+      color="grey.300"
     >
       <Stack direction={["column", "row"]}>
         <Box>
@@ -94,7 +73,25 @@ const QuestionCard = ({
           </Stack>
         </Box>
         <Stack direction="row" alignItems="start">
-          {buttons}
+          <Text
+            as="button"
+            color="black"
+            align="right"
+            marginRight="24px"
+            textStyle="link"
+          >
+            Edit
+          </Text>
+          <Text
+            as="button"
+            color="red.200"
+            fontWeight="700"
+            fontSize="16px"
+            align="right"
+            textStyle="link"
+          >
+            Delete
+          </Text>
         </Stack>
       </Stack>
     </Container>

--- a/frontend/src/components/common/QuestionCard.tsx
+++ b/frontend/src/components/common/QuestionCard.tsx
@@ -33,7 +33,7 @@ const QuestionCard = ({
     <Container
       borderRadius="22px"
       padding="24px"
-      maxWidth="2xl"
+      maxWidth={["318px", "918px"]}
       background="white"
       color="grey.300"
     >
@@ -56,7 +56,7 @@ const QuestionCard = ({
           >
             {text}
           </Text>
-          <Stack overflow="hidden" minWidth="sm" direction="row">
+          <Stack overflow="hidden" direction="row">
             {tags.map((tag, key) => (
               <Tag
                 key={key}

--- a/frontend/src/components/common/QuestionCard.tsx
+++ b/frontend/src/components/common/QuestionCard.tsx
@@ -11,7 +11,7 @@ import {
 
 type QuestionCardProps = {
   date: Date;
-  questionTitle: string;
+  title: string;
   image: string;
   text: string;
   tags: string[];
@@ -19,11 +19,16 @@ type QuestionCardProps = {
 
 const QuestionCard = ({
   date,
-  questionTitle,
+  title,
   image,
   text,
   tags,
 }: QuestionCardProps): React.ReactElement => {
+  const formatDate = (d: Date) =>
+    `${String(d.getDate()).padStart(2, "0")} / ${String(
+      d.getMonth() + 1,
+    ).padStart(2, "0")} / ${String(d.getFullYear()).substring(2, 4)}`;
+
   return (
     <Container
       borderRadius="22px"
@@ -33,17 +38,12 @@ const QuestionCard = ({
       color="grey.300"
     >
       <Stack direction={["column", "row"]}>
-        <Box>
+        <Box marginBottom={["24px", "0px"]}>
           <Text textStyle="eyebrow" align="left">
-            {`${String(date.getDate()).padStart(2, "0")} / ${String(
-              date.getMonth() + 1,
-            ).padStart(2, "0")} / ${String(date.getFullYear()).substring(
-              2,
-              4,
-            )}`}
+            {formatDate(date)}
           </Text>
           <Text marginBottom="12px" textStyle="subtitle1" align="left">
-            {questionTitle}
+            {title}
           </Text>
           <Flex justifyContent="left">
             <Image src={image} alt="IMAGE" />

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -5,6 +5,7 @@ import {
   VStack,
   Text,
 } from "@chakra-ui/react";
+
 import { ArrowBackOutlineIcon, ArrowForwardOutlineIcon } from "../common/icons";
 import MainPageButton from "../common/MainPageButton";
 import AdminConfirmationMessage from "../common/Admin/AdminConfirmationMessage";
@@ -178,7 +179,7 @@ const ComponentLibrary = (): React.ReactElement => {
         date={new Date()}
         questionTitle="Question Title"
         image=""
-        text="Question Text"
+        text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra."
         tags={["Grade 2", "Unit #", "Lesson #"]}
       />
     </div>

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -179,7 +179,7 @@ const ComponentLibrary = (): React.ReactElement => {
         date={new Date()}
         title="Question Title"
         image=""
-        text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra."
+        text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra. Lorem ipsum dolor sit amet,"
         tags={["Grade 2", "Unit #", "Lesson #"]}
       />
     </div>

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -177,7 +177,7 @@ const ComponentLibrary = (): React.ReactElement => {
       <MainPageButton />
       <QuestionCard
         date={new Date()}
-        questionTitle="Question Title"
+        title="Question Title"
         image=""
         text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Diam, luctus id elementum, pellentesque ornare consectetur ac pharetra."
         tags={["Grade 2", "Unit #", "Lesson #"]}

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -5,10 +5,10 @@ import {
   VStack,
   Text,
 } from "@chakra-ui/react";
-
 import { ArrowBackOutlineIcon, ArrowForwardOutlineIcon } from "../common/icons";
 import MainPageButton from "../common/MainPageButton";
 import AdminConfirmationMessage from "../common/Admin/AdminConfirmationMessage";
+import QuestionCard from "../common/QuestionCard";
 
 const ButtonExamples = () => {
   return (
@@ -174,6 +174,13 @@ const ComponentLibrary = (): React.ReactElement => {
       <ButtonExamples />
       <AdminConfirmationMessage />
       <MainPageButton />
+      <QuestionCard
+        date={new Date()}
+        questionTitle="Question Title"
+        image=""
+        text="Question Text"
+        tags={["Grade 2", "Unit #", "Lesson #"]}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Question Component](https://www.notion.so/uwblueprintexecs/Question-Component-356de586178345d9bbddb2d4eb3c167d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* `QuestionCard.tsx`: Create the `QuestionCard` component, which displays a question, to follow the behaviour described in the above ticket and in the Figma design [here](https://www.figma.com/file/Uia7C5xwqDlkLnrXMyt5hn/Jump-Math-Design-System?node-id=227%3A4454) (Note: slight discrepancy from the design with respect to the tag fade - pending revision after the finalized version of the Question card component)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
<img width="694" alt="Screen Shot 2022-10-09 at 4 37 06 PM" src="https://user-images.githubusercontent.com/68651393/194778389-d0691c21-3f75-4ad2-9cfb-a8c0bb0cf679.png">
<img width="352" alt="Screen Shot 2022-10-09 at 11 17 40 PM" src="https://user-images.githubusercontent.com/68651393/194794776-ca3b17a9-8c48-454c-b595-95ceca9f074d.png">

Figma design linked above

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Quick note: there are quite a few linting changes here that are redundant with those in https://github.com/uwblueprint/jump-math/pull/55 - will rebase after that PR is merged

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
