### PR TITLE
backend: Compute Submission Count

### DIFF
--- a/backend/services/implementations/__tests__/statisticService.test.ts
+++ b/backend/services/implementations/__tests__/statisticService.test.ts
@@ -87,13 +87,20 @@ describe("mongo statisticService", (): void => {
     expect(actualResult).toEqual(expectedResult);
   });
 
-  it("getSubmissionCountByTest", async () => {
+  it("getSubmissionCountByTest with multiple submissions", async () => {
     await MgTestSession.insertMany(mockTestSessions);
 
     const actualResult = await statisticService.getSubmissionCountByTest(
       mockTestWithId.id,
     );
     expect(actualResult).toEqual(13);
+  });
+
+  it("getSubmissionCountByTest with 0 submissions", async () => {
+    const actualResult = await statisticService.getSubmissionCountByTest(
+      mockTestWithId.id,
+    );
+    expect(actualResult).toEqual(0);
   });
 
   it("getTestGradeStatisticsBySchool", async () => {

--- a/backend/services/implementations/__tests__/statisticService.test.ts
+++ b/backend/services/implementations/__tests__/statisticService.test.ts
@@ -87,6 +87,15 @@ describe("mongo statisticService", (): void => {
     expect(actualResult).toEqual(expectedResult);
   });
 
+  it("getSubmissionCountByTest", async () => {
+    await MgTestSession.insertMany(mockTestSessions);
+
+    const actualResult = await statisticService.getSubmissionCountByTest(
+      mockTestWithId.id,
+    );
+    expect(actualResult).toEqual(13);
+  });
+
   it("getTestGradeStatisticsBySchool", async () => {
     await MgTestSession.insertMany(mockTestSessions);
 

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -1,10 +1,17 @@
-import { Types } from "mongoose";
-import MgTestSession, { GradingStatus } from "../../models/testSession.model";
+import MgTestSession from "../../models/testSession.model";
 import {
   IStatisticService,
   QuestionStatistic,
   TestStatistic,
 } from "../interfaces/statisticService";
+import {
+  countTestSubmissions,
+  filterTestsByTestIdQuery,
+  filterUngradedTests,
+  getDocumentsBySchoolId,
+  groupResultsById,
+  unwindResults,
+} from "../../utilities/pipelineQueryUtils";
 
 class StatisticService implements IStatisticService {
   /* eslint-disable class-methods-use-this */
@@ -13,51 +20,20 @@ class StatisticService implements IStatisticService {
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
       // Stage 1: filter out tests that have the requested testId
-      { $match: { test: { $eq: Types.ObjectId(testId) } } },
+      filterTestsByTestIdQuery(testId),
 
       // Stage 2: filter out results that are not graded
-      {
-        $project: {
-          results: {
-            $filter: {
-              input: "$results",
-              as: "results",
-              cond: {
-                $eq: [
-                  "$$results.gradingStatus",
-                  GradingStatus.GRADED.toString(),
-                ],
-              },
-            },
-          },
-          school: 1,
-        },
-      },
+      filterUngradedTests,
 
-      // Stage 3: unwind on the results field so that there is a document for each student result
-      { $unwind: "$results" },
+      // Stage 3: unwind on the results field so that there is a do cument for each student result
+      unwindResults,
 
       // Stage 4: get school documents corresponding to the school id
-      {
-        $lookup: {
-          from: "schools",
-          localField: "school",
-          foreignField: "_id",
-          as: "school",
-        },
-      },
+      getDocumentsBySchoolId,
 
       // Stage 5: group together documents by the school country and keep track of the
       // result breakdown array so that the average grade per question can be computed
-      {
-        $group: {
-          _id: "$school.country",
-          averageScore: { $avg: "$results.score" },
-          resultBreakdowns: {
-            $push: "$results.breakdown",
-          },
-        },
-      },
+      groupResultsById("$school.country"),
     ];
 
     const aggCursor = await MgTestSession.aggregate(pipeline);
@@ -70,41 +46,17 @@ class StatisticService implements IStatisticService {
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
       // Stage 1: match tests that have the requested testId
-      { $match: { test: { $eq: Types.ObjectId(testId) } } },
+      filterTestsByTestIdQuery(testId),
 
       // Stage 2: filter out results that are not graded
-      {
-        $project: {
-          results: {
-            $filter: {
-              input: "$results",
-              as: "results",
-              cond: {
-                $eq: [
-                  "$$results.gradingStatus",
-                  GradingStatus.GRADED.toString(),
-                ],
-              },
-            },
-          },
-          school: 1,
-        },
-      },
+      filterUngradedTests,
 
       // Stage 3: unwind on the results field so that there is a document for each student result
-      { $unwind: "$results" },
+      unwindResults,
 
       // Stage 4: group together documents by the school id and keep track of the
       // result breakdown array so that the average grade per question can be computed
-      {
-        $group: {
-          _id: "$school",
-          averageScore: { $avg: "$results.score" },
-          resultBreakdowns: {
-            $push: "$results.breakdown",
-          },
-        },
-      },
+      groupResultsById("$school"),
     ];
 
     const aggCursor = await MgTestSession.aggregate(pipeline);
@@ -116,36 +68,21 @@ class StatisticService implements IStatisticService {
   async getSubmissionCountByTest(testId: string): Promise<number> {
     const pipeline = [
       // Stage 1: filter out tests that have the requested testId
-      { $match: { test: { $eq: Types.ObjectId(testId) } } },
+      filterTestsByTestIdQuery(testId),
 
       // Stage 2: filter out results that are not graded
-      {
-        $project: {
-          results: {
-            $filter: {
-              input: "$results",
-              as: "results",
-              cond: {
-                $eq: [
-                  "$$results.gradingStatus",
-                  GradingStatus.GRADED.toString(),
-                ],
-              },
-            },
-          },
-        },
-      },
+      filterUngradedTests,
 
       // Stage 3: unwind on the results field so that there is a document for each student result
-      { $unwind: "$results" },
+      unwindResults,
 
       // Stage 4: counts number of graded tests
-      { $count: "numSubmittedTests" },
+      countTestSubmissions,
     ];
 
     const aggCursor = await MgTestSession.aggregate(pipeline);
 
-    return aggCursor[0]?.numSubmittedTests || 0;
+    return aggCursor[0]?.numSubmittedTests ?? 0;
   }
 
   private getAverageScorePerQuestion(

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -6,9 +6,9 @@ import {
 } from "../interfaces/statisticService";
 import {
   countTestSubmissions,
-  filterTestsByTestIdQuery,
+  filterTestsByTestId,
   filterUngradedTests,
-  getDocumentsBySchoolId,
+  joinSchoolIdWithSchoolDocument,
   groupResultsById,
   unwindResults,
 } from "../../utilities/pipelineQueryUtils";
@@ -19,20 +19,14 @@ class StatisticService implements IStatisticService {
     testId: string,
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
-      // Stage 1: filter out tests that have the requested testId
-      filterTestsByTestIdQuery(testId),
+      filterTestsByTestId(testId),
 
-      // Stage 2: filter out results that are not graded
       filterUngradedTests,
 
-      // Stage 3: unwind on the results field so that there is a do cument for each student result
       unwindResults,
 
-      // Stage 4: get school documents corresponding to the school id
-      getDocumentsBySchoolId,
+      joinSchoolIdWithSchoolDocument,
 
-      // Stage 5: group together documents by the school country and keep track of the
-      // result breakdown array so that the average grade per question can be computed
       groupResultsById("$school.country"),
     ];
 
@@ -45,17 +39,12 @@ class StatisticService implements IStatisticService {
     testId: string,
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
-      // Stage 1: match tests that have the requested testId
-      filterTestsByTestIdQuery(testId),
+      filterTestsByTestId(testId),
 
-      // Stage 2: filter out results that are not graded
       filterUngradedTests,
 
-      // Stage 3: unwind on the results field so that there is a document for each student result
       unwindResults,
 
-      // Stage 4: group together documents by the school id and keep track of the
-      // result breakdown array so that the average grade per question can be computed
       groupResultsById("$school"),
     ];
 
@@ -67,16 +56,12 @@ class StatisticService implements IStatisticService {
   /* eslint-disable class-methods-use-this */
   async getSubmissionCountByTest(testId: string): Promise<number> {
     const pipeline = [
-      // Stage 1: filter out tests that have the requested testId
-      filterTestsByTestIdQuery(testId),
+      filterTestsByTestId(testId),
 
-      // Stage 2: filter out results that are not graded
       filterUngradedTests,
 
-      // Stage 3: unwind on the results field so that there is a document for each student result
       unwindResults,
 
-      // Stage 4: counts number of graded tests
       countTestSubmissions,
     ];
 

--- a/backend/services/implementations/statisticService.ts
+++ b/backend/services/implementations/statisticService.ts
@@ -20,13 +20,14 @@ class StatisticService implements IStatisticService {
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
       filterTestsByTestId(testId),
-
-      filterUngradedTests,
-
+      {
+        $project: {
+          results: filterUngradedTests,
+          school: 1,
+        },
+      },
       unwindResults,
-
       joinSchoolIdWithSchoolDocument,
-
       groupResultsById("$school.country"),
     ];
 
@@ -40,11 +41,13 @@ class StatisticService implements IStatisticService {
   ): Promise<Map<string, TestStatistic>> {
     const pipeline = [
       filterTestsByTestId(testId),
-
-      filterUngradedTests,
-
+      {
+        $project: {
+          results: filterUngradedTests,
+          school: 1,
+        },
+      },
       unwindResults,
-
       groupResultsById("$school"),
     ];
 
@@ -57,11 +60,12 @@ class StatisticService implements IStatisticService {
   async getSubmissionCountByTest(testId: string): Promise<number> {
     const pipeline = [
       filterTestsByTestId(testId),
-
-      filterUngradedTests,
-
+      {
+        $project: {
+          results: filterUngradedTests,
+        },
+      },
       unwindResults,
-
       countTestSubmissions,
     ];
 

--- a/backend/services/interfaces/statisticService.ts
+++ b/backend/services/interfaces/statisticService.ts
@@ -43,7 +43,7 @@ export interface IStatisticService {
 
   /**
    * This method returns the number of submitted tests for a given test.
-   * The return value is an integer that contains the given number of tests.
+   * The return value is an integer that contains the number of test results.
    *
    * @param testId The unique identifier of the test to obtain statistics for
    */

--- a/backend/services/interfaces/statisticService.ts
+++ b/backend/services/interfaces/statisticService.ts
@@ -40,4 +40,12 @@ export interface IStatisticService {
   getTestGradeStatisticsBySchool(
     testId: string,
   ): Promise<Map<string, TestStatistic>>;
+
+  /**
+   * This method returns the number of submitted tests for a given test.
+   * The return value is an integer that contains the given number of tests.
+   *
+   * @param testId The unique identifier of the test to obtain statistics for
+   */
+  getSubmissionCountByTest(testId: string): Promise<number>;
 }

--- a/backend/utilities/pipelineQueryUtils.ts
+++ b/backend/utilities/pipelineQueryUtils.ts
@@ -20,21 +20,16 @@ export const filterTestsByTestId = (
 
 // Filter out results that are not graded
 export const filterUngradedTests = {
-  $project: {
-    results: {
-      $filter: {
-        input: "$results",
-        as: "results",
-        cond: {
-          $eq: ["$$results.gradingStatus", GradingStatus.GRADED.toString()],
-        },
-      },
+  $filter: {
+    input: "$results",
+    as: "results",
+    cond: {
+      $eq: ["$$results.gradingStatus", GradingStatus.GRADED.toString()],
     },
-    school: 1,
   },
 };
 
-// Unwind on the results field so that there is a do cument for each student result
+// Unwind on the results field so that there is a document for each student result
 export const unwindResults = {
   $unwind: "$results",
 };
@@ -63,7 +58,7 @@ export const groupResultsById = (id: string): GroupResultsByIdReturnType => {
   };
 };
 
-// Counts number of graded tests
+// Stores the number of graded tests in "numSubmittedTests" field
 export const countTestSubmissions = {
   $count: "numSubmittedTests",
 };

--- a/backend/utilities/pipelineQueryUtils.ts
+++ b/backend/utilities/pipelineQueryUtils.ts
@@ -1,14 +1,24 @@
 import { FilterQuery, Types } from "mongoose";
 import { GradingStatus } from "../models/testSession.model";
 
-export const filterTestsByTestIdQuery = (
+type GroupResultsByIdReturnType = {
+  $group: {
+    _id: string;
+    averageScore: { $avg: string };
+    resultBreakdowns: { $push: string };
+  };
+};
+
+// Filter out tests that have the requested testId
+export const filterTestsByTestId = (
   testId: string,
-): FilterQuery<Record<string, any>> => {
+): FilterQuery<Record<string, unknown>> => {
   return {
     $match: { test: { $eq: Types.ObjectId(testId) } },
   };
 };
 
+// Filter out results that are not graded
 export const filterUngradedTests = {
   $project: {
     results: {
@@ -24,11 +34,13 @@ export const filterUngradedTests = {
   },
 };
 
+// Unwind on the results field so that there is a do cument for each student result
 export const unwindResults = {
   $unwind: "$results",
 };
 
-export const getDocumentsBySchoolId = {
+// Get school documents corresponding to the school id
+export const joinSchoolIdWithSchoolDocument = {
   $lookup: {
     from: "schools",
     localField: "school",
@@ -37,7 +49,9 @@ export const getDocumentsBySchoolId = {
   },
 };
 
-export const groupResultsById = (id: string) => {
+// Group together documents by an id and keep track of the
+// result breakdown array so that the average grade per question can be computed
+export const groupResultsById = (id: string): GroupResultsByIdReturnType => {
   return {
     $group: {
       _id: id,
@@ -49,6 +63,7 @@ export const groupResultsById = (id: string) => {
   };
 };
 
+// Counts number of graded tests
 export const countTestSubmissions = {
   $count: "numSubmittedTests",
 };

--- a/backend/utilities/pipelineQueryUtils.ts
+++ b/backend/utilities/pipelineQueryUtils.ts
@@ -1,0 +1,54 @@
+import { FilterQuery, Types } from "mongoose";
+import { GradingStatus } from "../models/testSession.model";
+
+export const filterTestsByTestIdQuery = (
+  testId: string,
+): FilterQuery<Record<string, any>> => {
+  return {
+    $match: { test: { $eq: Types.ObjectId(testId) } },
+  };
+};
+
+export const filterUngradedTests = {
+  $project: {
+    results: {
+      $filter: {
+        input: "$results",
+        as: "results",
+        cond: {
+          $eq: ["$$results.gradingStatus", GradingStatus.GRADED.toString()],
+        },
+      },
+    },
+    school: 1,
+  },
+};
+
+export const unwindResults = {
+  $unwind: "$results",
+};
+
+export const getDocumentsBySchoolId = {
+  $lookup: {
+    from: "schools",
+    localField: "school",
+    foreignField: "_id",
+    as: "school",
+  },
+};
+
+export const groupResultsById = (id: string) => {
+  return {
+    $group: {
+      _id: id,
+      averageScore: { $avg: "$results.score" },
+      resultBreakdowns: {
+        $push: "$results.breakdown",
+      },
+    },
+  };
+};
+
+export const countTestSubmissions = {
+  $count: "numSubmittedTests",
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Compute Submission Count](https://www.notion.so/uwblueprintexecs/47bf4727a2444bccad4a91952898b8f3?v=9658436bf9be409e90581631a7155f16&p=ac9ba6f20c244de9b727beed96d0d511&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented a function in `statisticService.ts` to compute the number of test submissions
* Created `pipelineQueryUtils.ts` and refactored respective functions


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test values with the mock test sessions


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensuring function work as intended
* Refactoring is cohesive and names are comprehensive


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
