### PR TITLE
feat: unarchive assessment from assessments table

### DIFF
--- a/frontend/src/components/assessments/assessment-status/EditStatusButtons/UnarchiveButton.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusButtons/UnarchiveButton.tsx
@@ -12,21 +12,21 @@ const UnarchiveButton = ({
   assessmentId,
   closePopover,
 }: UnarchiveButtonProps): React.ReactElement => {
-  const [showUnarchiveModal, setshowUnarchiveModal] = React.useState(false);
+  const [showUnarchiveModal, setShowUnarchiveModal] = React.useState(false);
 
   return (
     <>
       <EditStatusButton
-        name="Unarchive"
+        name="Un-archive"
         onClick={() => {
           closePopover();
-          setshowUnarchiveModal(true);
+          setShowUnarchiveModal(true);
         }}
       />
       <UnarchiveModal
         assessmentId={assessmentId}
         isOpen={showUnarchiveModal}
-        onClose={() => setshowUnarchiveModal(false)}
+        onClose={() => setShowUnarchiveModal(false)}
       />
     </>
   );

--- a/frontend/src/components/assessments/assessment-status/EditStatusButtons/UnarchiveButton.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusButtons/UnarchiveButton.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import EditStatusButton from "../EditStatusButton";
+import UnarchiveModal from "../EditStatusModals/UnarchiveModal";
+
+interface UnarchiveButtonProps {
+  assessmentId: string;
+  closePopover: () => void;
+}
+
+const UnarchiveButton = ({
+  assessmentId,
+  closePopover,
+}: UnarchiveButtonProps): React.ReactElement => {
+  const [showUnarchiveModal, setshowUnarchiveModal] = React.useState(false);
+
+  return (
+    <>
+      <EditStatusButton
+        name="Unarchive"
+        onClick={() => {
+          closePopover();
+          setshowUnarchiveModal(true);
+        }}
+      />
+      <UnarchiveModal
+        assessmentId={assessmentId}
+        isOpen={showUnarchiveModal}
+        onClose={() => setshowUnarchiveModal(false)}
+      />
+    </>
+  );
+};
+
+export default UnarchiveButton;

--- a/frontend/src/components/assessments/assessment-status/EditStatusModals/UnarchiveModal.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusModals/UnarchiveModal.tsx
@@ -29,12 +29,12 @@ const UnarchiveModal = ({
     await unarchiveAssessment({ variables: { id: assessmentId } });
     if (error) {
       showToast({
-        message: "Assessment failed to unarchive. Please try again.",
+        message: "Assessment failed to un-archive. Please try again.",
         status: "error",
       });
     } else {
       showToast({
-        message: "Assessment unarchived.",
+        message: "Assessment un-archived.",
         status: "success",
       });
     }
@@ -43,13 +43,13 @@ const UnarchiveModal = ({
 
   return (
     <Modal
-      body="Once this assessment is unarchived, it will be visible to other teachers and become a draft on the assessments page."
-      header="Unarchive Assessment"
+      body="View this assessment under drafts once you un-archive it"
+      header="Un-archive Assessment"
       isOpen={isOpen}
       onCancel={onClose}
       onClose={onClose}
       onSubmit={onUnarchiveAssessment}
-      submitButtonText="Unarchive"
+      submitButtonText="Un-archive"
     />
   );
 };

--- a/frontend/src/components/assessments/assessment-status/EditStatusModals/UnarchiveModal.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusModals/UnarchiveModal.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { useMutation } from "@apollo/client";
+
+import { UNARCHIVE_TEST } from "../../../../APIClients/mutations/TestMutations";
+import GET_ALL_TESTS from "../../../../APIClients/queries/TestQueries";
+import Modal from "../../../common/Modal";
+import Toast from "../../../common/Toast";
+
+interface UnarchiveModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  assessmentId: string;
+}
+
+const UnarchiveModal = ({
+  isOpen,
+  onClose,
+  assessmentId,
+}: UnarchiveModalProps): React.ReactElement => {
+  const [unarchiveAssessment, { error }] = useMutation<{
+    unarchiveAssessment: string;
+  }>(UNARCHIVE_TEST, {
+    refetchQueries: [{ query: GET_ALL_TESTS }],
+  });
+
+  const { showToast } = Toast();
+
+  const onUnarchiveAssessment = async () => {
+    await unarchiveAssessment({ variables: { id: assessmentId } });
+    if (error) {
+      showToast({
+        message: "Assessment failed to unarchive. Please try again.",
+        status: "error",
+      });
+    } else {
+      showToast({
+        message: "Assessment unarchived.",
+        status: "success",
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      body="Once this assessment is unarchived, it will be visible to other teachers and become a draft on the assessments page."
+      header="Unarchive Assessment"
+      isOpen={isOpen}
+      onCancel={onClose}
+      onClose={onClose}
+      onSubmit={onUnarchiveAssessment}
+      submitButtonText="Unarchive"
+    />
+  );
+};
+
+export default UnarchiveModal;

--- a/frontend/src/components/assessments/assessment-status/EditStatusPopover.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusPopover.tsx
@@ -16,6 +16,7 @@ import { Status } from "../../../types/AssessmentTypes";
 import DeleteButton from "./EditStatusButtons/DeleteButton";
 import DuplicateButton from "./EditStatusButtons/DuplicateButton";
 import PublishButton from "./EditStatusButtons/PublishButton";
+import UnarchiveButton from "./EditStatusButtons/UnarchiveButton";
 
 interface EditStatusPopoverProps {
   assessmentId: string;
@@ -62,6 +63,12 @@ const EditStatusPopover = ({
             {(assessmentStatus === Status.DRAFT ||
               assessmentStatus === Status.PUBLISHED) && (
               <DuplicateButton
+                assessmentId={assessmentId}
+                closePopover={onClose}
+              />
+            )}
+            {assessmentStatus === Status.ARCHIVED && (
+              <UnarchiveButton
                 assessmentId={assessmentId}
                 closePopover={onClose}
               />


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Unarchive Assessment in Display page](https://www.notion.so/uwblueprintexecs/Unarchive-Assessment-in-Display-page-0f76b5023fd543448caacbb403e8c78e?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* created UnarchiveModal and UnarchiveButton
* made adjustments in EditStatusPopover


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test in [local host](http://localhost:3000/admin/assessments)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
