### PR TITLE
backend: Create resolver to Publish Assessment

### DIFF
--- a/backend/graphql/resolvers/testResolvers.ts
+++ b/backend/graphql/resolvers/testResolvers.ts
@@ -1,4 +1,9 @@
 import TestService from "../../services/implementations/testService";
+import {
+  AssessmentStatus,
+  QuestionComponentMetadata,
+  QuestionComponent,
+} from "../../models/test.model";
 import UserService from "../../services/implementations/userService";
 import {
   ITestService,
@@ -8,11 +13,6 @@ import {
   QuestionComponentMetadataRequest,
 } from "../../services/interfaces/testService";
 import IUserService from "../../services/interfaces/userService";
-
-import {
-  QuestionComponentMetadata,
-  QuestionComponent,
-} from "../../models/test.model";
 
 const userService: IUserService = new UserService();
 const testService: ITestService = new TestService(userService);
@@ -130,6 +130,25 @@ const testResolvers = {
       { id }: { id: string },
     ): Promise<string> => {
       return testService.deleteTest(id);
+    },
+
+    publishTest: async (
+      _req: undefined,
+      { test_id }: { test_id: string },
+    ): Promise<TestResponseDTO | null> => {
+      const testToUpdate = await testService.getTestById(test_id);
+      if (!testToUpdate) {
+        throw new Error(`Test with id ${test_id} does not exist.`);
+      }
+      if (testToUpdate.status !== AssessmentStatus.DRAFT) {
+        throw new Error(`Test with id ${test_id} cannot be published.`);
+      }
+      const updatedTest = await testService.updateTest(test_id, {
+        ...testToUpdate,
+        status: AssessmentStatus.PUBLISHED,
+        admin: testToUpdate.admin.id,
+      });
+      return updatedTest;
     },
   },
 };

--- a/backend/graphql/resolvers/testResolvers.ts
+++ b/backend/graphql/resolvers/testResolvers.ts
@@ -131,19 +131,15 @@ const testResolvers = {
     ): Promise<string> => {
       return testService.deleteTest(id);
     },
-
     publishTest: async (
       _req: undefined,
-      { test_id }: { test_id: string },
+      { testId }: { testId: string },
     ): Promise<TestResponseDTO | null> => {
-      const testToUpdate = await testService.getTestById(test_id);
-      if (!testToUpdate) {
-        throw new Error(`Test with id ${test_id} does not exist.`);
-      }
+      const testToUpdate = await testService.getTestById(testId);
       if (testToUpdate.status !== AssessmentStatus.DRAFT) {
-        throw new Error(`Test with id ${test_id} cannot be published.`);
+        throw new Error(`Test with id ${testId} cannot be published.`);
       }
-      const updatedTest = await testService.updateTest(test_id, {
+      const updatedTest = await testService.updateTest(testId, {
         ...testToUpdate,
         status: AssessmentStatus.PUBLISHED,
         admin: testToUpdate.admin.id,


### PR DESCRIPTION
[Create resolver to Publish Assessment](https://www.notion.so/uwblueprintexecs/Create-resolver-to-Publish-Assessment-f6ab6361dffa4932b7151f42e3b2af26)


The scope of this ticket is to add backend functionality to allow admins to publish existing assessments.



- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
