### PR TITLE
feat: reorder & delete & edit functionality for question cards

### DIFF
--- a/frontend/src/components/assessments/assessment-creation/AddQuestionButton.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AddQuestionButton.tsx
@@ -1,15 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Button, Text } from "@chakra-ui/react";
 
 import { PlusOutlineIcon } from "../../../assets/icons";
+import AssessmentContext from "../../../contexts/AssessmentContext";
 
-interface AddQuestionButtonProps {
-  setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const AddQuestionButton = ({
-  setShowQuestionEditor,
-}: AddQuestionButtonProps): React.ReactElement => {
+const AddQuestionButton = (): React.ReactElement => {
+  const { setShowQuestionEditor } = useContext(AssessmentContext);
   return (
     <Button
       border="1px dashed #636363"

--- a/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
@@ -47,6 +47,7 @@ const AssessmentQuestions = ({
             <QuestionCard
               key={question.id}
               id={question.id}
+              index={i}
               questionNumber={i + 1}
               questions={getQuestionTexts(question.elements)}
               setQuestions={setQuestions}

--- a/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Box, Button, HStack, Spacer, Text, VStack } from "@chakra-ui/react";
 
 import { PlusOutlineIcon } from "../../../assets/icons";
+import AssessmentContext from "../../../contexts/AssessmentContext";
 import { Question } from "../../../types/QuestionTypes";
 import {
   generateQuestionCardTags,
@@ -15,14 +16,13 @@ import QuestionSummary from "./QuestionSummary";
 interface AssessmentQuestionsProps {
   questions: Question[];
   setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
-  setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const AssessmentQuestions = ({
   questions,
   setQuestions,
-  setShowQuestionEditor,
 }: AssessmentQuestionsProps): React.ReactElement => {
+  const { setShowQuestionEditor } = useContext(AssessmentContext);
   const pointCount: number = questions.reduce(
     (a, b) => a + getQuestionTexts(b.elements).length,
     0,
@@ -48,13 +48,14 @@ const AssessmentQuestions = ({
               key={question.id}
               id={question.id}
               index={i}
+              questionInfo={question}
               questionNumber={i + 1}
               questions={getQuestionTexts(question.elements)}
               setQuestions={setQuestions}
               tags={generateQuestionCardTags(question.elements)}
             />
           ))}
-          <AddQuestionButton setShowQuestionEditor={setShowQuestionEditor} />
+          <AddQuestionButton />
         </VStack>
         <Spacer />
         <Box width="33%">

--- a/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Button, HStack, Spacer, Text, VStack } from "@chakra-ui/react";
 
 import { PlusOutlineIcon } from "../../../assets/icons";
-import { QuestionElement } from "../../../types/QuestionTypes";
+import { Question } from "../../../types/QuestionTypes";
 import {
   generateQuestionCardTags,
   getQuestionTexts,
@@ -13,16 +13,18 @@ import QuestionCard from "./QuestionCard";
 import QuestionSummary from "./QuestionSummary";
 
 interface AssessmentQuestionsProps {
-  questions: QuestionElement[][];
+  questions: Question[];
+  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
   setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const AssessmentQuestions = ({
   questions,
+  setQuestions,
   setShowQuestionEditor,
 }: AssessmentQuestionsProps): React.ReactElement => {
   const pointCount: number = questions.reduce(
-    (a, b) => a + getQuestionTexts(b).length,
+    (a, b) => a + getQuestionTexts(b.elements).length,
     0,
   );
 
@@ -43,10 +45,12 @@ const AssessmentQuestions = ({
         <VStack alignItems="left" spacing="6" width="64%">
           {questions.map((question, i) => (
             <QuestionCard
-              key={i}
+              key={question.id}
+              id={question.id}
               questionNumber={i + 1}
-              questions={getQuestionTexts(question)}
-              tags={generateQuestionCardTags(question)}
+              questions={getQuestionTexts(question.elements)}
+              setQuestions={setQuestions}
+              tags={generateQuestionCardTags(question.elements)}
             />
           ))}
           <AddQuestionButton setShowQuestionEditor={setShowQuestionEditor} />

--- a/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
@@ -32,12 +32,7 @@ const AssessmentQuestions = (): React.ReactElement => {
       <HStack alignItems="flex-start" display="flex" minWidth="940px">
         <VStack alignItems="left" spacing="6" width="64%">
           {questions.map((question, i) => (
-            <QuestionCard
-              key={question.id}
-              index={i}
-              question={question}
-              questionNumber={i + 1}
-            />
+            <QuestionCard key={question.id} index={i} question={question} />
           ))}
           <AddQuestionButton />
         </VStack>

--- a/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentQuestions.tsx
@@ -3,26 +3,14 @@ import { Box, Button, HStack, Spacer, Text, VStack } from "@chakra-ui/react";
 
 import { PlusOutlineIcon } from "../../../assets/icons";
 import AssessmentContext from "../../../contexts/AssessmentContext";
-import { Question } from "../../../types/QuestionTypes";
-import {
-  generateQuestionCardTags,
-  getQuestionTexts,
-} from "../../../utils/QuestionUtils";
+import { getQuestionTexts } from "../../../utils/QuestionUtils";
 
 import AddQuestionButton from "./AddQuestionButton";
 import QuestionCard from "./QuestionCard";
 import QuestionSummary from "./QuestionSummary";
 
-interface AssessmentQuestionsProps {
-  questions: Question[];
-  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
-}
-
-const AssessmentQuestions = ({
-  questions,
-  setQuestions,
-}: AssessmentQuestionsProps): React.ReactElement => {
-  const { setShowQuestionEditor } = useContext(AssessmentContext);
+const AssessmentQuestions = (): React.ReactElement => {
+  const { questions, setShowQuestionEditor } = useContext(AssessmentContext);
   const pointCount: number = questions.reduce(
     (a, b) => a + getQuestionTexts(b.elements).length,
     0,
@@ -46,13 +34,9 @@ const AssessmentQuestions = ({
           {questions.map((question, i) => (
             <QuestionCard
               key={question.id}
-              id={question.id}
               index={i}
-              questionInfo={question}
+              question={question}
               questionNumber={i + 1}
-              questions={getQuestionTexts(question.elements)}
-              setQuestions={setQuestions}
-              tags={generateQuestionCardTags(question.elements)}
             />
           ))}
           <AddQuestionButton />

--- a/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
+++ b/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import {
   Box,
@@ -19,6 +19,7 @@ import {
   EditOutlineIcon,
   HamburgerMenuIcon,
 } from "../../../assets/icons";
+import AssessmentContext from "../../../contexts/AssessmentContext";
 import { DragQuestionItem, DragTypes } from "../../../types/DragTypes";
 import { Question } from "../../../types/QuestionTypes";
 import { shouldReorder } from "../../../utils/QuestionUtils";
@@ -30,6 +31,7 @@ interface QuestionCardProps {
   index: number;
   tags: QuestionTagProps[];
   questionNumber: number;
+  questionInfo: Question;
   questions: string[];
   setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
 }
@@ -38,10 +40,14 @@ const QuestionCard = ({
   id,
   index,
   questionNumber,
+  questionInfo,
   questions,
   setQuestions,
   tags,
 }: QuestionCardProps): React.ReactElement => {
+  const { setShowQuestionEditor, setEditorQuestion } = useContext(
+    AssessmentContext,
+  );
   const removeQuestionCard = () => {
     setQuestions((prevQuestions) =>
       prevQuestions.filter((question) => question.id !== id),
@@ -140,6 +146,10 @@ const QuestionCard = ({
                 color="currentColor"
                 fontSize="24px"
                 icon={<EditOutlineIcon />}
+                onClick={() => {
+                  setShowQuestionEditor(true);
+                  setEditorQuestion(questionInfo);
+                }}
                 size="icon"
               />
             </Box>

--- a/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
+++ b/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
@@ -32,13 +32,11 @@ import QuestionTag from "./QuestionTag";
 
 interface QuestionCardProps {
   index: number;
-  questionNumber: number;
   question: Question;
 }
 
 const QuestionCard = ({
   index,
-  questionNumber,
   question,
 }: QuestionCardProps): React.ReactElement => {
   const { setQuestions, setShowQuestionEditor, setEditorQuestion } = useContext(
@@ -132,7 +130,7 @@ const QuestionCard = ({
         <VStack alignItems="left" paddingRight="4" spacing="6" width="94%">
           <HStack>
             <Text color="grey.400" textStyle="subtitle1">
-              Question {questionNumber}
+              Question {index + 1}
             </Text>
             <Spacer />
             <Box

--- a/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
+++ b/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
@@ -22,35 +22,31 @@ import {
 import AssessmentContext from "../../../contexts/AssessmentContext";
 import { DragQuestionItem, DragTypes } from "../../../types/DragTypes";
 import { Question } from "../../../types/QuestionTypes";
-import { shouldReorder } from "../../../utils/QuestionUtils";
+import {
+  generateQuestionCardTags,
+  getQuestionTexts,
+  shouldReorder,
+} from "../../../utils/QuestionUtils";
 
-import QuestionTag, { QuestionTagProps } from "./QuestionTag";
+import QuestionTag from "./QuestionTag";
 
 interface QuestionCardProps {
-  id: string;
   index: number;
-  tags: QuestionTagProps[];
   questionNumber: number;
-  questionInfo: Question;
-  questions: string[];
-  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
+  question: Question;
 }
 
 const QuestionCard = ({
-  id,
   index,
   questionNumber,
-  questionInfo,
-  questions,
-  setQuestions,
-  tags,
+  question,
 }: QuestionCardProps): React.ReactElement => {
-  const { setShowQuestionEditor, setEditorQuestion } = useContext(
+  const { setQuestions, setShowQuestionEditor, setEditorQuestion } = useContext(
     AssessmentContext,
   );
   const removeQuestionCard = () => {
     setQuestions((prevQuestions) =>
-      prevQuestions.filter((question) => question.id !== id),
+      prevQuestions.filter((prevQuestion) => prevQuestion.id !== question.id),
     );
   };
 
@@ -64,6 +60,9 @@ const QuestionCard = ({
       }),
     );
   };
+
+  const questionTexts = getQuestionTexts(question.elements);
+  const tags = generateQuestionCardTags(question.elements);
 
   const dragRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
@@ -91,6 +90,8 @@ const QuestionCard = ({
       }
     },
   });
+
+  const { id } = question;
 
   const [{ isDragging }, drag, preview] = useDrag({
     type: DragTypes.QUESTION_CARD,
@@ -148,7 +149,7 @@ const QuestionCard = ({
                 icon={<EditOutlineIcon />}
                 onClick={() => {
                   setShowQuestionEditor(true);
-                  setEditorQuestion(questionInfo);
+                  setEditorQuestion(question);
                 }}
                 size="icon"
               />
@@ -168,10 +169,10 @@ const QuestionCard = ({
             fontWeight="700"
             spacing={4}
             stylePosition="inside"
-            styleType={questions.length > 1 ? "lower-alpha" : "none"}
+            styleType={questionTexts.length > 1 ? "lower-alpha" : "none"}
             textStyle="paragraph"
           >
-            {questions.map((question, key) => (
+            {questionTexts.map((questionText, key) => (
               <ListItem
                 key={key}
                 color="grey.400"
@@ -180,13 +181,13 @@ const QuestionCard = ({
                 whiteSpace="nowrap"
               >
                 <Text as="span" textStyle="paragraph">
-                  {question}
+                  {questionText}
                 </Text>
               </ListItem>
             ))}
           </List>
           <Text color="grey.300" textStyle="caption">
-            Total: {questions.length} points
+            Total: {questionTexts.length} points
           </Text>
           <HStack overflow="hidden">
             {tags.map((tag, key) => (

--- a/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
+++ b/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import {
   Box,
+  Button,
   HStack,
+  IconButton,
   List,
   ListItem,
   Spacer,
@@ -14,20 +16,31 @@ import {
   EditOutlineIcon,
   HamburgerMenuIcon,
 } from "../../../assets/icons";
+import { Question } from "../../../types/QuestionTypes";
 
 import QuestionTag, { QuestionTagProps } from "./QuestionTag";
 
 interface QuestionCardProps {
+  id: string;
   tags: QuestionTagProps[];
   questionNumber: number;
   questions: string[];
+  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
 }
 
 const QuestionCard = ({
-  tags,
+  id,
   questionNumber,
   questions,
+  setQuestions,
+  tags,
 }: QuestionCardProps): React.ReactElement => {
+  const removeQuestionCard = () => {
+    setQuestions((prevQuestions) =>
+      prevQuestions.filter((question) => question.id !== id),
+    );
+  };
+
   return (
     <Box
       background="white"
@@ -53,15 +66,29 @@ const QuestionCard = ({
             </Text>
             <Spacer />
             <Box
+              _hover={{ color: "grey.300" }}
               color="blue.300"
               cursor="pointer"
               fontSize="24px"
               paddingRight="1"
             >
-              <EditOutlineIcon />
+              <Button
+                as={IconButton}
+                color="currentColor"
+                fontSize="24px"
+                icon={<EditOutlineIcon />}
+                size="icon"
+              />
             </Box>
-            <Box color="blue.300" cursor="pointer" fontSize="24px">
-              <DeleteOutlineIcon />
+            <Box _hover={{ color: "grey.300" }} color="blue.300">
+              <Button
+                as={IconButton}
+                color="currentColor"
+                fontSize="24px"
+                icon={<DeleteOutlineIcon />}
+                onClick={removeQuestionCard}
+                size="icon"
+              />
             </Box>
           </HStack>
           <List

--- a/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
+++ b/frontend/src/components/assessments/assessment-creation/QuestionCard.tsx
@@ -42,6 +42,11 @@ const QuestionCard = ({
   const { setQuestions, setShowQuestionEditor, setEditorQuestion } = useContext(
     AssessmentContext,
   );
+
+  const { id } = question;
+  const questionTexts = getQuestionTexts(question.elements);
+  const tags = generateQuestionCardTags(question.elements);
+
   const removeQuestionCard = () => {
     setQuestions((prevQuestions) =>
       prevQuestions.filter((prevQuestion) => prevQuestion.id !== question.id),
@@ -58,9 +63,6 @@ const QuestionCard = ({
       }),
     );
   };
-
-  const questionTexts = getQuestionTexts(question.elements);
-  const tags = generateQuestionCardTags(question.elements);
 
   const dragRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
@@ -88,8 +90,6 @@ const QuestionCard = ({
       }
     },
   });
-
-  const { id } = question;
 
   const [{ isDragging }, drag, preview] = useDrag({
     type: DragTypes.QUESTION_CARD,

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -1,25 +1,10 @@
 import React from "react";
 
-import { QuestionElementType } from "../../types/QuestionTypes";
-import QuestionCard from "../assessments/assessment-creation/QuestionCard";
 import ArchiveModal from "../assessments/assessment-status/EditStatusModals/ArchiveModal";
 
 const ComponentLibrary = (): React.ReactElement => {
   return (
     <div>
-      <QuestionCard
-        questionNumber={1}
-        questions={[
-          "Thomas has 3 apples, 4 apples and 7 pears. Thomas also has 3 other friends, Andrian, Mariah, and Carley.",
-          "Thomas has 3 apples, 4 apples and 7 pears. Thomas also has 3 other friends, Andrian, Mariah, and Carley.",
-          "Thomas has 3 apples, 4 apples and 7 pears. Thomas also has 3 other friends, Andrian, Mariah, and Carley, who like to eat apples.",
-        ]}
-        tags={[
-          { type: QuestionElementType.MULTIPLE_CHOICE, count: 2 },
-          { type: QuestionElementType.SHORT_ANSWER, count: 1 },
-          { type: QuestionElementType.MULTI_SELECT, count: 1 },
-        ]}
-      />
       <ArchiveModal isOpen onClose={() => {}} />
     </div>
   );

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -8,7 +8,7 @@ import { CREATE_NEW_ASSESSMENT } from "../../../APIClients/mutations/TestMutatio
 import { TestRequest } from "../../../APIClients/types/TestClientTypes";
 import { ASSESSMENTS_PAGE } from "../../../constants/Routes";
 import { Status } from "../../../types/AssessmentTypes";
-import { QuestionElement } from "../../../types/QuestionTypes";
+import { Question } from "../../../types/QuestionTypes";
 import { formatQuestionsRequest } from "../../../utils/QuestionUtils";
 import AssessmentQuestions from "../../assessments/assessment-creation/AssessmentQuestions";
 import BasicInformation from "../../assessments/assessment-creation/BasicInformation";
@@ -20,12 +20,12 @@ const CreateAssessmentPage = (): React.ReactElement => {
 
   const [showQuestionEditor, setShowQuestionEditor] = useState(false);
   const [name, setName] = useState("");
-  const [questions, setQuestions] = useState<QuestionElement[][]>([]);
   const [errorMessage, setErrorMessage] = useState("");
 
   const [createTest] = useMutation<{
     createTest: { createTest: { id: string } };
   }>(CREATE_NEW_ASSESSMENT);
+  const [questions, setQuestions] = useState<Question[]>([]);
 
   const {
     handleSubmit,
@@ -97,6 +97,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
             <Divider borderColor="grey.200" />
             <AssessmentQuestions
               questions={questions}
+              setQuestions={setQuestions}
               setShowQuestionEditor={setShowQuestionEditor}
             />
           </VStack>

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -21,15 +21,15 @@ import QuestionEditor from "../../question-creation/QuestionEditor";
 const CreateAssessmentPage = (): React.ReactElement => {
   const history = useHistory();
 
-  const [showQuestionEditor, setShowQuestionEditor] = useState(false);
   const [name, setName] = useState("");
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [showQuestionEditor, setShowQuestionEditor] = useState(false);
+  const [editorQuestion, setEditorQuestion] = useState<Question | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
 
   const [createTest] = useMutation<{
     createTest: { createTest: { id: string } };
   }>(CREATE_NEW_ASSESSMENT);
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [editorQuestion, setEditorQuestion] = useState<Question | null>(null);
 
   const {
     handleSubmit,
@@ -81,17 +81,16 @@ const CreateAssessmentPage = (): React.ReactElement => {
     <DndProvider backend={HTML5Backend}>
       <AssessmentContext.Provider
         value={{
-          editorQuestion,
-          setEditorQuestion,
+          questions,
+          setQuestions,
           showQuestionEditor,
           setShowQuestionEditor,
+          editorQuestion,
+          setEditorQuestion,
         }}
       >
         {showQuestionEditor ? (
-          <QuestionEditor
-            setQuestions={setQuestions}
-            setShowQuestionEditor={setShowQuestionEditor}
-          />
+          <QuestionEditor />
         ) : (
           <VStack spacing="8" width="100%">
             <CreateAssessementHeader name={name} onSave={handleSave} />
@@ -107,10 +106,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
                 watch={watch}
               />
               <Divider borderColor="grey.200" />
-              <AssessmentQuestions
-                questions={questions}
-                setQuestions={setQuestions}
-              />
+              <AssessmentQuestions />
             </VStack>
           </VStack>
         )}

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 import { useMutation } from "@apollo/client";
@@ -74,7 +76,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
   const handleSave = handleSubmit(onSave, onError);
 
   return (
-    <>
+    <DndProvider backend={HTML5Backend}>
       {showQuestionEditor ? (
         <QuestionEditor
           setQuestions={setQuestions}
@@ -103,7 +105,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
           </VStack>
         </VStack>
       )}
-    </>
+    </DndProvider>
   );
 };
 

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -9,6 +9,7 @@ import { Divider, VStack } from "@chakra-ui/react";
 import { CREATE_NEW_ASSESSMENT } from "../../../APIClients/mutations/TestMutations";
 import { TestRequest } from "../../../APIClients/types/TestClientTypes";
 import { ASSESSMENTS_PAGE } from "../../../constants/Routes";
+import AssessmentContext from "../../../contexts/AssessmentContext";
 import { Status } from "../../../types/AssessmentTypes";
 import { Question } from "../../../types/QuestionTypes";
 import { formatQuestionsRequest } from "../../../utils/QuestionUtils";
@@ -28,6 +29,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
     createTest: { createTest: { id: string } };
   }>(CREATE_NEW_ASSESSMENT);
   const [questions, setQuestions] = useState<Question[]>([]);
+  const [editorQuestion, setEditorQuestion] = useState<Question | null>(null);
 
   const {
     handleSubmit,
@@ -77,34 +79,42 @@ const CreateAssessmentPage = (): React.ReactElement => {
 
   return (
     <DndProvider backend={HTML5Backend}>
-      {showQuestionEditor ? (
-        <QuestionEditor
-          setQuestions={setQuestions}
-          setShowQuestionEditor={setShowQuestionEditor}
-        />
-      ) : (
-        <VStack spacing="8" width="100%">
-          <CreateAssessementHeader name={name} onSave={handleSave} />
-          <VStack spacing="8" width="92%">
-            <BasicInformation
-              clearErrors={clearErrors}
-              control={control}
-              errorMessage={errorMessage}
-              errors={errors}
-              register={register}
-              setName={setName}
-              setValue={setValue}
-              watch={watch}
-            />
-            <Divider borderColor="grey.200" />
-            <AssessmentQuestions
-              questions={questions}
-              setQuestions={setQuestions}
-              setShowQuestionEditor={setShowQuestionEditor}
-            />
+      <AssessmentContext.Provider
+        value={{
+          editorQuestion,
+          setEditorQuestion,
+          showQuestionEditor,
+          setShowQuestionEditor,
+        }}
+      >
+        {showQuestionEditor ? (
+          <QuestionEditor
+            setQuestions={setQuestions}
+            setShowQuestionEditor={setShowQuestionEditor}
+          />
+        ) : (
+          <VStack spacing="8" width="100%">
+            <CreateAssessementHeader name={name} onSave={handleSave} />
+            <VStack spacing="8" width="92%">
+              <BasicInformation
+                clearErrors={clearErrors}
+                control={control}
+                errorMessage={errorMessage}
+                errors={errors}
+                register={register}
+                setName={setName}
+                setValue={setValue}
+                watch={watch}
+              />
+              <Divider borderColor="grey.200" />
+              <AssessmentQuestions
+                questions={questions}
+                setQuestions={setQuestions}
+              />
+            </VStack>
           </VStack>
-        </VStack>
-      )}
+        )}
+      </AssessmentContext.Provider>
     </DndProvider>
   );
 };

--- a/frontend/src/components/question-creation/QuestionEditor.tsx
+++ b/frontend/src/components/question-creation/QuestionEditor.tsx
@@ -3,22 +3,14 @@ import { Flex } from "@chakra-ui/react";
 
 import AssessmentContext from "../../contexts/AssessmentContext";
 import QuestionEditorContext from "../../contexts/QuestionEditorContext";
-import { Question, QuestionElement } from "../../types/QuestionTypes";
+import { QuestionElement } from "../../types/QuestionTypes";
 
 import AddMultiOptionModal from "./question-elements/modals/multi-option/AddMultiOptionModal";
 import AddShortAnswerModal from "./question-elements/modals/short-answer/AddShortAnswerModal";
 import QuestionSidebar from "./QuestionSidebar";
 import QuestionWorkspace from "./QuestionWorkspace";
 
-interface QuestionEditorProps {
-  setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
-}
-
-const QuestionEditor = ({
-  setShowQuestionEditor,
-  setQuestions,
-}: QuestionEditorProps): React.ReactElement => {
+const QuestionEditor = (): React.ReactElement => {
   const { editorQuestion } = useContext(AssessmentContext);
   const [questionElements, setQuestionElements] = React.useState<
     QuestionElement[]
@@ -51,10 +43,7 @@ const QuestionEditor = ({
       }}
     >
       <Flex minHeight="100vh">
-        <QuestionSidebar
-          setQuestions={setQuestions}
-          setShowQuestionEditor={setShowQuestionEditor}
-        />
+        <QuestionSidebar />
         <QuestionWorkspace />
       </Flex>
       <AddShortAnswerModal />

--- a/frontend/src/components/question-creation/QuestionEditor.tsx
+++ b/frontend/src/components/question-creation/QuestionEditor.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Flex } from "@chakra-ui/react";
 
+import AssessmentContext from "../../contexts/AssessmentContext";
 import QuestionEditorContext from "../../contexts/QuestionEditorContext";
 import { Question, QuestionElement } from "../../types/QuestionTypes";
 
@@ -18,9 +19,10 @@ const QuestionEditor = ({
   setShowQuestionEditor,
   setQuestions,
 }: QuestionEditorProps): React.ReactElement => {
+  const { editorQuestion } = useContext(AssessmentContext);
   const [questionElements, setQuestionElements] = React.useState<
     QuestionElement[]
-  >([]);
+  >(editorQuestion ? editorQuestion.elements : []);
   const [showAddShortAnswerModal, setShowAddShortAnswerModal] = React.useState(
     false,
   );

--- a/frontend/src/components/question-creation/QuestionEditor.tsx
+++ b/frontend/src/components/question-creation/QuestionEditor.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 import { Flex } from "@chakra-ui/react";
 
 import QuestionEditorContext from "../../contexts/QuestionEditorContext";
@@ -36,32 +34,30 @@ const QuestionEditor = ({
   const [showEditorError, setShowEditorError] = React.useState(false);
 
   return (
-    <DndProvider backend={HTML5Backend}>
-      <QuestionEditorContext.Provider
-        value={{
-          questionElements,
-          setQuestionElements,
-          showAddShortAnswerModal,
-          setShowAddShortAnswerModal,
-          showAddMultipleChoiceModal,
-          setShowAddMultipleChoiceModal,
-          showAddMultiSelectModal,
-          setShowAddMultiSelectModal,
-          showEditorError,
-          setShowEditorError,
-        }}
-      >
-        <Flex minHeight="100vh">
-          <QuestionSidebar
-            setQuestions={setQuestions}
-            setShowQuestionEditor={setShowQuestionEditor}
-          />
-          <QuestionWorkspace />
-        </Flex>
-        <AddShortAnswerModal />
-        <AddMultiOptionModal />
-      </QuestionEditorContext.Provider>
-    </DndProvider>
+    <QuestionEditorContext.Provider
+      value={{
+        questionElements,
+        setQuestionElements,
+        showAddShortAnswerModal,
+        setShowAddShortAnswerModal,
+        showAddMultipleChoiceModal,
+        setShowAddMultipleChoiceModal,
+        showAddMultiSelectModal,
+        setShowAddMultiSelectModal,
+        showEditorError,
+        setShowEditorError,
+      }}
+    >
+      <Flex minHeight="100vh">
+        <QuestionSidebar
+          setQuestions={setQuestions}
+          setShowQuestionEditor={setShowQuestionEditor}
+        />
+        <QuestionWorkspace />
+      </Flex>
+      <AddShortAnswerModal />
+      <AddMultiOptionModal />
+    </QuestionEditorContext.Provider>
   );
 };
 

--- a/frontend/src/components/question-creation/QuestionEditor.tsx
+++ b/frontend/src/components/question-creation/QuestionEditor.tsx
@@ -4,7 +4,7 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 import { Flex } from "@chakra-ui/react";
 
 import QuestionEditorContext from "../../contexts/QuestionEditorContext";
-import { QuestionElement } from "../../types/QuestionTypes";
+import { Question, QuestionElement } from "../../types/QuestionTypes";
 
 import AddMultiOptionModal from "./question-elements/modals/multi-option/AddMultiOptionModal";
 import AddShortAnswerModal from "./question-elements/modals/short-answer/AddShortAnswerModal";
@@ -13,7 +13,7 @@ import QuestionWorkspace from "./QuestionWorkspace";
 
 interface QuestionEditorProps {
   setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-  setQuestions: React.Dispatch<React.SetStateAction<QuestionElement[][]>>;
+  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
 }
 
 const QuestionEditor = ({

--- a/frontend/src/components/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/question-creation/QuestionSidebar.tsx
@@ -74,7 +74,15 @@ const renderAccordionItem = (items: AccordionItemProps[]) => {
 };
 
 const QuestionSidebar = (): React.ReactElement => {
-  const { setShowQuestionEditor } = useContext(AssessmentContext);
+  const { setShowQuestionEditor, setEditorQuestion } = useContext(
+    AssessmentContext,
+  );
+
+  const closeQuestionEditor = () => {
+    setEditorQuestion(null);
+    setShowQuestionEditor(false);
+  };
+
   return (
     <VStack
       boxShadow="8px 0px 4px -2px rgba(193, 186, 186, 0.25)"
@@ -86,7 +94,7 @@ const QuestionSidebar = (): React.ReactElement => {
         <Box justifyContent="flex-start" paddingLeft="0">
           <Button
             leftIcon={<ArrowBackOutlineIcon />}
-            onClick={() => setShowQuestionEditor(false)}
+            onClick={closeQuestionEditor}
             size="sm"
             variant="tertiary"
           >
@@ -133,7 +141,7 @@ const QuestionSidebar = (): React.ReactElement => {
         <Button minWidth={0} variant="secondary">
           Preview
         </Button>
-        <SaveQuestionEditorButton />
+        <SaveQuestionEditorButton closeQuestionEditor={closeQuestionEditor} />
       </HStack>
     </VStack>
   );

--- a/frontend/src/components/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/question-creation/QuestionSidebar.tsx
@@ -23,17 +23,14 @@ import {
   ShortAnswerIcon,
   TextIcon,
 } from "../../assets/icons";
-import {
-  QuestionElement,
-  QuestionElementType,
-} from "../../types/QuestionTypes";
+import { Question, QuestionElementType } from "../../types/QuestionTypes";
 
 import SaveQuestionEditorButton from "./question-elements/SaveQuestionEditorButton";
 import QuestionSidebarItem from "./QuestionSidebarItem";
 
 interface QuestionSidebarProps {
   setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-  setQuestions: React.Dispatch<React.SetStateAction<QuestionElement[][]>>;
+  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
 }
 
 interface AccordionItemProps {

--- a/frontend/src/components/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/question-creation/QuestionSidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import {
   Accordion,
   AccordionButton,
@@ -23,15 +23,11 @@ import {
   ShortAnswerIcon,
   TextIcon,
 } from "../../assets/icons";
-import { Question, QuestionElementType } from "../../types/QuestionTypes";
+import AssessmentContext from "../../contexts/AssessmentContext";
+import { QuestionElementType } from "../../types/QuestionTypes";
 
 import SaveQuestionEditorButton from "./question-elements/SaveQuestionEditorButton";
 import QuestionSidebarItem from "./QuestionSidebarItem";
-
-interface QuestionSidebarProps {
-  setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
-}
 
 interface AccordionItemProps {
   title: string;
@@ -77,10 +73,8 @@ const renderAccordionItem = (items: AccordionItemProps[]) => {
   });
 };
 
-const QuestionSidebar = ({
-  setShowQuestionEditor,
-  setQuestions,
-}: QuestionSidebarProps): React.ReactElement => {
+const QuestionSidebar = (): React.ReactElement => {
+  const { setShowQuestionEditor } = useContext(AssessmentContext);
   return (
     <VStack
       boxShadow="8px 0px 4px -2px rgba(193, 186, 186, 0.25)"
@@ -139,10 +133,7 @@ const QuestionSidebar = ({
         <Button minWidth={0} variant="secondary">
           Preview
         </Button>
-        <SaveQuestionEditorButton
-          setQuestions={setQuestions}
-          setShowQuestionEditor={setShowQuestionEditor}
-        />
+        <SaveQuestionEditorButton />
       </HStack>
     </VStack>
   );

--- a/frontend/src/components/question-creation/question-elements/SaveQuestionEditorButton.tsx
+++ b/frontend/src/components/question-creation/question-elements/SaveQuestionEditorButton.tsx
@@ -2,24 +2,16 @@ import React, { useContext } from "react";
 import { Button } from "@chakra-ui/react";
 import { v4 as uuidv4 } from "uuid";
 
+import AssessmentContext from "../../../contexts/AssessmentContext";
 import QuestionEditorContext from "../../../contexts/QuestionEditorContext";
 import {
-  Question,
   QuestionElement,
   QuestionElementType,
   ResponseElementType,
 } from "../../../types/QuestionTypes";
 import { updatedQuestionElement } from "../../../utils/QuestionUtils";
 
-interface SaveQuestionEditorButtonProps {
-  setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
-}
-
-const SaveQuestionEditorButton = ({
-  setShowQuestionEditor,
-  setQuestions,
-}: SaveQuestionEditorButtonProps): React.ReactElement => {
+const SaveQuestionEditorButton = (): React.ReactElement => {
   const questionError =
     "Please create a question to be associated with this response";
   const responseError =
@@ -27,6 +19,7 @@ const SaveQuestionEditorButton = ({
   const emptyElementError =
     "Please ensure this field is filled. If you do not need this item, please delete it.";
 
+  const { setQuestions, setShowQuestionEditor } = useContext(AssessmentContext);
   const {
     questionElements,
     setQuestionElements,

--- a/frontend/src/components/question-creation/question-elements/SaveQuestionEditorButton.tsx
+++ b/frontend/src/components/question-creation/question-elements/SaveQuestionEditorButton.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { Button } from "@chakra-ui/react";
+import update from "immutability-helper";
 import { v4 as uuidv4 } from "uuid";
 
 import AssessmentContext from "../../../contexts/AssessmentContext";
@@ -19,7 +20,12 @@ const SaveQuestionEditorButton = (): React.ReactElement => {
   const emptyElementError =
     "Please ensure this field is filled. If you do not need this item, please delete it.";
 
-  const { setQuestions, setShowQuestionEditor } = useContext(AssessmentContext);
+  const {
+    setQuestions,
+    setShowQuestionEditor,
+    editorQuestion,
+    setEditorQuestion,
+  } = useContext(AssessmentContext);
   const {
     questionElements,
     setQuestionElements,
@@ -114,9 +120,34 @@ const SaveQuestionEditorButton = (): React.ReactElement => {
       validateNoEmptyElementErrors() &&
       validateNoExistingErrors()
     ) {
-      setQuestions((prevQuestions) => {
-        return [...prevQuestions, { id: uuidv4(), elements: questionElements }];
+      const validatedQuestionElements = questionElements.map((element) => {
+        return {
+          ...element,
+          error: "",
+        };
       });
+      if (editorQuestion) {
+        setQuestions((prevQuestions) => {
+          const indexToUpdate = prevQuestions.findIndex(
+            (question) => question.id === editorQuestion.id,
+          );
+          return update(prevQuestions, {
+            [indexToUpdate]: {
+              $merge: {
+                elements: validatedQuestionElements,
+              },
+            },
+          });
+        });
+        setEditorQuestion(null);
+      } else {
+        setQuestions((prevQuestions) => {
+          return [
+            ...prevQuestions,
+            { id: uuidv4(), elements: validatedQuestionElements },
+          ];
+        });
+      }
       setShowQuestionEditor(false);
     }
   };

--- a/frontend/src/components/question-creation/question-elements/SaveQuestionEditorButton.tsx
+++ b/frontend/src/components/question-creation/question-elements/SaveQuestionEditorButton.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from "react";
 import { Button } from "@chakra-ui/react";
+import { v4 as uuidv4 } from "uuid";
 
 import QuestionEditorContext from "../../../contexts/QuestionEditorContext";
 import {
+  Question,
   QuestionElement,
   QuestionElementType,
   ResponseElementType,
@@ -11,7 +13,7 @@ import { updatedQuestionElement } from "../../../utils/QuestionUtils";
 
 interface SaveQuestionEditorButtonProps {
   setShowQuestionEditor: React.Dispatch<React.SetStateAction<boolean>>;
-  setQuestions: React.Dispatch<React.SetStateAction<QuestionElement[][]>>;
+  setQuestions: React.Dispatch<React.SetStateAction<Question[]>>;
 }
 
 const SaveQuestionEditorButton = ({
@@ -120,7 +122,7 @@ const SaveQuestionEditorButton = ({
       validateNoExistingErrors()
     ) {
       setQuestions((prevQuestions) => {
-        return [...prevQuestions, questionElements];
+        return [...prevQuestions, { id: uuidv4(), elements: questionElements }];
       });
       setShowQuestionEditor(false);
     }

--- a/frontend/src/contexts/AssessmentContext.ts
+++ b/frontend/src/contexts/AssessmentContext.ts
@@ -1,0 +1,20 @@
+import { createContext } from "react";
+
+import { Question } from "../types/QuestionTypes";
+
+type AssessmentContextType = {
+  showQuestionEditor: boolean;
+  setShowQuestionEditor: (_showQuestionEditor: boolean) => void;
+  editorQuestion: Question | null;
+  setEditorQuestion: (_editorQuestion: Question | null) => void;
+};
+
+const AssessmentContext = createContext<AssessmentContextType>({
+  showQuestionEditor: false,
+  setShowQuestionEditor: (_showQuestionEditor: boolean): void => {},
+  editorQuestion: null,
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  setEditorQuestion: (_editorQuestion: Question | null): void => {},
+});
+
+export default AssessmentContext;

--- a/frontend/src/contexts/AssessmentContext.ts
+++ b/frontend/src/contexts/AssessmentContext.ts
@@ -3,6 +3,8 @@ import { createContext } from "react";
 import { Question } from "../types/QuestionTypes";
 
 type AssessmentContextType = {
+  questions: Question[];
+  setQuestions: (_questions: (prevElements: Question[]) => Question[]) => void;
   showQuestionEditor: boolean;
   setShowQuestionEditor: (_showQuestionEditor: boolean) => void;
   editorQuestion: Question | null;
@@ -10,10 +12,13 @@ type AssessmentContextType = {
 };
 
 const AssessmentContext = createContext<AssessmentContextType>({
+  questions: [],
+  setQuestions: (
+    _questions: (prevElements: Question[]) => Question[],
+  ): void => {},
   showQuestionEditor: false,
   setShowQuestionEditor: (_showQuestionEditor: boolean): void => {},
   editorQuestion: null,
-  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   setEditorQuestion: (_editorQuestion: Question | null): void => {},
 });
 

--- a/frontend/src/types/DragTypes.tsx
+++ b/frontend/src/types/DragTypes.tsx
@@ -1,6 +1,7 @@
 export const DragTypes = {
   QUESTION_SIDEBAR_ITEM: "Question Sidebar Item",
   QUESTION_ELEMENT_ITEM: "Question Element Item",
+  QUESTION_CARD: "Question Card",
 };
 
 export interface DragQuestionItem {

--- a/frontend/src/types/QuestionTypes.ts
+++ b/frontend/src/types/QuestionTypes.ts
@@ -4,6 +4,11 @@ import {
   TextMetadata,
 } from "./QuestionMetadataTypes";
 
+export type Question = {
+  id: string;
+  elements: QuestionElement[];
+};
+
 export interface QuestionElement {
   id: string;
   type: QuestionElementType;

--- a/frontend/src/utils/QuestionUtils.ts
+++ b/frontend/src/utils/QuestionUtils.ts
@@ -16,6 +16,7 @@ import {
 import {
   MultiData,
   MultiOptionData,
+  Question,
   QuestionElement,
   QuestionElementDataType,
   QuestionElementType,
@@ -138,10 +139,10 @@ const formatMultiSelectRequest = (data: MultiData): MultiSelectMetadata => {
 };
 
 export const formatQuestionsRequest = (
-  questions: QuestionElement[][],
+  questions: Question[],
 ): QuestionComponentRequest[][] => {
   return questions.map((question) => {
-    return question.map((element) => {
+    return question.elements.map((element) => {
       switch (element.type) {
         case QuestionElementType.QUESTION_TEXT:
           return {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Reordering, editing and deleting functionality for question cards](https://www.notion.so/uwblueprintexecs/Reordering-editing-and-deleting-functionality-for-Question-Cards-9c25c549771c4974b2030ca70c4231b2?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Refactored some common assessment states and setters into`AssessmentContext`
* Added a type `Question` to store an associated id with each question
* Reordering functionality for question cards
* Editing functionality for question cards
* Deletion functionality for question cards

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correct reordering functionality
* Correct editing functionality
* Correct deleting functionality