### PR TITLE
feat: Duplicate Assessment in Display Page

### DIFF
--- a/frontend/src/components/assessments/EditStatusButtons/DuplicateButton.tsx
+++ b/frontend/src/components/assessments/EditStatusButtons/DuplicateButton.tsx
@@ -12,7 +12,7 @@ const DuplicateButton = ({
   assessmentId,
   closePopover,
 }: DuplicateButtonProps): React.ReactElement => {
-  const [showDuplicateModal, setshowDuplicateModal] = React.useState(false);
+  const [showDuplicateModal, setShowDuplicateModal] = React.useState(false);
 
   return (
     <>
@@ -20,13 +20,13 @@ const DuplicateButton = ({
         name="Duplicate"
         onClick={() => {
           closePopover();
-          setshowDuplicateModal(true);
+          setShowDuplicateModal(true);
         }}
       />
       <DuplicateModal
         assessmentId={assessmentId}
         isOpen={showDuplicateModal}
-        onClose={() => setshowDuplicateModal(false)}
+        onClose={() => setShowDuplicateModal(false)}
       />
     </>
   );

--- a/frontend/src/components/assessments/EditStatusButtons/DuplicateButton.tsx
+++ b/frontend/src/components/assessments/EditStatusButtons/DuplicateButton.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import EditStatusButton from "../EditStatusButton";
+import DuplicateModal from "../EditStatusModals/DuplicateModal";
+
+interface DuplicateButtonProps {
+  assessmentId: string;
+  closePopover: () => void;
+}
+
+const DuplicateButton = ({
+  assessmentId,
+  closePopover,
+}: DuplicateButtonProps): React.ReactElement => {
+  const [showDuplicateModal, setshowDuplicateModal] = React.useState(false);
+
+  return (
+    <>
+      <EditStatusButton
+        name="Duplicate"
+        onClick={() => {
+          closePopover();
+          setshowDuplicateModal(true);
+        }}
+      />
+      <DuplicateModal
+        assessmentId={assessmentId}
+        isOpen={showDuplicateModal}
+        onClose={() => setshowDuplicateModal(false)}
+      />
+    </>
+  );
+};
+
+export default DuplicateButton;

--- a/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
+++ b/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
@@ -43,7 +43,7 @@ const DuplicateModal = ({
 
   return (
     <Modal
-      body="Create a copy of this existing assessment, and view it under draft assessments."
+      body="Create a copy of this existing assessment. This new assessment can be viewed under draft assessments."
       header="Duplicate Assessment"
       isOpen={isOpen}
       onCancel={onClose}

--- a/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
+++ b/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
@@ -43,7 +43,7 @@ const DuplicateModal = ({
 
   return (
     <Modal
-      body="Once this is duplicated, teachers will be able to make a copy of this assessment for their students."
+      body="Create a copy of this existing assessment, and view it under draft assessments."
       header="Duplicate Assessment"
       isOpen={isOpen}
       onCancel={onClose}

--- a/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
+++ b/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
@@ -6,7 +6,7 @@ import GET_ALL_TESTS from "../../../APIClients/queries/TestQueries";
 import Modal from "../../common/Modal";
 import Toast from "../../common/Toast";
 
-interface PublishModalProps {
+interface DuplicateModalProps {
   isOpen: boolean;
   onClose: () => void;
   assessmentId: string;
@@ -16,7 +16,7 @@ const DuplicateModal = ({
   isOpen,
   onClose,
   assessmentId,
-}: PublishModalProps): React.ReactElement => {
+}: DuplicateModalProps): React.ReactElement => {
   const [duplicateAssessment, { error }] = useMutation<{
     duplicateAssessment: string;
   }>(DUPLICATE_TEST, {

--- a/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
+++ b/frontend/src/components/assessments/EditStatusModals/DuplicateModal.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { useMutation } from "@apollo/client";
+
+import { DUPLICATE_TEST } from "../../../APIClients/mutations/TestMutations";
+import GET_ALL_TESTS from "../../../APIClients/queries/TestQueries";
+import Modal from "../../common/Modal";
+import Toast from "../../common/Toast";
+
+interface PublishModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  assessmentId: string;
+}
+
+const DuplicateModal = ({
+  isOpen,
+  onClose,
+  assessmentId,
+}: PublishModalProps): React.ReactElement => {
+  const [duplicateAssessment, { error }] = useMutation<{
+    duplicateAssessment: string;
+  }>(DUPLICATE_TEST, {
+    refetchQueries: [{ query: GET_ALL_TESTS }],
+  });
+
+  const { showToast } = Toast();
+
+  const onDuplicateAssessment = async () => {
+    await duplicateAssessment({ variables: { id: assessmentId } });
+    if (error) {
+      showToast({
+        message: "Assessment failed to duplicate. Please try again.",
+        status: "error",
+      });
+    } else {
+      showToast({
+        message: "Assessment duplicated.",
+        status: "success",
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      body="Once this is duplicated, teachers will be able to make a copy of this assessment for their students."
+      header="Duplicate Assessment"
+      isOpen={isOpen}
+      onCancel={onClose}
+      onClose={onClose}
+      onSubmit={onDuplicateAssessment}
+      submitButtonText="Duplicate"
+    />
+  );
+};
+
+export default DuplicateModal;

--- a/frontend/src/components/assessments/EditStatusPopover.tsx
+++ b/frontend/src/components/assessments/EditStatusPopover.tsx
@@ -59,10 +59,13 @@ const EditStatusPopover = ({
                 closePopover={onClose}
               />
             )}
-            <DuplicateButton
-              assessmentId={assessmentId}
-              closePopover={onClose}
-            />
+            {(assessmentStatus === Status.DRAFT ||
+              assessmentStatus === Status.PUBLISHED) && (
+              <DuplicateButton
+                assessmentId={assessmentId}
+                closePopover={onClose}
+              />
+            )}
             <DeleteButton assessmentId={assessmentId} closePopover={onClose} />
           </VStack>
         </PopoverBody>

--- a/frontend/src/components/assessments/EditStatusPopover.tsx
+++ b/frontend/src/components/assessments/EditStatusPopover.tsx
@@ -14,6 +14,7 @@ import { MoreVerticalOutlineIcon } from "../../assets/icons";
 import { Status } from "../../types/AssessmentTypes";
 
 import DeleteButton from "./EditStatusButtons/DeleteButton";
+import DuplicateButton from "./EditStatusButtons/DuplicateButton";
 import PublishButton from "./EditStatusButtons/PublishButton";
 
 interface EditStatusPopoverProps {
@@ -58,6 +59,10 @@ const EditStatusPopover = ({
                 closePopover={onClose}
               />
             )}
+            <DuplicateButton
+              assessmentId={assessmentId}
+              closePopover={onClose}
+            />
             <DeleteButton assessmentId={assessmentId} closePopover={onClose} />
           </VStack>
         </PopoverBody>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Duplicate Assessment in Display Page](https://www.notion.so/uwblueprintexecs/Duplicate-Assessment-in-Display-Page-37725d5d1e2d408ca6b94f38515e6e89)

SIDE NOTE: I have asked design what the appropriate confirmation modal should be. Once they let me know, I will change the message.
<img width="698" alt="Screenshot 2023-03-29 at 3 44 23 PM" src="https://user-images.githubusercontent.com/60047036/228650953-653c6d46-2eb6-4e47-a25c-7e55c2046d97.png">
<img width="296" alt="Screenshot 2023-03-29 at 3 46 46 PM" src="https://user-images.githubusercontent.com/60047036/228650956-ccbc0af0-184a-4763-9440-44ef0c1dc783.png">



The scope of this ticket is to implement the frontend feature to duplicate an assessment
Make sure the following tasks are completed:

- Show the `Duplicate` button on the display page for `DRAFT` assessments
- Show the `Duplicate` button on the display page for `PUBLISHED` assessments
- When the `Duplicate` button is clicked, show the appropriate confirmation modal. You may need to ask design for this.

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
