### PR TITLE
fix: teacher signup back button

### DIFF
--- a/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
+++ b/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useFormContext } from "react-hook-form";
-import { watch } from "fs";
 
 import { TEACHER_SIGNUP_IMAGE } from "../../../../assets/images";
 import {
@@ -14,15 +13,20 @@ const TeacherSignupFour = ({
   setPage,
   handleSubmitCallback,
 }: TeacherSignupProps): React.ReactElement => {
-  const { setValue } = useFormContext<TeacherSignupForm>();
-
+  const { setValue, watch } = useFormContext<TeacherSignupForm>();
   const title = "Teacher Sign Up";
   const subtitle = "Please set a secure password for your account";
   const image = TEACHER_SIGNUP_IMAGE;
   const form = (
     <PasswordForm
       handleSubmitCallback={handleSubmitCallback}
-      setStep={setPage}
+      setStep={() => {
+        if (watch("school.name")) {
+          setPage(3);
+        } else {
+          setPage(2);
+        }
+      }}
       setValue={setValue}
       version="TeacherSignup"
     />

--- a/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
+++ b/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useFormContext } from "react-hook-form";
+import { watch } from "fs";
 
 import { TEACHER_SIGNUP_IMAGE } from "../../../../assets/images";
 import {
@@ -21,7 +22,7 @@ const TeacherSignupFour = ({
   const form = (
     <PasswordForm
       handleSubmitCallback={handleSubmitCallback}
-      setStep={() => setPage(2)}
+      setStep={setPage}
       setValue={setValue}
       version="TeacherSignup"
     />

--- a/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
+++ b/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
@@ -21,7 +21,7 @@ const TeacherSignupFour = ({
   const form = (
     <PasswordForm
       handleSubmitCallback={handleSubmitCallback}
-      setStep={setPage}
+      setStep={() => setPage(2)}
       setValue={setValue}
       version="TeacherSignup"
     />


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix teacher signup back button](https://www.notion.so/uwblueprintexecs/Fix-teacher-signup-back-button-eb564f02bc854ce0b2d9054250e16601)


Teacher signup page 4 back button goes to page 3 instead of page 2


It should go back to page 2

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
