### PR TITLE
backend: delete images on delete test

### DIFF
--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -81,6 +81,15 @@ class TestService implements ITestService {
         throw new Error(`Test ID ${id} not found`);
       }
       if (testToDelete.status === AssessmentStatus.DRAFT) {
+        try {
+          await this.deleteImages(testToDelete.questions);
+        } catch (imageError) {
+          Logger.error(
+            `Failed to delete test images. Reason = ${getErrorMessage(
+              imageError,
+            )}`,
+          );
+        }
         await MgTest.findByIdAndDelete(id);
       } else {
         await MgTest.findByIdAndUpdate(

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -81,6 +81,7 @@ class TestService implements ITestService {
         throw new Error(`Test ID ${id} not found`);
       }
       if (testToDelete.status === AssessmentStatus.DRAFT) {
+        await MgTest.findByIdAndDelete(id);
         try {
           await this.deleteImages(testToDelete.questions);
         } catch (imageError) {
@@ -90,7 +91,6 @@ class TestService implements ITestService {
             )}`,
           );
         }
-        await MgTest.findByIdAndDelete(id);
       } else {
         await MgTest.findByIdAndUpdate(
           id,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete Images on Delete Test](https://www.notion.so/uwblueprintexecs/Delete-images-on-delete-test-3a33d884a3ef403899a6957b823d539b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `deleteImages` function to `deleteTest`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Ensure images are properly deleted


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
