### PR TITLE
feat: Update createTestSession to store reference in related class

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -92,6 +92,7 @@ const graphQLMiddlewares = {
     archiveTest: authorizedByAdmin(),
     createClass: authorizedByAllRoles(),
     createStudent: authorizedByAllRoles(),
+    createTestSession: authorizedByAllRoles(),
   },
 };
 

--- a/backend/graphql/resolvers/testSessionResolvers.ts
+++ b/backend/graphql/resolvers/testSessionResolvers.ts
@@ -63,9 +63,12 @@ const testSessionResolvers = {
   Mutation: {
     createTestSession: async (
       _req: undefined,
-      { testSession }: { testSession: TestSessionRequestDTO },
+      {
+        classId,
+        testSession,
+      }: { classId: string; testSession: TestSessionRequestDTO },
     ): Promise<TestSessionResponseDTO> => {
-      return testSessionService.createTestSession({ ...testSession });
+      return testSessionService.createTestSession(classId, testSession);
     },
   },
 };

--- a/backend/graphql/types/testSessionType.ts
+++ b/backend/graphql/types/testSessionType.ts
@@ -42,7 +42,7 @@ const testSessionType = gql`
     teacher: ID!
     school: ID!
     gradeLevel: Int!
-    results: [ResultRequestDTO]!
+    results: [ResultRequestDTO]
     accessCode: String!
     startTime: Date!
   }
@@ -55,6 +55,7 @@ const testSessionType = gql`
 
   extend type Mutation {
     createTestSession(
+      classId: String!
       testSession: TestSessionRequestDTO!
     ): TestSessionResponseDTO!
   }

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -3,6 +3,7 @@ import TestSessionService from "../testSessionService";
 import db from "../../../testUtils/testDb";
 
 import MgTestSession from "../../../models/testSession.model";
+import MgClass, { Class } from "../../../models/class.model";
 import {
   assertResponseMatchesExpected,
   assertResultsResponseMatchesExpected,
@@ -20,6 +21,7 @@ import { mockTestWithId, mockTestWithId2 } from "../../../testUtils/tests";
 import { mockSchoolWithId } from "../../../testUtils/school";
 import SchoolService from "../schoolService";
 import { mockTeacher, testUsers } from "../../../testUtils/users";
+import { testClassAfterCreation } from "../../../testUtils/class";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
@@ -56,11 +58,32 @@ describe("mongo testSessionService", (): void => {
     await db.clear();
   });
 
-  it("createTestSession", async () => {
-    const res = await testSessionService.createTestSession(mockTestSession);
+  it("createTestSession for valid class id", async () => {
+    const classObj: Class = await MgClass.create(testClassAfterCreation);
+    const res = await testSessionService.createTestSession(
+      classObj.id,
+      mockTestSession,
+    );
 
     assertResponseMatchesExpected(mockTestSession, res);
     expect(res.results).toBeUndefined();
+
+    const updatedClass: Class = (await MgClass.findById(classObj.id))!;
+    expect(
+      Array.from(updatedClass.testSessions).map((id) => id.toString()),
+    ).toEqual([res.id]);
+  });
+
+  it("createTestSession for invalid class id", async () => {
+    const invalidClassId = "62c248c0f79d6c3c9ebbea92";
+    await expect(async () => {
+      await testSessionService.createTestSession(
+        invalidClassId,
+        mockTestSession,
+      );
+    }).rejects.toThrowError(
+      `Test session could not be added to class with id ${invalidClassId}`,
+    );
   });
 
   it("getAllTestSessions", async () => {

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -110,11 +110,13 @@ export interface ResultResponseDTO {
 export interface ITestSessionService {
   /**
    * create a TestSession with the fields given in the DTO, return created TestSession
+   * @param classId id of the class to create the TestSession in
    * @param testSession new testSession
    * @returns the created TestSession
    * @throws Error if creation fails
    */
   createTestSession(
+    classId: string,
     testSession: TestSessionRequestDTO,
   ): Promise<TestSessionResponseDTO>;
 

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -110,7 +110,7 @@ export interface ResultResponseDTO {
 export interface ITestSessionService {
   /**
    * create a TestSession with the fields given in the DTO, return created TestSession
-   * @param classId id of the class to create the TestSession in
+   * @param id of the class taking the test session
    * @param testSession new testSession
    * @returns the created TestSession
    * @throws Error if creation fails

--- a/backend/testUtils/class.ts
+++ b/backend/testUtils/class.ts
@@ -34,14 +34,12 @@ export const updatedTestStudents: StudentRequestDTO[] = [
 
 export const testStudentsWithIds: StudentResponseDTO[] = [
   {
+    ...testStudents[0],
     id: "6421bf4b8c29e57d38efc7bd",
-    firstName: "David",
-    lastName: "Liu",
   },
   {
+    ...testStudents[1],
     id: "6421bf4b8c29e57d38efc7be",
-    firstName: "Calvin",
-    lastName: "Zhang",
   },
 ];
 // set up test classes
@@ -100,6 +98,12 @@ export const mockClassWithId = {
 export const mockClassWithId2 = {
   ...mockClassWithId,
   id: "62c248c0f79d6c3c9ebbea92",
+};
+
+export const testClassAfterCreation = {
+  ...testClass[0],
+  students: [],
+  testSessions: [],
 };
 
 export const assertResponseMatchesExpected = (

--- a/frontend/src/APIClients/mutations/TestSessionMutations.ts
+++ b/frontend/src/APIClients/mutations/TestSessionMutations.ts
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+const CREATE_TEST_SESSION = gql`
+  mutation CreateTestSession(
+    $classId: String!
+    $testSession: TestSessionRequestDTO!
+  ) {
+    createTestSession(classId: $classId, testSession: $testSession) {
+      id
+    }
+  }
+`;
+
+export default CREATE_TEST_SESSION;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update createTestSession logic to store reference in related class](https://www.notion.so/uwblueprintexecs/Update-createTestSession-logic-to-store-reference-in-related-class-97096434af6b43179bc4310f9cb04bb3?pvs=4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* I added the function directly in TestSessionService, which is a bit not ideal since it directly uses MgClass, but the two services would otherwise have a circular dependency. And I don't think we need to store a class service within test session


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. yarn test
2. GraphQL

<img width="992" alt="image" src="https://user-images.githubusercontent.com/69697180/235534397-cfd410d3-645d-4d2e-80c1-203b48037647.png">
(second test session)
<img width="370" alt="image" src="https://user-images.githubusercontent.com/69697180/235534427-3873659b-d30b-45ee-83af-94068e9b12ba.png">



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
