### PR TITLE
chore: refactoring mutations, queries and types to APIClients folder

### DIFF
--- a/frontend/src/APIClients/mutations/AuthMutations.ts
+++ b/frontend/src/APIClients/mutations/AuthMutations.ts
@@ -1,0 +1,57 @@
+import { gql } from "@apollo/client";
+
+export const REGISTER = gql`
+  mutation Signup_Register(
+    $firstName: String!
+    $lastName: String!
+    $email: String!
+    $password: String!
+  ) {
+    register(
+      user: {
+        firstName: $firstName
+        lastName: $lastName
+        email: $email
+        password: $password
+      }
+    ) {
+      id
+      firstName
+      lastName
+      email
+      role
+      accessToken
+    }
+  }
+`;
+
+export const LOGIN = gql`
+  mutation Login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      id
+      firstName
+      lastName
+      email
+      role
+      accessToken
+    }
+  }
+`;
+
+export const LOGOUT = gql`
+  mutation Logout($userId: ID!) {
+    logout(userId: $userId)
+  }
+`;
+
+export const REFRESH = gql`
+  mutation Refresh {
+    refresh
+  }
+`;
+
+export const RESET_PASSWORD = gql`
+  mutation ResetPassword($email: String!) {
+    resetPassword(email: $email)
+  }
+`;

--- a/frontend/src/APIClients/mutations/UserMutations.ts
+++ b/frontend/src/APIClients/mutations/UserMutations.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-const ADD_USER = gql`
+export const ADD_USER = gql`
   mutation AddUser($user: CreateUserDTO!) {
     createUser(user: $user) {
       id
@@ -12,4 +12,8 @@ const ADD_USER = gql`
   }
 `;
 
-export default ADD_USER;
+export const REMOVE_USER = gql`
+  mutation DeleteUserByEmail($email: String!) {
+    deleteUserByEmail(email: $email)
+  }
+`;

--- a/frontend/src/APIClients/types/SchoolClientTypes.ts
+++ b/frontend/src/APIClients/types/SchoolClientTypes.ts
@@ -1,4 +1,4 @@
-import { UserResponse } from "./UserTypes";
+import { UserResponse } from "./UserClientTypes";
 
 export interface SchoolResponse {
   /** the unique identifier for the school */

--- a/frontend/src/APIClients/types/UserClientTypes.ts
+++ b/frontend/src/APIClients/types/UserClientTypes.ts
@@ -1,0 +1,17 @@
+import { Role } from "../../types/AuthTypes";
+
+export type UserRequest = {
+  firstName: string;
+  lastName: string;
+  password: string;
+  email: string;
+  role: Role;
+};
+
+export type UserResponse = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: Role;
+};

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -8,6 +8,7 @@ import {
 import { gql, useMutation } from "@apollo/client";
 
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import { LOGIN } from "../../APIClients/mutations/AuthMutations";
 import { HOME_PAGE, SIGNUP_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
 import { AuthenticatedUser } from "../../types/AuthTypes";
@@ -18,19 +19,6 @@ type GoogleErrorResponse = {
   error: string;
   details: string;
 };
-
-const LOGIN = gql`
-  mutation Login($email: String!, $password: String!) {
-    login(email: $email, password: $password) {
-      id
-      firstName
-      lastName
-      email
-      role
-      accessToken
-    }
-  }
-`;
 
 const LOGIN_WITH_GOOGLE = gql`
   mutation LoginWithGoogle($idToken: String!) {

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -1,14 +1,9 @@
 import React, { useContext } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import { LOGOUT } from "../../APIClients/mutations/AuthMutations";
 import AuthContext from "../../contexts/AuthContext";
-
-const LOGOUT = gql`
-  mutation Logout($userId: ID!) {
-    logout(userId: $userId)
-  }
-`;
 
 const Logout = (): React.ReactElement => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/auth/RefreshCredentials.tsx
+++ b/frontend/src/components/auth/RefreshCredentials.tsx
@@ -1,14 +1,9 @@
 import React, { useContext } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import { REFRESH } from "../../APIClients/mutations/AuthMutations";
 import AuthContext from "../../contexts/AuthContext";
-
-const REFRESH = gql`
-  mutation Refresh {
-    refresh
-  }
-`;
 
 const RefreshCredentials = (): React.ReactElement => {
   const { setAuthenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -1,12 +1,7 @@
 import React, { useContext } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
-
-const RESET_PASSWORD = gql`
-  mutation ResetPassword($email: String!) {
-    resetPassword(email: $email)
-  }
-`;
+import { RESET_PASSWORD } from "../../APIClients/mutations/AuthMutations";
 
 const ResetPassword = (): React.ReactElement => {
   const { authenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -1,36 +1,12 @@
 import React, { useContext, useState } from "react";
 import { Redirect } from "react-router-dom";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import { REGISTER } from "../../APIClients/mutations/AuthMutations";
 import { HOME_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
 import { AuthenticatedUser } from "../../types/AuthTypes";
-
-const REGISTER = gql`
-  mutation Signup_Register(
-    $firstName: String!
-    $lastName: String!
-    $email: String!
-    $password: String!
-  ) {
-    register(
-      user: {
-        firstName: $firstName
-        lastName: $lastName
-        email: $email
-        password: $password
-      }
-    ) {
-      id
-      firstName
-      lastName
-      email
-      role
-      accessToken
-    }
-  }
-`;
 
 const Signup = (): React.ReactElement => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/auth/TeacherSignup/TeacherSignupTwo.tsx
+++ b/frontend/src/components/auth/TeacherSignup/TeacherSignupTwo.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@apollo/client";
 import { Button, VStack, Text, FormControl, FormLabel } from "@chakra-ui/react";
 import React from "react";
 import GET_SCHOOLS from "../../../APIClients/queries/SchoolQueries";
-import { SchoolResponse } from "../../../types/SchoolTypes";
+import { SchoolResponse } from "../../../APIClients/types/SchoolClientTypes";
 import SelectFormInput from "./SelectFormInput";
 import { TeacherSignupProps } from "./types";
 import ErrorMessage from "./ErrorMessage";

--- a/frontend/src/components/common/AddAdminModal.tsx
+++ b/frontend/src/components/common/AddAdminModal.tsx
@@ -28,7 +28,7 @@ import ModalFooterButtons from "./ModalFooterButtons";
 import { PlusOutlineIcon } from "./icons";
 import { ADMIN_PAGE } from "../../constants/Routes";
 import { UserRequest } from "../../types/UserTypes";
-import ADD_USER from "../../APIClients/mutations/UserMutations";
+import { ADD_USER } from "../../APIClients/mutations/UserMutations";
 import GET_USERS_BY_ROLE from "../../APIClients/queries/UserQueries";
 
 const AddAdminModal = (): React.ReactElement => {

--- a/frontend/src/components/common/AddAdminModal.tsx
+++ b/frontend/src/components/common/AddAdminModal.tsx
@@ -27,7 +27,7 @@ import AdminConfirmationMessage from "./Admin/AdminConfirmationMessage";
 import ModalFooterButtons from "./ModalFooterButtons";
 import { PlusOutlineIcon } from "./icons";
 import { ADMIN_PAGE } from "../../constants/Routes";
-import { UserRequest } from "../../types/UserTypes";
+import { UserRequest } from "../../APIClients/types/UserClientTypes";
 import { ADD_USER } from "../../APIClients/mutations/UserMutations";
 import GET_USERS_BY_ROLE from "../../APIClients/queries/UserQueries";
 

--- a/frontend/src/components/common/Admin/RemoveUserModal.tsx
+++ b/frontend/src/components/common/Admin/RemoveUserModal.tsx
@@ -1,4 +1,4 @@
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import {
   Button,
   Divider,
@@ -14,18 +14,13 @@ import ModalText from "./ModalText";
 import RemoveUserConfirmationModal from "./RemoveUserConfirmationModal";
 import RemoveUserErrorModal from "./RemoveUserErrorModal";
 import GET_USERS_BY_ROLE from "../../../APIClients/queries/UserQueries";
+import { REMOVE_USER } from "../../../APIClients/mutations/UserMutations";
 
 interface RemoveUserModalProps {
   name: string;
   email: string;
   onCloseParent: () => void;
 }
-
-const REMOVE_USER = gql`
-  mutation DeleteUserByEmail($email: String!) {
-    deleteUserByEmail(email: $email)
-  }
-`;
 
 const RemoveUserModal = ({
   name,

--- a/frontend/src/types/UserTypes.ts
+++ b/frontend/src/types/UserTypes.ts
@@ -1,23 +1,5 @@
-import { Role } from "./AuthTypes";
-
 export type AdminUser = {
   firstName: string;
   lastName: string;
   email: string;
-};
-
-export type UserRequest = {
-  firstName: string;
-  lastName: string;
-  password: string;
-  email: string;
-  role: Role;
-};
-
-export type UserResponse = {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  role: Role;
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Clean Frontend File Structure](https://www.notion.so/uwblueprintexecs/Clean-Frontend-File-Structure-e333aeb27be741e3a07705aa67530007)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* moved mutations and queries to `APIClients`
* moved request and response types to new `types` folder in `APIClients`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test that there are no breaking changes.