### PR TITLE
fix: disable the built-in dark mode in the frontend

### DIFF
--- a/frontend/src/themes/index.ts
+++ b/frontend/src/themes/index.ts
@@ -36,6 +36,10 @@ const theme = extendTheme({
     Tag,
     Textarea,
   },
+  config: {
+    initialColorMode: "light",
+    useSystemColorMode: false,
+  },
 });
 
 export default theme;


### PR DESCRIPTION
## Notion ticket link
[Remove dark mode from chakra](https://www.notion.so/uwblueprintexecs/Remove-dark-mode-from-Chakra-1b48773686674cfd9482fc7aad7d9f1e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Config change


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. ?? Open in browser which supports dark mode, try before and after


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
