### PR TITLE
feat: publish assessment from create assessment page

### DIFF
--- a/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
@@ -16,11 +16,12 @@ import {
 } from "../../../assets/icons";
 import { getReadableDate } from "../../../utils/GeneralUtils";
 import BackButton from "../../common/BackButton";
+import PublishModal from "../assessment-status/EditStatusModals/PublishModal";
 
 interface CreateAssessementHeaderProps {
   name: string;
-  onSave: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onPublish: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onSave: () => void;
+  onPublish: () => void;
 }
 
 const CreateAssessementHeader = ({
@@ -28,47 +29,55 @@ const CreateAssessementHeader = ({
   onSave,
   onPublish,
 }: CreateAssessementHeaderProps): React.ReactElement => {
+  const [showPublishModal, setShowPublishModal] = React.useState(false);
   return (
-    <Box
-      borderBottom="1px"
-      borderBottomColor="grey.200"
-      padding="1.5em 2em 1.5em 2em"
-      width="100%"
-    >
-      <Flex minWidth="max-content">
-        <HStack alignItems="start" spacing={6}>
-          <BackButton />
-          <VStack align="left">
-            <Text textStyle="subtitle1">{name || "Untitled Assessment"}</Text>
-            <Text textStyle="smallerParagraph">
-              Created {getReadableDate()}
-            </Text>
-          </VStack>
-        </HStack>
-        <Spacer />
-        <HStack spacing={2}>
-          <Button leftIcon={<EyeOutlineIcon />} size="sm" variant="tertiary">
-            Preview
-          </Button>
-          <Button
-            leftIcon={<SaveOutlineIcon />}
-            minWidth="10"
-            onClick={onSave}
-            variant="secondary"
-          >
-            Save
-          </Button>
-          <Button
-            leftIcon={<TextOutlineIcon />}
-            minWidth="10"
-            onClick={onPublish}
-            variant="primary"
-          >
-            Publish
-          </Button>
-        </HStack>
-      </Flex>
-    </Box>
+    <>
+      <Box
+        borderBottom="1px"
+        borderBottomColor="grey.200"
+        padding="1.5em 2em 1.5em 2em"
+        width="100%"
+      >
+        <Flex minWidth="max-content">
+          <HStack alignItems="start" spacing={6}>
+            <BackButton />
+            <VStack align="left">
+              <Text textStyle="subtitle1">{name || "Untitled Assessment"}</Text>
+              <Text textStyle="smallerParagraph">
+                Created {getReadableDate()}
+              </Text>
+            </VStack>
+          </HStack>
+          <Spacer />
+          <HStack spacing={2}>
+            <Button leftIcon={<EyeOutlineIcon />} size="sm" variant="tertiary">
+              Preview
+            </Button>
+            <Button
+              leftIcon={<SaveOutlineIcon />}
+              minWidth="10"
+              onClick={onSave}
+              variant="secondary"
+            >
+              Save
+            </Button>
+            <Button
+              leftIcon={<TextOutlineIcon />}
+              minWidth="10"
+              onClick={() => setShowPublishModal(true)}
+              variant="primary"
+            >
+              Publish
+            </Button>
+          </HStack>
+        </Flex>
+      </Box>
+      <PublishModal
+        isOpen={showPublishModal}
+        onClose={() => setShowPublishModal(false)}
+        publishAssessment={onPublish}
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
@@ -20,11 +20,13 @@ import BackButton from "../../common/BackButton";
 interface CreateAssessementHeaderProps {
   name: string;
   onSave: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onPublish: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const CreateAssessementHeader = ({
   name,
   onSave,
+  onPublish,
 }: CreateAssessementHeaderProps): React.ReactElement => {
   return (
     <Box
@@ -59,6 +61,7 @@ const CreateAssessementHeader = ({
           <Button
             leftIcon={<TextOutlineIcon />}
             minWidth="10"
+            onClick={onPublish}
             variant="primary"
           >
             Publish

--- a/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
@@ -23,7 +23,7 @@ import PublishModal from "../assessment-status/EditStatusModals/PublishModal";
 interface CreateAssessementHeaderProps {
   name: string;
   handleSubmit: UseFormHandleSubmit<TestRequest>;
-  onPublish: (data: TestRequest) => Promise<void>;
+  onConfirmPublish: (data: TestRequest) => Promise<void>;
   onSave: (data: TestRequest) => Promise<void>;
   onError: () => void;
   validateForm: () => boolean;
@@ -32,21 +32,21 @@ interface CreateAssessementHeaderProps {
 const CreateAssessementHeader = ({
   name,
   handleSubmit,
-  onPublish,
+  onConfirmPublish,
   onSave,
   onError,
   validateForm,
 }: CreateAssessementHeaderProps): React.ReactElement => {
   const [showPublishModal, setShowPublishModal] = React.useState(false);
-  const confirmPublish = () => {
+  const onPublish = () => {
     if (validateForm()) {
       setShowPublishModal(true);
     }
   };
 
   const handleSave = handleSubmit(onSave, onError);
-  const handlePublish = handleSubmit(confirmPublish, onError);
-  const onConfirmPublish = handleSubmit(onPublish, onError);
+  const handlePublish = handleSubmit(onPublish, onError);
+  const handleConfirmPublish = handleSubmit(onConfirmPublish, onError);
 
   return (
     <>
@@ -93,7 +93,7 @@ const CreateAssessementHeader = ({
       <PublishModal
         isOpen={showPublishModal}
         onClose={() => setShowPublishModal(false)}
-        publishAssessment={onConfirmPublish}
+        publishAssessment={handleConfirmPublish}
       />
     </>
   );

--- a/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/CreateAssessmentHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { UseFormHandleSubmit } from "react-hook-form";
 import {
   Box,
   Button,
@@ -9,6 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
+import { TestRequest } from "../../../APIClients/types/TestClientTypes";
 import {
   EyeOutlineIcon,
   SaveOutlineIcon,
@@ -20,16 +22,32 @@ import PublishModal from "../assessment-status/EditStatusModals/PublishModal";
 
 interface CreateAssessementHeaderProps {
   name: string;
-  onSave: () => void;
-  onPublish: () => void;
+  handleSubmit: UseFormHandleSubmit<TestRequest>;
+  onPublish: (data: TestRequest) => Promise<void>;
+  onSave: (data: TestRequest) => Promise<void>;
+  onError: () => void;
+  validateForm: () => boolean;
 }
 
 const CreateAssessementHeader = ({
   name,
-  onSave,
+  handleSubmit,
   onPublish,
+  onSave,
+  onError,
+  validateForm,
 }: CreateAssessementHeaderProps): React.ReactElement => {
   const [showPublishModal, setShowPublishModal] = React.useState(false);
+  const confirmPublish = () => {
+    if (validateForm()) {
+      setShowPublishModal(true);
+    }
+  };
+
+  const handleSave = handleSubmit(onSave, onError);
+  const handlePublish = handleSubmit(confirmPublish, onError);
+  const onConfirmPublish = handleSubmit(onPublish, onError);
+
   return (
     <>
       <Box
@@ -56,7 +74,7 @@ const CreateAssessementHeader = ({
             <Button
               leftIcon={<SaveOutlineIcon />}
               minWidth="10"
-              onClick={onSave}
+              onClick={handleSave}
               variant="secondary"
             >
               Save
@@ -64,7 +82,7 @@ const CreateAssessementHeader = ({
             <Button
               leftIcon={<TextOutlineIcon />}
               minWidth="10"
-              onClick={() => setShowPublishModal(true)}
+              onClick={handlePublish}
               variant="primary"
             >
               Publish
@@ -75,7 +93,7 @@ const CreateAssessementHeader = ({
       <PublishModal
         isOpen={showPublishModal}
         onClose={() => setShowPublishModal(false)}
-        publishAssessment={onPublish}
+        publishAssessment={onConfirmPublish}
       />
     </>
   );

--- a/frontend/src/components/assessments/assessment-status/EditStatusButtons/PublishButton.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusButtons/PublishButton.tsx
@@ -1,5 +1,9 @@
 import React from "react";
+import { useMutation } from "@apollo/client";
 
+import { PUBLISH_TEST } from "../../../../APIClients/mutations/TestMutations";
+import GET_ALL_TESTS from "../../../../APIClients/queries/TestQueries";
+import Toast from "../../../common/Toast";
 import EditStatusButton from "../EditStatusButton";
 import PublishModal from "../EditStatusModals/PublishModal";
 
@@ -12,7 +16,29 @@ const PublishButton = ({
   assessmentId,
   closePopover,
 }: PublishButtonProps): React.ReactElement => {
-  const [showPublishModal, setshowPublishModal] = React.useState(false);
+  const [showPublishModal, setShowPublishModal] = React.useState(false);
+  const [publishAssessment, { error }] = useMutation<{
+    publishAssessment: string;
+  }>(PUBLISH_TEST, {
+    refetchQueries: [{ query: GET_ALL_TESTS }],
+  });
+
+  const { showToast } = Toast();
+
+  const handlePublishAssessment = async () => {
+    await publishAssessment({ variables: { id: assessmentId } });
+    if (error) {
+      showToast({
+        message: "Assessment failed to publish. Please try again.",
+        status: "error",
+      });
+    } else {
+      showToast({
+        message: "Assessment published.",
+        status: "success",
+      });
+    }
+  };
 
   return (
     <>
@@ -20,13 +46,13 @@ const PublishButton = ({
         name="Publish"
         onClick={() => {
           closePopover();
-          setshowPublishModal(true);
+          setShowPublishModal(true);
         }}
       />
       <PublishModal
-        assessmentId={assessmentId}
         isOpen={showPublishModal}
-        onClose={() => setshowPublishModal(false)}
+        onClose={() => setShowPublishModal(false)}
+        publishAssessment={handlePublishAssessment}
       />
     </>
   );

--- a/frontend/src/components/assessments/assessment-status/EditStatusModals/PublishModal.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusModals/PublishModal.tsx
@@ -1,43 +1,20 @@
 import React from "react";
-import { useMutation } from "@apollo/client";
 
-import { PUBLISH_TEST } from "../../../../APIClients/mutations/TestMutations";
-import GET_ALL_TESTS from "../../../../APIClients/queries/TestQueries";
 import Modal from "../../../common/Modal";
-import Toast from "../../../common/Toast";
 
 interface PublishModalProps {
   isOpen: boolean;
   onClose: () => void;
-  assessmentId: string;
+  publishAssessment: () => void;
 }
 
 const PublishModal = ({
   isOpen,
   onClose,
-  assessmentId,
+  publishAssessment,
 }: PublishModalProps): React.ReactElement => {
-  const [publishAssessment, { error }] = useMutation<{
-    publishAssessment: string;
-  }>(PUBLISH_TEST, {
-    refetchQueries: [{ query: GET_ALL_TESTS }],
-  });
-
-  const { showToast } = Toast();
-
-  const onPublishAssessment = async () => {
-    await publishAssessment({ variables: { id: assessmentId } });
-    if (error) {
-      showToast({
-        message: "Assessment failed to publish. Please try again.",
-        status: "error",
-      });
-    } else {
-      showToast({
-        message: "Assessment published.",
-        status: "success",
-      });
-    }
+  const onPublishAssessment = () => {
+    publishAssessment();
     onClose();
   };
 

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -49,10 +49,16 @@ const CreateAssessmentPage = (): React.ReactElement => {
     }
   }, [questions, errorMessage]);
 
-  const onCreateTest = async (test: TestRequest) => {
+  const validateForm = () => {
     if (questions.length === 0) {
       setErrorMessage(noQuestionError);
-    } else {
+      return false;
+    }
+    return true;
+  };
+
+  const onCreateTest = async (test: TestRequest) => {
+    if (validateForm()) {
       await createTest({
         variables: {
           test,
@@ -75,7 +81,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
     });
   };
 
-  const onPublish: SubmitHandler<TestRequest> = async (data) => {
+  const onPublish: SubmitHandler<TestRequest> = async (data: TestRequest) => {
     onCreateTest({
       ...data,
       status: Status.PUBLISHED,
@@ -86,9 +92,6 @@ const CreateAssessmentPage = (): React.ReactElement => {
   const onError = () => {
     setErrorMessage("Please resolve all issues before publishing or saving");
   };
-
-  const handleSave = handleSubmit(onSave, onError);
-  const handlePublish = handleSubmit(onPublish, onError);
 
   return (
     <DndProvider backend={HTML5Backend}>
@@ -107,9 +110,12 @@ const CreateAssessmentPage = (): React.ReactElement => {
         ) : (
           <VStack spacing="8" width="100%">
             <CreateAssessementHeader
+              handleSubmit={handleSubmit}
               name={name}
-              onPublish={handlePublish}
-              onSave={handleSave}
+              onError={onError}
+              onPublish={onPublish}
+              onSave={onSave}
+              validateForm={validateForm}
             />
             <VStack spacing="8" width="92%">
               <BasicInformation

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -49,7 +49,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
     }
   }, [questions, errorMessage]);
 
-  const createNewAssessment = async (test: TestRequest) => {
+  const onCreateTest = async (test: TestRequest) => {
     if (questions.length === 0) {
       setErrorMessage(noQuestionError);
     } else {
@@ -68,7 +68,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
   };
 
   const onSave: SubmitHandler<TestRequest> = async (data) => {
-    createNewAssessment({
+    onCreateTest({
       ...data,
       status: Status.DRAFT,
       questions: formatQuestionsRequest(questions),
@@ -76,7 +76,7 @@ const CreateAssessmentPage = (): React.ReactElement => {
   };
 
   const onPublish: SubmitHandler<TestRequest> = async (data) => {
-    createNewAssessment({
+    onCreateTest({
       ...data,
       status: Status.PUBLISHED,
       questions: formatQuestionsRequest(questions),

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -49,17 +49,13 @@ const CreateAssessmentPage = (): React.ReactElement => {
     }
   }, [questions, errorMessage]);
 
-  const onSave: SubmitHandler<TestRequest> = async (data) => {
+  const createNewAssessment = async (test: TestRequest) => {
     if (questions.length === 0) {
       setErrorMessage(noQuestionError);
     } else {
       await createTest({
         variables: {
-          test: {
-            ...data,
-            status: Status.DRAFT,
-            questions: formatQuestionsRequest(questions),
-          },
+          test,
         },
       })
         .then(() => {
@@ -71,11 +67,28 @@ const CreateAssessmentPage = (): React.ReactElement => {
     }
   };
 
+  const onSave: SubmitHandler<TestRequest> = async (data) => {
+    createNewAssessment({
+      ...data,
+      status: Status.DRAFT,
+      questions: formatQuestionsRequest(questions),
+    });
+  };
+
+  const onPublish: SubmitHandler<TestRequest> = async (data) => {
+    createNewAssessment({
+      ...data,
+      status: Status.PUBLISHED,
+      questions: formatQuestionsRequest(questions),
+    });
+  };
+
   const onError = () => {
     setErrorMessage("Please resolve all issues before publishing or saving");
   };
 
   const handleSave = handleSubmit(onSave, onError);
+  const handlePublish = handleSubmit(onPublish, onError);
 
   return (
     <DndProvider backend={HTML5Backend}>
@@ -93,7 +106,11 @@ const CreateAssessmentPage = (): React.ReactElement => {
           <QuestionEditor />
         ) : (
           <VStack spacing="8" width="100%">
-            <CreateAssessementHeader name={name} onSave={handleSave} />
+            <CreateAssessementHeader
+              name={name}
+              onPublish={handlePublish}
+              onSave={handleSave}
+            />
             <VStack spacing="8" width="92%">
               <BasicInformation
                 clearErrors={clearErrors}

--- a/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
+++ b/frontend/src/components/pages/admin/CreateAssessmentPage.tsx
@@ -112,8 +112,8 @@ const CreateAssessmentPage = (): React.ReactElement => {
             <CreateAssessementHeader
               handleSubmit={handleSubmit}
               name={name}
+              onConfirmPublish={onPublish}
               onError={onError}
-              onPublish={onPublish}
               onSave={onSave}
               validateForm={validateForm}
             />


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Publish Assessment in Create page](https://www.notion.so/uwblueprintexecs/Publish-Assessment-in-Create-page-97c1e33243224b9ba9c121b2c714e34f?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added handler for publish assessment


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. create a new test
2. click publish
3. verify that this creates a published test


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* functionality works as expected
* error handling works as expected
* existing publish assessment from display page works as expected
