### PR TITLE
fix: Remove Admin Field from Test Service

### DIFF
--- a/backend/graphql/resolvers/testResolvers.ts
+++ b/backend/graphql/resolvers/testResolvers.ts
@@ -11,10 +11,6 @@ import {
   QuestionComponentRequest,
   QuestionComponentMetadataRequest,
 } from "../../services/interfaces/testService";
-import {
-  QuestionComponentMetadata,
-  QuestionComponent,
-} from "../../models/test.model";
 
 const testService: ITestService = new TestService();
 
@@ -143,7 +139,6 @@ const testResolvers = {
       const updatedTest = await testService.updateTest(testId, {
         ...testToUpdate,
         status: AssessmentStatus.PUBLISHED,
-        admin: testToUpdate.admin.id,
       });
       return updatedTest;
     },

--- a/backend/graphql/resolvers/testResolvers.ts
+++ b/backend/graphql/resolvers/testResolvers.ts
@@ -1,5 +1,4 @@
 import TestService from "../../services/implementations/testService";
-import UserService from "../../services/implementations/userService";
 import {
   ITestService,
   TestRequestDTO,
@@ -7,15 +6,13 @@ import {
   QuestionComponentRequest,
   QuestionComponentMetadataRequest,
 } from "../../services/interfaces/testService";
-import IUserService from "../../services/interfaces/userService";
 
 import {
   QuestionComponentMetadata,
   QuestionComponent,
 } from "../../models/test.model";
 
-const userService: IUserService = new UserService();
-const testService: ITestService = new TestService(userService);
+const testService: ITestService = new TestService();
 
 type QuestionMetadataName =
   | "QuestionTextMetadata"

--- a/backend/graphql/types/testType.ts
+++ b/backend/graphql/types/testType.ts
@@ -100,7 +100,6 @@ const testType = gql`
   type TestResponseDTO {
     id: ID!
     name: String!
-    admin: UserDTO!
     questions: [[QuestionComponent]]!
     grade: Int!
     assessmentType: AssessmentTypeEnum!
@@ -111,7 +110,6 @@ const testType = gql`
 
   input TestRequestDTO {
     name: String!
-    admin: ID!
     questions: [[QuestionComponentInput]]!
     grade: Int!
     assessmentType: AssessmentTypeEnum!

--- a/backend/models/test.model.ts
+++ b/backend/models/test.model.ts
@@ -98,10 +98,6 @@ export interface Test extends Document {
   id: string;
   /** The name of the test */
   name: string;
-  /** The administrator to which the test belongs to - this is a reference to
-   * an ID in the User collection
-   */
-  admin: string;
   /** An ordered list of questions to be asked when students take the test */
   questions: QuestionComponent[][];
   /** The intended grade the test was made for */
@@ -120,11 +116,6 @@ const TestSchema: Schema = new Schema(
   {
     name: {
       type: String,
-      required: true,
-    },
-    admin: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "User",
       required: true,
     },
     questions: {

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -12,17 +12,13 @@ import {
   mockTestArray,
   questions,
 } from "../../../testUtils/tests";
-
-import UserService from "../userService";
 import {
   TestResponseDTO,
   CreateTestRequestDTO,
 } from "../../interfaces/testService";
-import { mockAdmin } from "../../../testUtils/users";
 
 describe("mongo testService", (): void => {
   let testService: TestService;
-  let userService: UserService;
 
   beforeAll(async () => {
     await db.connect();
@@ -33,8 +29,7 @@ describe("mongo testService", (): void => {
   });
 
   beforeEach(async () => {
-    userService = new UserService();
-    testService = new TestService(userService);
+    testService = new TestService();
   });
 
   afterEach(async () => {
@@ -42,16 +37,9 @@ describe("mongo testService", (): void => {
   });
 
   it("createTest", async () => {
-    userService.getUserById = jest.fn().mockReturnValue(mockAdmin);
     const res = await testService.createTest(mockTest);
 
     assertResponseMatchesExpected(mockTest, res);
-  });
-
-  it("createTest invalid admin userId", async () => {
-    await expect(async () => {
-      await testService.createTest(mockTest);
-    }).rejects.toThrowError(`userId ${mockTest.admin} not found`);
   });
 
   it("deleteTest", async () => {
@@ -71,13 +59,9 @@ describe("mongo testService", (): void => {
     // insert test into database
     const createdTest = await MgTest.create(mockTest);
 
-    // mock response of user service
-    userService.getUserById = jest.fn().mockReturnValue(mockAdmin);
-
     // create DTO object to update to
     const testUpdate: CreateTestRequestDTO = {
       name: "newTest",
-      admin: "62c248c0f79d6c3c9ebbea94",
       questions,
       grade: 10,
       assessmentType: AssessmentType.END,
@@ -95,13 +79,9 @@ describe("mongo testService", (): void => {
     // insert test into database
     await MgTest.create(mockTest);
 
-    // mock response of user service
-    userService.getUserById = jest.fn().mockReturnValue(mockAdmin);
-
     // create DTO object to update to
     const testUpdate: CreateTestRequestDTO = {
       name: "newTest",
-      admin: "62c248c0f79d6c3c9ebbea94",
       questions,
       grade: 10,
       assessmentType: AssessmentType.END,
@@ -119,7 +99,6 @@ describe("mongo testService", (): void => {
   });
 
   it("getTestById", async () => {
-    userService.getUserById = jest.fn().mockReturnValue(mockAdmin);
     const test = await MgTest.create(mockTest);
     const res = await testService.getTestById(test.id);
 
@@ -135,7 +114,6 @@ describe("mongo testService", (): void => {
   });
 
   it("getAllTests", async () => {
-    userService.getUserById = jest.fn().mockReturnValue(mockAdmin);
     await MgTest.insertMany(mockTestArray);
     const res = await testService.getAllTests();
 

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -38,7 +38,7 @@ describe("mongo testSessionService", (): void => {
   beforeEach(async () => {
     userService = new UserService();
     schoolService = new SchoolService(userService);
-    testService = new TestService(userService);
+    testService = new TestService();
     testSessionService = new TestSessionService(
       testService,
       userService,

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -6,25 +6,15 @@ import {
 } from "../interfaces/testService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
-import { UserDTO } from "../../types";
-import IUserService from "../interfaces/userService";
 
 const Logger = logger(__filename);
 
 class TestService implements ITestService {
-  userService: IUserService;
-
-  constructor(userService: IUserService) {
-    this.userService = userService;
-  }
-
   /* eslint-disable class-methods-use-this */
   async createTest(test: CreateTestRequestDTO): Promise<TestResponseDTO> {
     let newTest: Test | null;
-    let adminDto: UserDTO | null;
 
     try {
-      adminDto = await this.userService.getUserById(test.admin);
       newTest = await MgTest.create(test);
     } catch (error) {
       Logger.error(`Failed to create test. Reason = ${getErrorMessage(error)}`);
@@ -34,7 +24,6 @@ class TestService implements ITestService {
     return {
       id: newTest.id,
       name: newTest.name,
-      admin: adminDto,
       questions: newTest.questions,
       grade: newTest.grade,
       curriculumCountry: newTest.curriculumCountry,
@@ -62,7 +51,6 @@ class TestService implements ITestService {
     test: CreateTestRequestDTO,
   ): Promise<TestResponseDTO> {
     let updatedTest: Test | null;
-    let adminDto: UserDTO | null;
 
     try {
       updatedTest = await MgTest.findByIdAndUpdate(id, test, {
@@ -72,8 +60,6 @@ class TestService implements ITestService {
       if (!updatedTest) {
         throw new Error(`Test with id ${id} not found`);
       }
-
-      adminDto = await this.userService.getUserById(test.admin);
     } catch (error: unknown) {
       Logger.error(`Failed to update test. Reason = ${getErrorMessage(error)}`);
       throw error;
@@ -82,7 +68,6 @@ class TestService implements ITestService {
     return {
       id: updatedTest.id,
       name: updatedTest.name,
-      admin: adminDto,
       questions: updatedTest.questions,
       grade: updatedTest.grade,
       curriculumCountry: updatedTest.curriculumCountry,
@@ -94,14 +79,12 @@ class TestService implements ITestService {
 
   async getTestById(id: string): Promise<TestResponseDTO> {
     let test: Test | null;
-    let adminDto: UserDTO | null;
 
     try {
       test = await MgTest.findById(id);
       if (!test) {
         throw new Error(`Test ID ${id} not found`);
       }
-      adminDto = await this.userService.getUserById(test.admin);
     } catch (error: unknown) {
       Logger.error(
         `Failed to get test with ID ${id}. Reason = ${getErrorMessage(error)}`,
@@ -111,7 +94,6 @@ class TestService implements ITestService {
     return {
       id: test.id,
       name: test.name,
-      admin: adminDto,
       questions: test.questions,
       grade: test.grade,
       curriculumCountry: test.curriculumCountry,
@@ -136,11 +118,9 @@ class TestService implements ITestService {
   ): Promise<TestResponseDTO[]> {
     return Promise.all(
       tests.map(async (test) => {
-        const adminDTO = await this.userService.getUserById(test.admin);
         return {
           id: test.id,
           name: test.name,
-          admin: adminDTO,
           questions: test.questions,
           grade: test.grade,
           curriculumCountry: test.curriculumCountry,

--- a/backend/services/interfaces/testService.ts
+++ b/backend/services/interfaces/testService.ts
@@ -9,15 +9,12 @@ import {
   AssessmentType,
   AssessmentStatus,
 } from "../../models/test.model";
-import { UserDTO } from "../../types";
 
 export type TestResponseDTO = {
   /** the unique identifier of the response */
   id: string;
   /** the name of the test */
   name: string;
-  /** the UserDTO for the admin */
-  admin: UserDTO;
   /** an array of questions on the test */
   questions: QuestionComponent[][];
   /** the grade of the student */
@@ -32,10 +29,7 @@ export type TestResponseDTO = {
   curriculumRegion: string;
 };
 
-/** the request input expects an admin userId string rather than a UserDTO */
-export type CreateTestRequestDTO = Omit<TestResponseDTO, "id" | "admin"> & {
-  admin: string;
-};
+export type CreateTestRequestDTO = Omit<TestResponseDTO, "id">;
 
 export interface QuestionComponentMetadataRequest {
   questionTextMetadata: QuestionTextMetadata;
@@ -52,8 +46,6 @@ export type QuestionComponentRequest = Omit<QuestionComponent, "metadata"> &
 export type TestRequestDTO = {
   /** the name of the test */
   name: string;
-  /** the UserDTO for the admin */
-  admin: string;
   /** an ordered array of questions on the test */
   questions: QuestionComponentRequest[][];
   /** the grade of the student */

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -8,7 +8,6 @@ import {
   CreateTestRequestDTO,
   TestResponseDTO,
 } from "../services/interfaces/testService";
-import { mockAdmin } from "./users";
 
 export const questions: Array<Array<QuestionComponent>> = [
   [
@@ -83,7 +82,6 @@ export const questions: Array<Array<QuestionComponent>> = [
 
 export const mockTest: CreateTestRequestDTO = {
   name: "test",
-  admin: "62c248c0f79d6c3c9ebbea94",
   questions,
   grade: 11,
   assessmentType: AssessmentType.BEGINNING,
@@ -95,7 +93,6 @@ export const mockTest: CreateTestRequestDTO = {
 export const mockTestArray: Array<CreateTestRequestDTO> = [
   {
     name: "test1",
-    admin: "62c248c0f79d6c3c9ebbea94",
     questions,
     grade: 11,
     assessmentType: AssessmentType.END,
@@ -105,7 +102,6 @@ export const mockTestArray: Array<CreateTestRequestDTO> = [
   },
   {
     name: "test2",
-    admin: "62c248c0f79d6c3c9ebbea94",
     questions,
     grade: 11,
     assessmentType: AssessmentType.END,
@@ -115,7 +111,6 @@ export const mockTestArray: Array<CreateTestRequestDTO> = [
   },
   {
     name: "test3",
-    admin: "62c248c0f79d6c3c9ebbea94",
     questions,
     grade: 11,
     assessmentType: AssessmentType.END,
@@ -128,13 +123,11 @@ export const mockTestArray: Array<CreateTestRequestDTO> = [
 export const mockTestWithId: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea95",
   ...mockTest,
-  admin: mockAdmin,
 };
 
 export const mockTestWithId2: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea90",
   ...mockTest,
-  admin: mockAdmin,
 };
 
 export const assertResponseMatchesExpected = (
@@ -143,7 +136,6 @@ export const assertResponseMatchesExpected = (
 ): void => {
   expect(result.id).not.toBeNull();
   expect(result.name).toEqual(expected.name);
-  expect(result.admin).toEqual(mockAdmin);
   expect(result.assessmentType).toEqual(expected.assessmentType.toString());
   expect(result.curriculumCountry).toEqual(expected.curriculumCountry);
   expect(result.curriculumRegion).toEqual(expected.curriculumRegion);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Remove Admin Field from Test Service](https://www.notion.so/uwblueprintexecs/Remove-Admin-Field-from-Test-Service-f0a156fdce9c4e87aeb78f56dde84a82?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove `admin` from Test Service since it is no longer needed


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. `yarn test`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Changes should only apply to `/backend` since it has yet to be used in `/frontend`


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
