### PR TITLE
fix: admin page styling

### DIFF
--- a/frontend/src/components/common/AdminUserTable.tsx
+++ b/frontend/src/components/common/AdminUserTable.tsx
@@ -59,7 +59,7 @@ const AdminUserTable = ({
                   {user.email}
                 </Text>
               </Td>
-              <Td width="10%">
+              <Td width="5%">
                 <RemoveUserPopover
                   name={`${user.firstName} ${user.lastName}`}
                   email={user.email}

--- a/frontend/src/components/common/AdminUserTable.tsx
+++ b/frontend/src/components/common/AdminUserTable.tsx
@@ -30,12 +30,12 @@ const AdminUserTable = ({
         <Thead>
           <Tr>
             <Th>
-              <Text textStyle="link" color="blue.700" textTransform="none">
+              <Text textStyle="link" color="blue.300" textTransform="none">
                 Name
               </Text>
             </Th>
             <Th>
-              <Text textStyle="link" color="blue.700" textTransform="none">
+              <Text textStyle="link" color="blue.300" textTransform="none">
                 Email
               </Text>
             </Th>
@@ -50,6 +50,7 @@ const AdminUserTable = ({
             >
               <Td>
                 <Text
+                  as="b"
                   noOfLines={1}
                   style={{ display: "block" }}
                 >{`${user.firstName} ${user.lastName}`}</Text>

--- a/frontend/src/components/common/AdminUserTable.tsx
+++ b/frontend/src/components/common/AdminUserTable.tsx
@@ -31,12 +31,22 @@ const AdminUserTable = ({
         <Thead>
           <Tr>
             <Th>
-              <Text textStyle="link" color="blue.300" textTransform="none">
+              <Text
+                textStyle="mobileSubtitle2"
+                fontWeight="bold"
+                color="blue.300"
+                textTransform="none"
+              >
                 Name
               </Text>
             </Th>
             <Th>
-              <Text textStyle="link" color="blue.300" textTransform="none">
+              <Text
+                textStyle="mobileSubtitle2"
+                fontWeight="bold"
+                color="blue.300"
+                textTransform="none"
+              >
                 Email
               </Text>
             </Th>
@@ -51,13 +61,18 @@ const AdminUserTable = ({
             >
               <Td>
                 <Text
-                  as="b"
+                  fontWeight="bold"
+                  textStyle="mobileSubtitle2"
                   noOfLines={1}
                   style={{ display: "block" }}
                 >{`${user.firstName} ${user.lastName}`}</Text>
               </Td>
               <Td>
-                <Text noOfLines={1} style={{ display: "block" }}>
+                <Text
+                  textStyle="mobileSubtitle2"
+                  noOfLines={1}
+                  style={{ display: "block" }}
+                >
                   {user.email}
                 </Text>
               </Td>

--- a/frontend/src/components/common/AdminUserTable.tsx
+++ b/frontend/src/components/common/AdminUserTable.tsx
@@ -25,6 +25,7 @@ const AdminUserTable = ({
       border="1px solid"
       borderColor="#E2E8F0"
       borderRadius="12px"
+      minWidth="100%"
     >
       <Table sx={{ tableLayout: "auto" }} variant="unstyled" size="md">
         <Thead>

--- a/frontend/src/components/common/Form/EmailInput.tsx
+++ b/frontend/src/components/common/Form/EmailInput.tsx
@@ -29,6 +29,7 @@ const EmailInput = ({
       variant="filled"
       _invalid={{ borderColor: "red.200" }}
       isInvalid={isInvalid ?? false}
+      borderRadius="6px"
     />
   );
 };

--- a/frontend/src/components/common/Form/TextInput.tsx
+++ b/frontend/src/components/common/Form/TextInput.tsx
@@ -26,6 +26,7 @@ const TextInput = ({
       variant="filled"
       isInvalid={isInvalid ?? false}
       _invalid={{ borderColor: "red.200" }}
+      borderRadius="6px"
     />
   );
 };

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -111,6 +111,7 @@ const AdminPage = (): React.ReactElement => {
             <InputGroup maxWidth="280px">
               <Input
                 borderRadius="6px"
+                borderColor="grey.100"
                 backgroundColor="grey.100"
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search bar"

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -99,27 +99,15 @@ const AdminPage = (): React.ReactElement => {
       <SideBar pages={pages} />
       <VStack flex="1" align="left" margin="4.5em 2em 0em 2em">
         <Box>
-          <Text
-            textStyle="header4"
-            color="blue.300"
-            style={{ textAlign: "left" }}
-            marginBottom="0.5em"
-          >
-            Database
-          </Text>
           <HStack justifyContent="space-between">
-            <InputGroup maxWidth="280px">
-              <Input
-                borderRadius="6px"
-                borderColor="grey.100"
-                backgroundColor="grey.100"
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search bar"
-              />
-              <InputRightElement pointerEvents="none" h="full">
-                <SearchOutlineIcon />
-              </InputRightElement>
-            </InputGroup>
+            <Text
+              textStyle="header4"
+              color="blue.300"
+              style={{ textAlign: "left" }}
+              marginBottom="0.5em"
+            >
+              Database
+            </Text>
             <AddAdminModal />
           </HStack>
         </Box>
@@ -142,7 +130,21 @@ const AdminPage = (): React.ReactElement => {
               </TabList>
               <TabPanels>
                 <TabPanel>
-                  <AdminUserTable adminUsers={admins} />
+                  <VStack pt={4} spacing={6}>
+                    <InputGroup>
+                      <Input
+                        borderRadius="6px"
+                        borderColor="grey.100"
+                        backgroundColor="grey.100"
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="Search bar"
+                      />
+                      <InputRightElement pointerEvents="none" h="full">
+                        <SearchOutlineIcon />
+                      </InputRightElement>
+                    </InputGroup>
+                    <AdminUserTable adminUsers={admins} />
+                  </VStack>
                 </TabPanel>
                 <TabPanel>
                   <AdminUserTable adminUsers={admins} />

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -143,6 +143,11 @@ const AdminPage = (): React.ReactElement => {
                         <SearchOutlineIcon />
                       </InputRightElement>
                     </InputGroup>
+                    {search && (
+                      <Text fontSize="16px" color="grey.300" width="100%">
+                        Showing {admins.length} results for &quot;{search}&quot;
+                      </Text>
+                    )}
                     <AdminUserTable adminUsers={admins} />
                   </VStack>
                 </TabPanel>


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Making some small cosmetic changes as requested by design. The following changes have been implemented:
* Table headers and row `textStyle` is updated to `mobileSubtitle2`
* First column text is bolded
* Table header text colour has been updated to a lighter shade of blue
* Search bar is full page width
* The Admin page component hierarchy has been updated
* The border radiuses of all input boxes has been updated to `6px`
* Upon searching, a user is shown a message with how many entries match the search query

<img width="1920" alt="Screen Shot 2022-12-01 at 12 46 15 AM" src="https://user-images.githubusercontent.com/41273486/204975745-d533b7eb-c438-4de8-823f-5d29279908c8.png">