### PR TITLE
fix: sort popover

### DIFF
--- a/frontend/src/components/common/SortTablePopover.tsx
+++ b/frontend/src/components/common/SortTablePopover.tsx
@@ -44,9 +44,9 @@ const SortTablePopover = ({
           <>
             <PopoverTrigger>
               <Button
+                minWidth="10%"
                 rightIcon={<FilterOptionsIcon />}
                 variant="tertiary"
-                minWidth="10%"
               >
                 Sort
               </Button>
@@ -56,6 +56,7 @@ const SortTablePopover = ({
                 <Box w="1200px">
                   <Stack direction="row" spacing={30} sx={{ pt: "2", pl: "5" }}>
                     <RadioGroup
+                      color="blue.300"
                       onChange={(e) => {
                         if (e === "firstName" || e === "email") {
                           setSortProperty(e);
@@ -64,12 +65,7 @@ const SortTablePopover = ({
                       value={sortProperty}
                     >
                       <Stack>
-                        <Text
-                          color="blue.800"
-                          as="b"
-                          pb="2"
-                          textStyle="subtitle3"
-                        >
+                        <Text pb="2" textStyle="link">
                           Property
                         </Text>
                         <Radio defaultChecked value="firstName">
@@ -82,6 +78,7 @@ const SortTablePopover = ({
                       <Divider orientation="vertical" />
                     </Center>
                     <RadioGroup
+                      color="blue.300"
                       onChange={(e) => {
                         if (e === "Ascending" || e === "Descending") {
                           setSortOrder(e);
@@ -90,19 +87,10 @@ const SortTablePopover = ({
                       value={sortOrder}
                     >
                       <Stack>
-                        <Text
-                          color="blue.800"
-                          as="b"
-                          pb="2"
-                          textStyle="subtitle3"
-                        >
+                        <Text pb="2" textStyle="link">
                           Order
                         </Text>
-                        <Radio
-                          color="blue.800"
-                          defaultChecked
-                          value="Ascending"
-                        >
+                        <Radio defaultChecked value="Ascending">
                           Ascending
                         </Radio>
                         <Radio value="Descending">Descending</Radio>
@@ -121,13 +109,7 @@ const SortTablePopover = ({
                 pr={8}
               >
                 <Spacer />
-                <Button
-                  onClick={onClose}
-                  color="blue.800"
-                  size="lg"
-                  bg="#DFDFDF"
-                  colorScheme="blue"
-                >
+                <Button minWidth="10%" onClick={onClose} variant="secondary">
                   Apply
                 </Button>
               </PopoverFooter>

--- a/frontend/src/components/common/SortTablePopover.tsx
+++ b/frontend/src/components/common/SortTablePopover.tsx
@@ -45,7 +45,7 @@ const SortTablePopover = ({
             <PopoverTrigger>
               <Button
                 minWidth="10%"
-                rightIcon={<FilterOptionsIcon />}
+                leftIcon={<FilterOptionsIcon />}
                 variant="tertiary"
               >
                 Sort

--- a/frontend/src/components/common/SortTablePopover.tsx
+++ b/frontend/src/components/common/SortTablePopover.tsx
@@ -44,11 +44,9 @@ const SortTablePopover = ({
           <>
             <PopoverTrigger>
               <Button
-                size="sm"
-                pl="10%"
-                ml="0"
                 rightIcon={<FilterOptionsIcon />}
-                bg="#blue.300"
+                variant="tertiary"
+                minWidth="10%"
               >
                 Sort
               </Button>

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -126,30 +126,15 @@ const AdminPage = (): React.ReactElement => {
       <SideBar pages={pages} />
       <VStack flex="1" align="left" margin="4.5em 2em 0em 2em">
         <Box>
-          <Text
-            textStyle="header4"
-            color="blue.300"
-            style={{ textAlign: "left" }}
-            marginBottom="0.5em"
-          >
-            Database
-          </Text>
           <HStack justifyContent="space-between">
-            <HStack>
-              <InputGroup maxWidth="280px">
-                <Input
-                  borderRadius="6px"
-                  backgroundColor="grey.100"
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search bar"
-                />
-                <InputRightElement pointerEvents="none" h="full">
-                  <SearchOutlineIcon />
-                </InputRightElement>
-              </InputGroup>
-              <SortTablePopover OrderingSets={OrderingSets} />
-            </HStack>
-
+            <Text
+              textStyle="header4"
+              color="blue.300"
+              style={{ textAlign: "left" }}
+              marginBottom="0.5em"
+            >
+              Database
+            </Text>
             <AddAdminModal />
           </HStack>
         </Box>
@@ -173,18 +158,21 @@ const AdminPage = (): React.ReactElement => {
               <TabPanels>
                 <TabPanel>
                   <VStack pt={4} spacing={6}>
-                    <InputGroup>
-                      <Input
-                        borderRadius="6px"
-                        borderColor="grey.100"
-                        backgroundColor="grey.100"
-                        onChange={(e) => setSearch(e.target.value)}
-                        placeholder="Search bar"
-                      />
-                      <InputRightElement pointerEvents="none" h="full">
-                        <SearchOutlineIcon />
-                      </InputRightElement>
-                    </InputGroup>
+                    <HStack width="100%">
+                      <InputGroup width="90%">
+                        <Input
+                          borderRadius="6px"
+                          borderColor="grey.100"
+                          backgroundColor="grey.100"
+                          onChange={(e) => setSearch(e.target.value)}
+                          placeholder="Search bar"
+                        />
+                        <InputRightElement pointerEvents="none" h="full">
+                          <SearchOutlineIcon />
+                        </InputRightElement>
+                      </InputGroup>
+                      <SortTablePopover OrderingSets={OrderingSets} />
+                    </HStack>
                     {search && (
                       <Text fontSize="16px" color="grey.300" width="100%">
                         Showing {admins.length} results for &quot;{search}&quot;

--- a/frontend/src/themes/components/button.ts
+++ b/frontend/src/themes/components/button.ts
@@ -53,24 +53,17 @@ const Button = {
     secondary: {
       bg: "blue.50",
       color: "blue.300",
-      border: "1.5px solid",
-      borderColor: "blue.300",
       _active: {
         bg: "blue.100",
-        border: "1.5px solid",
       },
       _hover: {
         bg: "blue.100",
-        border: "1.5px solid #FFFFFF",
         _disabled: {
           bg: "blue.100",
-          borderColor: "blue.300",
         },
       },
       _disabled: {
         bg: "blue.100",
-        border: "1.5px solid",
-        borderColor: "blue.300",
         opacity: 0.4,
       },
       DarkBlueIcon,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Sort Popover Fixes](https://www.notion.so/uwblueprintexecs/Sort-Popover-Fixes-cd19dde3f1724f2b902b257480f786ea)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* some minor cosmetic fixes to the sort popover

**Updated Screen**
<img width="1436" alt="Screen Shot 2022-12-31 at 8 31 53 PM" src="https://user-images.githubusercontent.com/41273486/210158898-d059c698-bbb2-4130-9b3b-6d13a6e8d30c.png">

**Previous Screen**
<img width="1437" alt="Screen Shot 2022-12-31 at 8 39 46 PM" src="https://user-images.githubusercontent.com/41273486/210158896-6ff6ef04-5d64-41cd-8251-00348742842c.png">

**Design Screen** (this is a screenshot of the `Display Assessments` view, design agreed that the admin dashboard view should match this format)
![All](https://user-images.githubusercontent.com/41273486/210158894-e2b1e8c8-c4d0-4a9b-a47a-8acb36a103c8.png)
