### PR TITLE
fix: Delete teacherId from associated School Object on deleteTeacher

### DIFF
--- a/backend/services/implementations/__tests__/userService.test.ts
+++ b/backend/services/implementations/__tests__/userService.test.ts
@@ -130,6 +130,7 @@ describe("mongo userService", (): void => {
 
     await userService.deleteUserById(teacher.id);
     const associatedSchool = await SchoolModel.findById(schools[1].id);
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     expect(associatedSchool!.teachers.map(String)).toEqual(
       testSchools[1].teachers,
     );

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -2,7 +2,7 @@ import * as firebaseAdmin from "firebase-admin";
 
 import IUserService from "../interfaces/userService";
 import MgUser, { User } from "../../models/user.model";
-import MgSchool from "../../models/school.model";
+import MgSchool, { School } from "../../models/school.model";
 import {
   CreateUserDTO,
   Role,
@@ -320,6 +320,10 @@ class UserService implements IUserService {
         throw new Error(`userId ${userId} not found.`);
       }
 
+      if (deletedUser.role === "Teacher") {
+        await this.deleteTeacherFromSchool(userId);
+      }
+
       try {
         await firebaseAdmin.auth().deleteUser(deletedUser.authId);
       } catch (error) {
@@ -362,6 +366,10 @@ class UserService implements IUserService {
 
       if (!deletedUser) {
         throw new Error(`authId (Firebase uid) ${firebaseUser.uid} not found.`);
+      }
+
+      if (deletedUser.role === "Teacher") {
+        await this.deleteTeacherFromSchool(deletedUser.id);
       }
 
       try {
@@ -526,6 +534,28 @@ class UserService implements IUserService {
     ];
 
     return MgSchool.aggregate(pipeline);
+  }
+
+  private async deleteTeacherFromSchool(teacherId: string): Promise<string> {
+    try {
+      const updatedSchool: School | null = await MgSchool.findOneAndUpdate(
+        { teachers: teacherId },
+        { $pull: { teachers: teacherId } },
+        { new: true },
+      );
+      if (!updatedSchool) {
+        throw new Error(`School with teacher id ${teacherId} not found`);
+      }
+
+      return teacherId;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete teacher from school. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete teacher id from associated School Object on deleteTeacher](https://www.notion.so/uwblueprintexecs/Delete-teacher-id-from-associated-School-Object-on-deleteTeacher-f6595a11dd6f46fcba0c250da9f203ab?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated `deleteUserById` and `deleteUserByEmail` to call `deleteTeacherFromSchool` if user being deleted is a teacher
* `deleteTeacherFromSchool` finds the school associated with a given teacher id, and removes the id from its teacher array field
* Wrote unit test to test `deleteTeacherFromSchool`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. yarn test


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I wrote the function `deleteTeacherFromSchool` in the UserService instead of SchoolService because otherwise there is a cyclic dependency between the two services. I felt like this was the cleanest solution (though `MgSchool` is directly used in userService -> highly coupled). LMK if there's a better way!


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
