### PR TITLE
feat: assessment editor delete button

### DIFF
--- a/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Flex,
   HStack,
+  IconButton,
   Spacer,
   Text,
   VStack,
@@ -13,6 +14,7 @@ import {
 import { TestRequest } from "../../../APIClients/types/TestClientTypes";
 import {
   EyeOutlineIcon,
+  MoreVerticalOutlineIcon,
   SaveOutlineIcon,
   TextOutlineIcon,
 } from "../../../assets/icons";
@@ -90,6 +92,12 @@ const AssessmentEditorHeader = ({
             >
               Publish
             </Button>
+            <IconButton
+              aria-label="more-vertical-outline"
+              color="blue.700"
+              icon={<MoreVerticalOutlineIcon />}
+              minWidth="10"
+            />
           </HStack>
         </Flex>
       </Box>

--- a/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
@@ -5,21 +5,21 @@ import {
   Button,
   Flex,
   HStack,
-  IconButton,
   Spacer,
   Text,
+  useDisclosure,
   VStack,
 } from "@chakra-ui/react";
 
 import { TestRequest } from "../../../APIClients/types/TestClientTypes";
 import {
   EyeOutlineIcon,
-  MoreVerticalOutlineIcon,
   SaveOutlineIcon,
   TextOutlineIcon,
 } from "../../../assets/icons";
 import { getCurrentDate } from "../../../utils/GeneralUtils";
 import BackButton from "../../common/BackButton";
+import Popover from "../../common/Popover";
 import PublishModal from "../assessment-status/EditStatusModals/PublishModal";
 
 interface AssessmentEditorHeaderProps {
@@ -51,6 +51,8 @@ const AssessmentEditorHeader = ({
   const handleSave = handleSubmit(onSave, onError);
   const handlePublish = handleSubmit(onPublish, onError);
   const handleConfirmPublish = handleSubmit(onConfirmPublish, onError);
+
+  const { onOpen, isOpen, onClose } = useDisclosure();
 
   return (
     <>
@@ -92,12 +94,9 @@ const AssessmentEditorHeader = ({
             >
               Publish
             </Button>
-            <IconButton
-              aria-label="more-vertical-outline"
-              color="blue.700"
-              icon={<MoreVerticalOutlineIcon />}
-              minWidth="10"
-            />
+            <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
+              <Text>hi</Text>
+            </Popover>
           </HStack>
         </Flex>
       </Box>

--- a/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
@@ -58,7 +58,11 @@ const AssessmentEditorHeader = ({
   const handlePublish = handleSubmit(onPublish, onError);
   const handleConfirmPublish = handleSubmit(onConfirmPublish, onError);
 
-  const { onOpen, isOpen, onClose } = useDisclosure();
+  const {
+    onOpen: onOpenPopover,
+    isOpen: popoverIsOpen,
+    onClose: onClosePopover,
+  } = useDisclosure();
 
   return (
     <>
@@ -100,7 +104,11 @@ const AssessmentEditorHeader = ({
             >
               Publish
             </Button>
-            <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
+            <Popover
+              isOpen={popoverIsOpen}
+              onClose={onClosePopover}
+              onOpen={onOpenPopover}
+            >
               <VStack
                 divider={<Divider borderColor="grey.200" />}
                 spacing="0em"
@@ -108,7 +116,7 @@ const AssessmentEditorHeader = ({
                 <EditStatusButton
                   name="Delete"
                   onClick={() => {
-                    onClose();
+                    onClosePopover();
                     setShowDeleteModal(true);
                   }}
                 />

--- a/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/assessments/assessment-creation/AssessmentEditorHeader.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { UseFormHandleSubmit } from "react-hook-form";
+import { useHistory } from "react-router-dom";
 import {
   Box,
   Button,
+  Divider,
   Flex,
   HStack,
   Spacer,
@@ -20,6 +22,8 @@ import {
 import { getCurrentDate } from "../../../utils/GeneralUtils";
 import BackButton from "../../common/BackButton";
 import Popover from "../../common/Popover";
+import EditStatusButton from "../assessment-status/EditStatusButton";
+import DeleteModal from "../assessment-status/EditStatusModals/DeleteModal";
 import PublishModal from "../assessment-status/EditStatusModals/PublishModal";
 
 interface AssessmentEditorHeaderProps {
@@ -41,7 +45,9 @@ const AssessmentEditorHeader = ({
   onError,
   validateForm,
 }: AssessmentEditorHeaderProps): React.ReactElement => {
+  const history = useHistory();
   const [showPublishModal, setShowPublishModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
   const onPublish = () => {
     if (validateForm()) {
       setShowPublishModal(true);
@@ -95,7 +101,18 @@ const AssessmentEditorHeader = ({
               Publish
             </Button>
             <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
-              <Text>hi</Text>
+              <VStack
+                divider={<Divider borderColor="grey.200" />}
+                spacing="0em"
+              >
+                <EditStatusButton
+                  name="Delete"
+                  onClick={() => {
+                    onClose();
+                    setShowDeleteModal(true);
+                  }}
+                />
+              </VStack>
             </Popover>
           </HStack>
         </Flex>
@@ -104,6 +121,11 @@ const AssessmentEditorHeader = ({
         isOpen={showPublishModal}
         onClose={() => setShowPublishModal(false)}
         publishAssessment={handleConfirmPublish}
+      />
+      <DeleteModal
+        deleteAssessment={() => history.goBack()}
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
       />
     </>
   );

--- a/frontend/src/components/assessments/assessment-status/EditStatusButtons/DeleteButton.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusButtons/DeleteButton.tsx
@@ -1,5 +1,9 @@
 import React from "react";
+import { useMutation } from "@apollo/client";
 
+import { DELETE_TEST } from "../../../../APIClients/mutations/TestMutations";
+import { GET_ALL_TESTS } from "../../../../APIClients/queries/TestQueries";
+import Toast from "../../../common/Toast";
 import EditStatusButton from "../EditStatusButton";
 import DeleteModal from "../EditStatusModals/DeleteModal";
 
@@ -14,6 +18,29 @@ const DeleteButton = ({
 }: DeleteButtonProps): React.ReactElement => {
   const [showDeleteModal, setShowDeleteModal] = React.useState(false);
 
+  const [deleteAssessment, { error }] = useMutation<{
+    deleteAssessment: string;
+  }>(DELETE_TEST, {
+    refetchQueries: [{ query: GET_ALL_TESTS }],
+  });
+
+  const { showToast } = Toast();
+
+  const handleDeleteAssessment = async () => {
+    await deleteAssessment({ variables: { id: assessmentId } });
+    if (error) {
+      showToast({
+        message: "Assessment failed to delete. Please try again.",
+        status: "error",
+      });
+    } else {
+      showToast({
+        message: "Assessment deleted.",
+        status: "success",
+      });
+    }
+  };
+
   return (
     <>
       <EditStatusButton
@@ -24,7 +51,7 @@ const DeleteButton = ({
         }}
       />
       <DeleteModal
-        assessmentId={assessmentId}
+        deleteAssessment={handleDeleteAssessment}
         isOpen={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}
       />

--- a/frontend/src/components/assessments/assessment-status/EditStatusModals/DeleteModal.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusModals/DeleteModal.tsx
@@ -1,43 +1,20 @@
 import React from "react";
-import { useMutation } from "@apollo/client";
 
-import { DELETE_TEST } from "../../../../APIClients/mutations/TestMutations";
-import { GET_ALL_TESTS } from "../../../../APIClients/queries/TestQueries";
 import Modal from "../../../common/Modal";
-import Toast from "../../../common/Toast";
 
 interface DeleteModalProps {
   isOpen: boolean;
   onClose: () => void;
-  assessmentId: string;
+  deleteAssessment: () => void;
 }
 
 const DeleteModal = ({
   isOpen,
   onClose,
-  assessmentId,
+  deleteAssessment,
 }: DeleteModalProps): React.ReactElement => {
-  const [deleteAssessment, { error }] = useMutation<{
-    deleteAssessment: string;
-  }>(DELETE_TEST, {
-    refetchQueries: [{ query: GET_ALL_TESTS }],
-  });
-
-  const { showToast } = Toast();
-
-  const onDeleteAssessment = async () => {
-    await deleteAssessment({ variables: { id: assessmentId } });
-    if (error) {
-      showToast({
-        message: "Assessment failed to delete. Please try again.",
-        status: "error",
-      });
-    } else {
-      showToast({
-        message: "Assessment deleted.",
-        status: "success",
-      });
-    }
+  const onDeleteAssessment = () => {
+    deleteAssessment();
     onClose();
   };
 

--- a/frontend/src/components/assessments/assessment-status/EditStatusPopover.tsx
+++ b/frontend/src/components/assessments/assessment-status/EditStatusPopover.tsx
@@ -1,17 +1,8 @@
 import React from "react";
-import {
-  Divider,
-  IconButton,
-  Popover,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
-  useDisclosure,
-  VStack,
-} from "@chakra-ui/react";
+import { Divider, useDisclosure, VStack } from "@chakra-ui/react";
 
-import { MoreVerticalOutlineIcon } from "../../../assets/icons";
 import { Status } from "../../../types/AssessmentTypes";
+import Popover from "../../common/Popover";
 
 import ArchiveButton from "./EditStatusButtons/ArchiveButton";
 import DeleteButton from "./EditStatusButtons/DeleteButton";
@@ -29,65 +20,31 @@ const EditStatusPopover = ({
   assessmentId,
   assessmentStatus,
 }: EditStatusPopoverProps): React.ReactElement => {
-  const { onOpen, onClose, isOpen } = useDisclosure();
-
+  const { onOpen, isOpen, onClose } = useDisclosure();
   return (
-    <Popover
-      isOpen={isOpen}
-      onClose={onClose}
-      onOpen={onOpen}
-      placement="right"
-    >
-      <PopoverTrigger>
-        <IconButton
-          aria-label="more-vertical-outline"
-          icon={<MoreVerticalOutlineIcon boxSize={5} />}
-          size="sm"
-        />
-      </PopoverTrigger>
-      <PopoverContent
-        backgroundColor="grey.100"
-        borderRadius="15%"
-        maxHeight="50%"
-        width="80%"
-      >
-        <PopoverBody>
-          <VStack divider={<Divider borderColor="grey.200" />} spacing="0em">
-            {assessmentStatus === Status.DRAFT && (
-              <>
-                <PublishButton
-                  assessmentId={assessmentId}
-                  closePopover={onClose}
-                />
-                <Divider borderColor="grey.200" />
-                <EditButton
-                  assessmentId={assessmentId}
-                  closePopover={onClose}
-                />
-              </>
-            )}
-            {assessmentStatus === Status.ARCHIVED ? (
-              <UnarchiveButton
-                assessmentId={assessmentId}
-                closePopover={onClose}
-              />
-            ) : (
-              <>
-                <ArchiveButton
-                  assessmentId={assessmentId}
-                  closePopover={onClose}
-                />
-                <Divider borderColor="grey.200" />
-                <DuplicateButton
-                  assessmentId={assessmentId}
-                  closePopover={onClose}
-                />
-              </>
-            )}
-            <DeleteButton assessmentId={assessmentId} closePopover={onClose} />
-          </VStack>
-        </PopoverBody>
-      </PopoverContent>
+    <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
+      <VStack divider={<Divider borderColor="grey.200" />} spacing="0em">
+        {assessmentStatus === Status.DRAFT && (
+          <>
+            <PublishButton assessmentId={assessmentId} closePopover={onClose} />
+            <Divider borderColor="grey.200" />
+            <EditButton assessmentId={assessmentId} closePopover={onClose} />
+          </>
+        )}
+        {assessmentStatus === Status.ARCHIVED ? (
+          <UnarchiveButton assessmentId={assessmentId} closePopover={onClose} />
+        ) : (
+          <>
+            <ArchiveButton assessmentId={assessmentId} closePopover={onClose} />
+            <Divider borderColor="grey.200" />
+            <DuplicateButton
+              assessmentId={assessmentId}
+              closePopover={onClose}
+            />
+          </>
+        )}
+        <DeleteButton assessmentId={assessmentId} closePopover={onClose} />
+      </VStack>
     </Popover>
   );
 };

--- a/frontend/src/components/common/Popover.tsx
+++ b/frontend/src/components/common/Popover.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+  IconButton,
+  Popover as ChakraPopover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+} from "@chakra-ui/react";
+
+import { MoreVerticalOutlineIcon } from "../../assets/icons";
+
+interface PopoverProps {
+  children: React.ReactChild;
+  onOpen: () => void;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const Popover = ({
+  children,
+  onOpen,
+  isOpen,
+  onClose,
+}: PopoverProps): React.ReactElement => {
+  return (
+    <ChakraPopover
+      isOpen={isOpen}
+      onClose={onClose}
+      onOpen={onOpen}
+      placement="right"
+    >
+      <PopoverTrigger>
+        <IconButton
+          aria-label="more-vertical-outline"
+          icon={<MoreVerticalOutlineIcon boxSize={5} />}
+          size="sm"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        backgroundColor="grey.100"
+        borderRadius="15%"
+        maxHeight="50%"
+        width="80%"
+      >
+        <PopoverBody>{children}</PopoverBody>
+      </PopoverContent>
+    </ChakraPopover>
+  );
+};
+
+export default Popover;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete Button for Assessment Editor page](https://www.notion.so/uwblueprintexecs/Delete-button-for-assessment-editor-page-01b41fccd2a741bfbc3897564a362ef7?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added delete button to assessment editor (just closes the page)
* refactored popover to general popover component
Note: the button positioning and styling is a bit off... but that's true for all of our popover buttons. there's another ticket open to fix that (so will do later). the scope of that PR should also be to refactor other existing popovers into using this new `<Popover />` component

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* works as expected
