### PR TITLE
feat: refactor publishTest and archiveTest

### DIFF
--- a/backend/graphql/resolvers/testResolvers.ts
+++ b/backend/graphql/resolvers/testResolvers.ts
@@ -1,6 +1,5 @@
 import TestService from "../../services/implementations/testService";
 import {
-  AssessmentStatus,
   QuestionComponent,
   QuestionComponentMetadata,
 } from "../../models/test.model";

--- a/backend/graphql/resolvers/testResolvers.ts
+++ b/backend/graphql/resolvers/testResolvers.ts
@@ -138,15 +138,7 @@ const testResolvers = {
       _req: undefined,
       { id }: { id: string },
     ): Promise<TestResponseDTO | null> => {
-      const testToUpdate = await testService.getTestById(id);
-      if (testToUpdate.status !== AssessmentStatus.DRAFT) {
-        throw new Error(`Test with id ${id} cannot be published.`);
-      }
-      const updatedTest = await testService.updateTest(id, {
-        ...testToUpdate,
-        status: AssessmentStatus.PUBLISHED,
-      });
-      return updatedTest;
+      return testService.publishTest(id);
     },
     duplicateTest: async (
       _req: undefined,
@@ -164,18 +156,7 @@ const testResolvers = {
       _req: undefined,
       { id }: { id: string },
     ): Promise<TestResponseDTO | null> => {
-      const testToUpdate = await testService.getTestById(id);
-      if (
-        testToUpdate.status !== AssessmentStatus.DRAFT &&
-        testToUpdate.status !== AssessmentStatus.PUBLISHED
-      ) {
-        throw new Error(`Test with id ${id} cannot be archived.`);
-      }
-      const updatedTest = await testService.updateTest(id, {
-        ...testToUpdate,
-        status: AssessmentStatus.ARCHIVED,
-      });
-      return updatedTest;
+      return testService.archiveTest(id);
     },
   },
 };

--- a/backend/services/implementations/__tests__/statisticService.test.ts
+++ b/backend/services/implementations/__tests__/statisticService.test.ts
@@ -109,7 +109,7 @@ describe("mongo statisticService", (): void => {
     const actualResult = await statisticService.getMeanScoreByTest(
       mockTestWithId.id,
     );
-    expect(actualResult).toEqual(57.69);
+    expect(actualResult).toEqual(50.77);
   });
 
   it("getMeanScoreByTest with 0 submissions", async () => {

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -2,19 +2,18 @@ import TestService from "../testService";
 
 import db from "../../../testUtils/testDb";
 
-import MgTest, {
-  AssessmentStatus,
-  AssessmentType,
-  Test,
-} from "../../../models/test.model";
+import MgTest, { AssessmentStatus, Test } from "../../../models/test.model";
 import {
   assertResponseMatchesExpected,
+  mockArchivedTest,
+  mockDeletedTest,
+  mockPublishedTest,
   mockTest,
+  mockTest2,
   mockTestArray,
-  questions,
+  mockTestWithId2,
 } from "../../../testUtils/tests";
-import { TestResponseDTO, TestRequestDTO } from "../../interfaces/testService";
-import { Grade } from "../../../types";
+import { TestResponseDTO } from "../../interfaces/testService";
 
 describe("mongo testService", (): void => {
   let testService: TestService;
@@ -55,20 +54,9 @@ describe("mongo testService", (): void => {
     // insert test into database
     const createdTest = await MgTest.create(mockTest);
 
-    // create DTO object to update to
-    const testUpdate: TestRequestDTO = {
-      name: "newTest",
-      questions,
-      grade: Grade.GRADE_8,
-      assessmentType: AssessmentType.END,
-      curriculumCountry: "country",
-      curriculumRegion: "region",
-      status: AssessmentStatus.DRAFT,
-    };
-
     // update test and assert
-    const res = await testService.updateTest(createdTest.id, testUpdate);
-    assertResponseMatchesExpected(testUpdate, res);
+    const res = await testService.updateTest(createdTest.id, mockTest2);
+    assertResponseMatchesExpected(mockTestWithId2, res);
   });
 
   it("getTestById", async () => {
@@ -92,49 +80,30 @@ describe("mongo testService", (): void => {
     const test = await MgTest.create(mockTest);
 
     const publishedTest = await testService.publishTest(test.id);
-    assertResponseMatchesExpected(
-      {
-        ...mockTest,
-        status: AssessmentStatus.PUBLISHED,
-      },
-      publishedTest,
-    );
+    assertResponseMatchesExpected(mockPublishedTest, publishedTest);
     expect(test.id).toEqual(publishedTest.id);
   });
 
   it("duplicateTest", async () => {
-    const test = await MgTest.create({
-      ...mockTest,
-      status: AssessmentStatus.PUBLISHED,
-    });
+    const test = await MgTest.create(mockPublishedTest);
 
     const duplicateTest = await testService.duplicateTest(test.id);
     assertResponseMatchesExpected(mockTest, duplicateTest);
     expect(test.id).not.toEqual(duplicateTest.id);
 
     const originalTest = await testService.getTestById(test.id);
-    assertResponseMatchesExpected(test, originalTest);
+    assertResponseMatchesExpected(mockPublishedTest, originalTest);
     expect(test.id).toEqual(originalTest.id);
   });
 
   it("unarchiveTest", async () => {
-    const test = await MgTest.create({
-      ...mockTest,
-      status: AssessmentStatus.ARCHIVED,
-    });
+    const test = await MgTest.create(mockArchivedTest);
 
     const unarchivedTest = await testService.unarchiveTest(test.id);
-    assertResponseMatchesExpected(
-      {
-        ...mockTest,
-        status: AssessmentStatus.DRAFT,
-      },
-      unarchivedTest,
-    );
+    assertResponseMatchesExpected(mockTest, unarchivedTest);
     expect(test.id).not.toEqual(unarchivedTest.id);
 
     const originalTest = await MgTest.findById(test.id);
-    // TODO: update this to be soft delete instead of hard delete
     expect(originalTest?.status).toBe(AssessmentStatus.DELETED);
   });
 
@@ -142,13 +111,7 @@ describe("mongo testService", (): void => {
     const test = await MgTest.create(mockTest);
 
     const archivedTest = await testService.archiveTest(test.id);
-    assertResponseMatchesExpected(
-      {
-        ...mockTest,
-        status: AssessmentStatus.ARCHIVED,
-      },
-      archivedTest,
-    );
+    assertResponseMatchesExpected(mockArchivedTest, archivedTest);
     expect(test.id).toEqual(archivedTest.id);
   });
 
@@ -161,7 +124,7 @@ describe("mongo testService", (): void => {
       }).rejects.toThrowError(`Test ${notFoundId} not found`);
     });
 
-    it("updateTest for non-existing ID", async () => {
+    it("updateTest", async () => {
       await expect(async () => {
         await testService.updateTest(notFoundId, mockTest);
       }).rejects.toThrowError(`Test with id ${notFoundId} not found`);
@@ -205,10 +168,7 @@ describe("mongo testService", (): void => {
   describe("invalid status", () => {
     let test: Test;
     beforeEach(async () => {
-      test = await MgTest.create({
-        ...mockTest,
-        status: AssessmentStatus.DELETED,
-      });
+      test = await MgTest.create(mockDeletedTest);
     });
 
     it("publishTest", async () => {

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -5,6 +5,7 @@ import db from "../../../testUtils/testDb";
 import MgTest, {
   AssessmentStatus,
   AssessmentType,
+  Test,
 } from "../../../models/test.model";
 import {
   assertResponseMatchesExpected,
@@ -41,7 +42,6 @@ describe("mongo testService", (): void => {
 
   it("createTest", async () => {
     const res = await testService.createTest(mockTest);
-
     assertResponseMatchesExpected(mockTest, res);
   });
 
@@ -49,13 +49,6 @@ describe("mongo testService", (): void => {
     const savedTest = await MgTest.create(mockTest);
     const deletedTestId = await testService.deleteTest(savedTest.id);
     expect(deletedTestId).toBe(savedTest.id);
-  });
-
-  it("deleteTest not found", async () => {
-    const notFoundId = "62c248c0f79d6c3c9ebbea95";
-    expect(testService.deleteTest(notFoundId)).rejects.toThrowError(
-      `Test ${notFoundId} not found`,
-    );
   });
 
   it("updateTest", async () => {
@@ -78,42 +71,12 @@ describe("mongo testService", (): void => {
     assertResponseMatchesExpected(testUpdate, res);
   });
 
-  it("updateTest for non-existing ID", async () => {
-    // insert test into database
-    await MgTest.create(mockTest);
-
-    // create DTO object to update to
-    const testUpdate: TestRequestDTO = {
-      name: "newTest",
-      questions,
-      grade: Grade.GRADE_8,
-      assessmentType: AssessmentType.END,
-      curriculumCountry: "country",
-      curriculumRegion: "region",
-      status: AssessmentStatus.DRAFT,
-    };
-
-    const notFoundId = "62c248c0f79d6c3c9ebbea95";
-
-    // update test and assert
-    await expect(async () => {
-      await testService.updateTest(notFoundId, testUpdate);
-    }).rejects.toThrowError(`Test with id ${notFoundId} not found`);
-  });
-
   it("getTestById", async () => {
     const test = await MgTest.create(mockTest);
     const res = await testService.getTestById(test.id);
 
     expect(res.id).toEqual(test.id);
     assertResponseMatchesExpected(mockTest, res);
-  });
-
-  it("getTestById id not found", async () => {
-    const testId = "62c248c0f79d6c3c9ebbea93";
-    await expect(async () => {
-      await testService.getTestById(testId);
-    }).rejects.toThrowError(`Test ID ${testId} not found`);
   });
 
   it("getAllTests", async () => {
@@ -123,6 +86,20 @@ describe("mongo testService", (): void => {
     res.forEach((test: TestResponseDTO, i) => {
       assertResponseMatchesExpected(mockTestArray[i], test);
     });
+  });
+
+  it("publishTest", async () => {
+    const test = await MgTest.create(mockTest);
+
+    const publishedTest = await testService.publishTest(test.id);
+    assertResponseMatchesExpected(
+      {
+        ...mockTest,
+        status: AssessmentStatus.PUBLISHED,
+      },
+      publishedTest,
+    );
+    expect(test.id).toEqual(publishedTest.id);
   });
 
   it("duplicateTest", async () => {
@@ -140,7 +117,7 @@ describe("mongo testService", (): void => {
     expect(test.id).toEqual(originalTest.id);
   });
 
-  it("unarchiveTest - success", async () => {
+  it("unarchiveTest", async () => {
     const test = await MgTest.create({
       ...mockTest,
       status: AssessmentStatus.ARCHIVED,
@@ -161,11 +138,99 @@ describe("mongo testService", (): void => {
     expect(originalTest?.status).toBe(AssessmentStatus.DELETED);
   });
 
-  it("unarchiveTest - fail", async () => {
+  it("archiveTest", async () => {
     const test = await MgTest.create(mockTest);
-    await expect(async () => {
-      await testService.unarchiveTest(test.id);
-    }).rejects.toThrow(`Test ID ${test.id} is not in archived status`);
-    assertResponseMatchesExpected(mockTest, test);
+
+    const archivedTest = await testService.archiveTest(test.id);
+    assertResponseMatchesExpected(
+      {
+        ...mockTest,
+        status: AssessmentStatus.ARCHIVED,
+      },
+      archivedTest,
+    );
+    expect(test.id).toEqual(archivedTest.id);
+  });
+
+  describe("invalid id", () => {
+    const notFoundId = "62c248c0f79d6c3c9ebbea95";
+
+    it("deleteTest", async () => {
+      await expect(async () => {
+        await testService.deleteTest(notFoundId);
+      }).rejects.toThrowError(`Test ${notFoundId} not found`);
+    });
+
+    it("updateTest for non-existing ID", async () => {
+      await expect(async () => {
+        await testService.updateTest(notFoundId, mockTest);
+      }).rejects.toThrowError(`Test with id ${notFoundId} not found`);
+    });
+
+    it("getTestById", async () => {
+      await expect(async () => {
+        await testService.getTestById(notFoundId);
+      }).rejects.toThrowError(`Test ID ${notFoundId} not found`);
+    });
+
+    it("publishTest", async () => {
+      await expect(async () => {
+        await testService.publishTest(notFoundId);
+      }).rejects.toThrowError(
+        `Test with ID ${notFoundId} is not found or not in draft status`,
+      );
+    });
+
+    it("duplicateTest", async () => {
+      await expect(async () => {
+        await testService.duplicateTest(notFoundId);
+      }).rejects.toThrowError(`Test ID ${notFoundId} not found`);
+    });
+
+    it("unarchiveTest", async () => {
+      await expect(async () => {
+        await testService.unarchiveTest(notFoundId);
+      }).rejects.toThrowError(`Test ID ${notFoundId} not found`);
+    });
+
+    it("archiveTest", async () => {
+      await expect(async () => {
+        await testService.archiveTest(notFoundId);
+      }).rejects.toThrowError(
+        `Test with ID ${notFoundId} is not found or not in draft / published status`,
+      );
+    });
+  });
+
+  describe("invalid status", () => {
+    let test: Test;
+    beforeEach(async () => {
+      test = await MgTest.create({
+        ...mockTest,
+        status: AssessmentStatus.DELETED,
+      });
+    });
+
+    it("publishTest", async () => {
+      await expect(async () => {
+        await testService.publishTest(test.id);
+      }).rejects.toThrowError(
+        `Test with ID ${test.id} is not found or not in draft status`,
+      );
+    });
+
+    it("unarchiveTest", async () => {
+      await expect(async () => {
+        await testService.unarchiveTest(test.id);
+      }).rejects.toThrowError(`Test ID ${test.id} is not in archived status`);
+    });
+
+    it("archiveTest", async () => {
+      await expect(async () => {
+        await testService.archiveTest(test.id);
+      }).rejects.toThrowError(
+        `Test with ID ${test.id} is not found or not in draft / published status`,
+      );
+    });
   });
 });

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -2,18 +2,19 @@ import TestService from "../testService";
 
 import db from "../../../testUtils/testDb";
 
-import MgTest, { AssessmentStatus, Test } from "../../../models/test.model";
+import MgTest, {
+  AssessmentStatus,
+  AssessmentType,
+  Test,
+} from "../../../models/test.model";
 import {
   assertResponseMatchesExpected,
-  mockArchivedTest,
-  mockDeletedTest,
-  mockPublishedTest,
   mockTest,
-  mockTest2,
   mockTestArray,
-  mockTestWithId2,
+  questions,
 } from "../../../testUtils/tests";
-import { TestResponseDTO } from "../../interfaces/testService";
+import { TestResponseDTO, TestRequestDTO } from "../../interfaces/testService";
+import { Grade } from "../../../types";
 
 describe("mongo testService", (): void => {
   let testService: TestService;
@@ -54,9 +55,20 @@ describe("mongo testService", (): void => {
     // insert test into database
     const createdTest = await MgTest.create(mockTest);
 
+    // create DTO object to update to
+    const testUpdate: TestRequestDTO = {
+      name: "newTest",
+      questions,
+      grade: Grade.GRADE_8,
+      assessmentType: AssessmentType.END,
+      curriculumCountry: "country",
+      curriculumRegion: "region",
+      status: AssessmentStatus.DRAFT,
+    };
+
     // update test and assert
-    const res = await testService.updateTest(createdTest.id, mockTest2);
-    assertResponseMatchesExpected(mockTestWithId2, res);
+    const res = await testService.updateTest(createdTest.id, testUpdate);
+    assertResponseMatchesExpected(testUpdate, res);
   });
 
   it("getTestById", async () => {
@@ -80,30 +92,49 @@ describe("mongo testService", (): void => {
     const test = await MgTest.create(mockTest);
 
     const publishedTest = await testService.publishTest(test.id);
-    assertResponseMatchesExpected(mockPublishedTest, publishedTest);
+    assertResponseMatchesExpected(
+      {
+        ...mockTest,
+        status: AssessmentStatus.PUBLISHED,
+      },
+      publishedTest,
+    );
     expect(test.id).toEqual(publishedTest.id);
   });
 
   it("duplicateTest", async () => {
-    const test = await MgTest.create(mockPublishedTest);
+    const test = await MgTest.create({
+      ...mockTest,
+      status: AssessmentStatus.PUBLISHED,
+    });
 
     const duplicateTest = await testService.duplicateTest(test.id);
     assertResponseMatchesExpected(mockTest, duplicateTest);
     expect(test.id).not.toEqual(duplicateTest.id);
 
     const originalTest = await testService.getTestById(test.id);
-    assertResponseMatchesExpected(mockPublishedTest, originalTest);
+    assertResponseMatchesExpected(test, originalTest);
     expect(test.id).toEqual(originalTest.id);
   });
 
   it("unarchiveTest", async () => {
-    const test = await MgTest.create(mockArchivedTest);
+    const test = await MgTest.create({
+      ...mockTest,
+      status: AssessmentStatus.ARCHIVED,
+    });
 
     const unarchivedTest = await testService.unarchiveTest(test.id);
-    assertResponseMatchesExpected(mockTest, unarchivedTest);
+    assertResponseMatchesExpected(
+      {
+        ...mockTest,
+        status: AssessmentStatus.DRAFT,
+      },
+      unarchivedTest,
+    );
     expect(test.id).not.toEqual(unarchivedTest.id);
 
     const originalTest = await MgTest.findById(test.id);
+    // TODO: update this to be soft delete instead of hard delete
     expect(originalTest?.status).toBe(AssessmentStatus.DELETED);
   });
 
@@ -111,7 +142,13 @@ describe("mongo testService", (): void => {
     const test = await MgTest.create(mockTest);
 
     const archivedTest = await testService.archiveTest(test.id);
-    assertResponseMatchesExpected(mockArchivedTest, archivedTest);
+    assertResponseMatchesExpected(
+      {
+        ...mockTest,
+        status: AssessmentStatus.ARCHIVED,
+      },
+      archivedTest,
+    );
     expect(test.id).toEqual(archivedTest.id);
   });
 
@@ -124,7 +161,7 @@ describe("mongo testService", (): void => {
       }).rejects.toThrowError(`Test ${notFoundId} not found`);
     });
 
-    it("updateTest", async () => {
+    it("updateTest for non-existing ID", async () => {
       await expect(async () => {
         await testService.updateTest(notFoundId, mockTest);
       }).rejects.toThrowError(`Test with id ${notFoundId} not found`);
@@ -168,7 +205,10 @@ describe("mongo testService", (): void => {
   describe("invalid status", () => {
     let test: Test;
     beforeEach(async () => {
-      test = await MgTest.create(mockDeletedTest);
+      test = await MgTest.create({
+        ...mockTest,
+        status: AssessmentStatus.DELETED,
+      });
     });
 
     it("publishTest", async () => {

--- a/backend/services/interfaces/testService.ts
+++ b/backend/services/interfaces/testService.ts
@@ -91,6 +91,14 @@ export interface ITestService {
   getAllTests(): Promise<TestResponseDTO[]>;
 
   /**
+   * publish a Test given the id
+   * @param id string with the test id to be published
+   * @returns a TestResponseDTO with the published test
+   * @throws Error if Test with given id not found or it is not a draft
+   */
+  publishTest(id: string): Promise<TestResponseDTO>;
+
+  /**
    * duplicate a Test given the id
    * @param id string with the test id to be duplicated
    * @returns a TestResponseDTO with the duplicated test
@@ -105,4 +113,12 @@ export interface ITestService {
    * @throws Error if Test with given id not found or if Test is not archived
    */
   unarchiveTest(id: string): Promise<TestResponseDTO>;
+
+  /**
+   * archive a Test given the id
+   * @param id string with the test id to be archived
+   * @returns a TestResponseDTO with the archived test
+   * @throws Error if Test with given id not found or it is not a draft nor published
+   */
+  archiveTest(id: string): Promise<TestResponseDTO>;
 }

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -99,35 +99,15 @@ export const mockTest: TestRequestDTO = {
   status: AssessmentStatus.DRAFT,
 };
 
-export const mockTestArray: Array<TestRequestDTO> = [
-  {
-    name: "test1",
-    questions,
-    grade: Grade.GRADE_8,
-    assessmentType: AssessmentType.END,
-    curriculumCountry: "country1",
-    curriculumRegion: "region1",
-    status: AssessmentStatus.DRAFT,
-  },
-  {
-    name: "test2",
-    questions,
-    grade: Grade.GRADE_8,
-    assessmentType: AssessmentType.END,
-    curriculumCountry: "country2",
-    curriculumRegion: "region1",
-    status: AssessmentStatus.DRAFT,
-  },
-  {
-    name: "test3",
-    questions,
-    grade: Grade.GRADE_8,
-    assessmentType: AssessmentType.END,
-    curriculumCountry: "country2",
-    curriculumRegion: "region2",
-    status: AssessmentStatus.DRAFT,
-  },
-];
+export const mockTest2: TestRequestDTO = {
+  name: "newTest",
+  questions,
+  grade: Grade.GRADE_7,
+  assessmentType: AssessmentType.END,
+  curriculumCountry: "newCountry",
+  curriculumRegion: "newRegion",
+  status: AssessmentStatus.PUBLISHED,
+};
 
 export const mockTestWithId: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea95",
@@ -136,8 +116,28 @@ export const mockTestWithId: TestResponseDTO = {
 
 export const mockTestWithId2: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea90",
-  ...mockTest,
+  ...mockTest2,
 };
+
+export const mockPublishedTest: TestResponseDTO = {
+  ...mockTestWithId,
+  status: AssessmentStatus.PUBLISHED,
+};
+
+export const mockArchivedTest: TestResponseDTO = {
+  ...mockTestWithId,
+  status: AssessmentStatus.ARCHIVED,
+};
+
+export const mockDeletedTest: TestResponseDTO = {
+  ...mockTestWithId,
+  status: AssessmentStatus.DELETED,
+};
+
+export const mockTestArray: Array<TestResponseDTO> = [
+  mockTestWithId,
+  mockTestWithId2,
+];
 
 export const assertResponseMatchesExpected = (
   expected: TestRequestDTO,

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -99,15 +99,35 @@ export const mockTest: TestRequestDTO = {
   status: AssessmentStatus.DRAFT,
 };
 
-export const mockTest2: TestRequestDTO = {
-  name: "newTest",
-  questions,
-  grade: Grade.GRADE_7,
-  assessmentType: AssessmentType.END,
-  curriculumCountry: "newCountry",
-  curriculumRegion: "newRegion",
-  status: AssessmentStatus.PUBLISHED,
-};
+export const mockTestArray: Array<TestRequestDTO> = [
+  {
+    name: "test1",
+    questions,
+    grade: Grade.GRADE_8,
+    assessmentType: AssessmentType.END,
+    curriculumCountry: "country1",
+    curriculumRegion: "region1",
+    status: AssessmentStatus.DRAFT,
+  },
+  {
+    name: "test2",
+    questions,
+    grade: Grade.GRADE_8,
+    assessmentType: AssessmentType.END,
+    curriculumCountry: "country2",
+    curriculumRegion: "region1",
+    status: AssessmentStatus.DRAFT,
+  },
+  {
+    name: "test3",
+    questions,
+    grade: Grade.GRADE_8,
+    assessmentType: AssessmentType.END,
+    curriculumCountry: "country2",
+    curriculumRegion: "region2",
+    status: AssessmentStatus.DRAFT,
+  },
+];
 
 export const mockTestWithId: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea95",
@@ -116,28 +136,8 @@ export const mockTestWithId: TestResponseDTO = {
 
 export const mockTestWithId2: TestResponseDTO = {
   id: "62c248c0f79d6c3c9ebbea90",
-  ...mockTest2,
+  ...mockTest,
 };
-
-export const mockPublishedTest: TestResponseDTO = {
-  ...mockTestWithId,
-  status: AssessmentStatus.PUBLISHED,
-};
-
-export const mockArchivedTest: TestResponseDTO = {
-  ...mockTestWithId,
-  status: AssessmentStatus.ARCHIVED,
-};
-
-export const mockDeletedTest: TestResponseDTO = {
-  ...mockTestWithId,
-  status: AssessmentStatus.DELETED,
-};
-
-export const mockTestArray: Array<TestResponseDTO> = [
-  mockTestWithId,
-  mockTestWithId2,
-];
 
 export const assertResponseMatchesExpected = (
   expected: TestRequestDTO,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Refactor publishTest and archiveTest](https://www.notion.so/uwblueprintexecs/Refactor-publishTest-and-archiveTest-b7c0726b10634af8b87e979d9f8c4c51?pvs=4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Move logic for publishTest and archiveTest from resolvers to service
* Add new tests and refactor unit tests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. yarn test
2. GraphQL

publish
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/69697180/235566690-ce4eefb5-028b-42da-956c-b96d9385225d.png">
<img width="345" alt="image" src="https://user-images.githubusercontent.com/69697180/235566815-277e2f30-59d0-4e63-8a9f-1be68e1edc78.png">

archive
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/69697180/235566865-acff4106-63e9-464f-b514-1d9060efed72.png">
<img width="357" alt="image" src="https://user-images.githubusercontent.com/69697180/235566894-a3ca966f-3779-4b1e-8887-73eb8b447a6a.png">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
