### PR TITLE
fix: Delete dependent documents on deleteTeacher

### DIFF
--- a/backend/models/user.model.ts
+++ b/backend/models/user.model.ts
@@ -64,16 +64,19 @@ const UserSchema: Schema = new Schema({
   },
 });
 
-UserSchema.post("findOneAndDelete", async (doc) => {
+UserSchema.pre("findOneAndDelete", async function (next) {
+  const doc = await this.findOne(this.getQuery());
   if (doc.role !== "Teacher") return;
 
   /* eslint-disable no-underscore-dangle */
-  await MgTestSession.deleteMany({ teacher: doc._id });
   await MgSchool.findOneAndUpdate(
     { teachers: doc._id },
     { $pull: { teachers: doc._id } },
     { new: true },
   );
+  await MgTestSession.deleteMany({ teacher: doc._id });
+
+  next();
 });
 
 export default mongoose.model<User>("User", UserSchema);

--- a/backend/models/user.model.ts
+++ b/backend/models/user.model.ts
@@ -1,4 +1,6 @@
 import mongoose, { Schema, Document } from "mongoose";
+import MgTestSession from "./testSession.model";
+import MgSchool from "./school.model";
 
 import { Grade, Role } from "../types";
 
@@ -60,6 +62,18 @@ const UserSchema: Schema = new Schema({
     type: Boolean,
     required: false,
   },
+});
+
+UserSchema.post("findOneAndDelete", async (doc) => {
+  if (doc.role !== "Teacher") return;
+
+  /* eslint-disable no-underscore-dangle */
+  await MgTestSession.deleteMany({ teacher: doc._id });
+  await MgSchool.findOneAndUpdate(
+    { teachers: doc._id },
+    { $pull: { teachers: doc._id } },
+    { new: true },
+  );
 });
 
 export default mongoose.model<User>("User", UserSchema);

--- a/backend/services/implementations/__tests__/userService.test.ts
+++ b/backend/services/implementations/__tests__/userService.test.ts
@@ -1,10 +1,12 @@
 import UserModel from "../../../models/user.model";
 import UserService from "../userService";
 import SchoolModel from "../../../models/school.model";
+import TestSessionModel from "../../../models/testSession.model";
 import { UserDTO, TeacherDTO } from "../../../types";
 
 import db from "../../../testUtils/testDb";
 import { testSchools } from "../../../testUtils/school";
+import { mockTestSessions } from "../../../testUtils/testSession";
 
 const testUsers = [
   {
@@ -128,11 +130,27 @@ describe("mongo userService", (): void => {
     ];
     const schools = await SchoolModel.insertMany(updatedTestSchools);
 
+    const updatedTestSessions = [
+      {
+        ...mockTestSessions[0],
+        teacher: teacher.id,
+      },
+      {
+        ...mockTestSessions[1],
+        teacher: teacher.id,
+      },
+    ];
+    await TestSessionModel.insertMany(updatedTestSessions);
+
     await userService.deleteUserById(teacher.id);
     const associatedSchool = await SchoolModel.findById(schools[1].id);
+    const associatedTestSession = await TestSessionModel.find({
+      teacher: teacher.id,
+    });
     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     expect(associatedSchool!.teachers.map(String)).toEqual(
       testSchools[1].teachers,
     );
+    expect(associatedTestSession).toEqual([]);
   });
 });

--- a/backend/services/implementations/__tests__/userService.test.ts
+++ b/backend/services/implementations/__tests__/userService.test.ts
@@ -130,6 +130,7 @@ describe("mongo userService", (): void => {
 
     await userService.deleteUserById(teacher.id);
     const associatedSchool = await SchoolModel.findById(schools[1].id);
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     expect(associatedSchool!.teachers.map(String)).toEqual(
       testSchools[1].teachers,
     );

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -170,6 +170,7 @@ class AuthService implements IAuthService {
         .auth()
         .generatePasswordResetLink(email);
       const regex = /(?<=&oobCode=)(.*)(?=&apiKey=)/gm;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       [oobCode] = resetLink.match(regex)!;
     } catch (error) {
       Logger.error(

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -2,7 +2,7 @@ import * as firebaseAdmin from "firebase-admin";
 
 import IUserService from "../interfaces/userService";
 import MgUser, { User } from "../../models/user.model";
-import MgSchool, { School } from "../../models/school.model";
+import MgSchool from "../../models/school.model";
 import {
   CreateUserDTO,
   Role,
@@ -320,10 +320,6 @@ class UserService implements IUserService {
         throw new Error(`userId ${userId} not found.`);
       }
 
-      if (deletedUser.role === "Teacher") {
-        await this.deleteTeacherFromSchool(userId);
-      }
-
       try {
         await firebaseAdmin.auth().deleteUser(deletedUser.authId);
       } catch (error) {
@@ -366,10 +362,6 @@ class UserService implements IUserService {
 
       if (!deletedUser) {
         throw new Error(`authId (Firebase uid) ${firebaseUser.uid} not found.`);
-      }
-
-      if (deletedUser.role === "Teacher") {
-        await this.deleteTeacherFromSchool(deletedUser.id);
       }
 
       try {
@@ -534,28 +526,6 @@ class UserService implements IUserService {
     ];
 
     return MgSchool.aggregate(pipeline);
-  }
-
-  private async deleteTeacherFromSchool(teacherId: string): Promise<string> {
-    try {
-      const updatedSchool: School | null = await MgSchool.findOneAndUpdate(
-        { teachers: teacherId },
-        { $pull: { teachers: teacherId } },
-        { new: true },
-      );
-      if (!updatedSchool) {
-        throw new Error(`School with teacher id ${teacherId} not found`);
-      }
-
-      return teacherId;
-    } catch (error: unknown) {
-      Logger.error(
-        `Failed to delete teacher from school. Reason = ${getErrorMessage(
-          error,
-        )}`,
-      );
-      throw error;
-    }
   }
 }
 

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -2,7 +2,7 @@ import * as firebaseAdmin from "firebase-admin";
 
 import IUserService from "../interfaces/userService";
 import MgUser, { User } from "../../models/user.model";
-import MgSchool from "../../models/school.model";
+import MgSchool, { School } from "../../models/school.model";
 import {
   CreateUserDTO,
   Role,
@@ -320,6 +320,10 @@ class UserService implements IUserService {
         throw new Error(`userId ${userId} not found.`);
       }
 
+      if (deletedUser.role === "Teacher") {
+        await this.deleteTeacherFromSchool(userId);
+      }
+
       try {
         await firebaseAdmin.auth().deleteUser(deletedUser.authId);
       } catch (error) {
@@ -362,6 +366,10 @@ class UserService implements IUserService {
 
       if (!deletedUser) {
         throw new Error(`authId (Firebase uid) ${firebaseUser.uid} not found.`);
+      }
+
+      if (deletedUser.role === "Teacher") {
+        await this.deleteTeacherFromSchool(deletedUser.id);
       }
 
       try {
@@ -526,6 +534,28 @@ class UserService implements IUserService {
     ];
 
     return MgSchool.aggregate(pipeline);
+  }
+
+  private async deleteTeacherFromSchool(teacherId: string): Promise<string> {
+    try {
+      const updatedSchool: School | null = await MgSchool.findOneAndUpdate(
+        { teachers: teacherId },
+        { $pull: { teachers: teacherId } },
+        { new: true },
+      );
+      if (!updatedSchool) {
+        throw new Error(`School with teacher id ${teacherId} not found`);
+      }
+
+      return teacherId;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete teacher from school. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete Test Sessions associated with teacher on deleteTeacher](https://www.notion.so/uwblueprintexecs/Delete-Test-Sessions-associated-with-teacher-on-deleteTeacher-38743ea27b1648cd9ea36e7df5d6bf31?pvs=4)
[Delete teacher id from associated School Object on deleteTeacher](https://www.notion.so/uwblueprintexecs/Delete-teacher-id-from-associated-School-Object-on-deleteTeacher-f6595a11dd6f46fcba0c250da9f203ab?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated `UserModel` middleware to do the following after `findOneAndDelete` is executed
   * Delete all test sessions containing the deleted teacher's id
   * Delete the teacher id from the School document which contains it
* Wrote unit tests for success and failure

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. yarn test


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Info on middleware: https://mongoosejs.com/docs/middleware.html#use-cases


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
