### PR TITLE
feat: sort assessments by "last updated"

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -19,6 +19,7 @@ import testSessionResolvers from "./resolvers/testSessionResolvers";
 import testSessionType from "./types/testSessionType";
 import classResolvers from "./resolvers/classResolvers";
 import classType from "./types/classType";
+import commonType from "./types/commonType";
 
 const query = gql`
   type Query {
@@ -36,6 +37,7 @@ const executableSchema = makeExecutableSchema({
   typeDefs: [
     query,
     mutation,
+    commonType,
     authType,
     entityType,
     schoolType,

--- a/backend/graphql/types/commonType.ts
+++ b/backend/graphql/types/commonType.ts
@@ -1,0 +1,8 @@
+import { gql } from "apollo-server-express";
+
+const commonType = gql`
+  scalar Date
+  scalar FileUpload
+`;
+
+export default commonType;

--- a/backend/graphql/types/testSessionType.ts
+++ b/backend/graphql/types/testSessionType.ts
@@ -1,8 +1,6 @@
 import { gql } from "apollo-server-express";
 
 const testSessionType = gql`
-  scalar Date
-
   type ResultResponseDTO {
     student: String!
     score: Float!

--- a/backend/graphql/types/testType.ts
+++ b/backend/graphql/types/testType.ts
@@ -51,8 +51,6 @@ const testType = gql`
     text: String!
   }
 
-  scalar FileUpload
-
   input ImageMetadataRequestInput {
     file: FileUpload
     previewUrl: String!
@@ -135,6 +133,7 @@ const testType = gql`
     curriculumCountry: String!
     curriculumRegion: String!
     status: StatusEnum!
+    updatedAt: Date!
   }
 
   input TestRequestDTO {

--- a/backend/models/test.model.ts
+++ b/backend/models/test.model.ts
@@ -35,6 +35,8 @@ export interface Test extends Document {
   curriculumCountry: string;
   /** the region that the test is to be administered in */
   curriculumRegion: string;
+  /** the time the assessment was last updated */
+  updatedAt: Date;
 }
 
 const TestSchema: Schema = new Schema(

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -71,6 +71,7 @@ class TestService implements ITestService {
       curriculumRegion: newTest.curriculumRegion,
       assessmentType: newTest.assessmentType,
       status: newTest.status,
+      updatedAt: newTest.updatedAt,
     };
   }
 
@@ -141,6 +142,7 @@ class TestService implements ITestService {
       curriculumRegion: updatedTest.curriculumRegion,
       assessmentType: updatedTest.assessmentType,
       status: updatedTest.status,
+      updatedAt: updatedTest.updatedAt,
     };
   }
 
@@ -266,6 +268,7 @@ class TestService implements ITestService {
       curriculumRegion: unarchivedTest.curriculumRegion,
       assessmentType: unarchivedTest.assessmentType,
       status: unarchivedTest.status,
+      updatedAt: unarchivedTest.updatedAt,
     };
   }
 
@@ -322,6 +325,7 @@ class TestService implements ITestService {
           curriculumRegion: test.curriculumRegion,
           assessmentType: test.assessmentType,
           status: test.status,
+          updatedAt: test.updatedAt,
         };
       }),
     );

--- a/backend/services/interfaces/testService.ts
+++ b/backend/services/interfaces/testService.ts
@@ -28,6 +28,8 @@ export interface BaseTestDTO<
   curriculumCountry: string;
   /** the region that the test is to be administered in */
   curriculumRegion: string;
+  /** the time the assessment was last updated */
+  updatedAt: Date;
 }
 
 export type GraphQLTestDTO = BaseTestDTO<GraphQLQuestionComponent>;

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -113,6 +113,7 @@ export const mockTestRequest: TestRequestDTO = {
   curriculumCountry: "country",
   curriculumRegion: "region",
   status: AssessmentStatus.DRAFT,
+  updatedAt: new Date(),
 };
 
 export const mockTestRequest2: TestRequestDTO = {
@@ -123,6 +124,7 @@ export const mockTestRequest2: TestRequestDTO = {
   curriculumCountry: "newCountry",
   curriculumRegion: "newRegion",
   status: AssessmentStatus.PUBLISHED,
+  updatedAt: new Date(),
 };
 
 export const mockTestWithId: TestResponseDTO = {

--- a/frontend/src/APIClients/queries/TestQueries.ts
+++ b/frontend/src/APIClients/queries/TestQueries.ts
@@ -50,6 +50,7 @@ export const GET_ALL_TESTS = gql`
       curriculumCountry
       curriculumRegion
       status
+      updatedAt
     }
   }
 `;

--- a/frontend/src/components/common/table/SortMenu.tsx
+++ b/frontend/src/components/common/table/SortMenu.tsx
@@ -23,6 +23,7 @@ export interface SortMenuProps {
   labels: string[];
   onSortProperty: React.Dispatch<React.SetStateAction<string>>;
   onSortOrder: React.Dispatch<React.SetStateAction<string>>;
+  initialSortOrder?: string;
 }
 
 const SortMenu = ({
@@ -30,9 +31,10 @@ const SortMenu = ({
   labels,
   onSortProperty,
   onSortOrder,
+  initialSortOrder = "ascending",
 }: SortMenuProps): React.ReactElement => {
   const [sortProperty, setSortProperty] = React.useState(properties[0]);
-  const [sortOrder, setSortOrder] = React.useState("ascending");
+  const [sortOrder, setSortOrder] = React.useState(initialSortOrder);
 
   const propertyList = (
     <RadioGroup

--- a/frontend/src/components/pages/admin/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/admin/DisplayAssessmentsPage.tsx
@@ -32,8 +32,8 @@ import SortMenu from "../../common/table/SortMenu";
 const DisplayAssessmentsPage = (): React.ReactElement => {
   const unselectedTabColor = "#727278";
   const [search, setSearch] = React.useState("");
-  const [sortProperty, setSortProperty] = React.useState("name");
-  const [sortOrder, setSortOrder] = React.useState("ascending");
+  const [sortProperty, setSortProperty] = React.useState("updatedAt");
+  const [sortOrder, setSortOrder] = React.useState("descending");
 
   const [grades, setGrades] = React.useState<Array<string>>([]);
   const [testTypes, setTestTypes] = React.useState<Array<string>>([]);
@@ -114,10 +114,20 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
           searchLength={assessments.length}
           sortMenuComponent={
             <SortMenu
-              labels={["name", "status", "grade", "type", "country", "region"]}
+              initialSortOrder="descending"
+              labels={[
+                "last updated",
+                "name",
+                "status",
+                "grade",
+                "type",
+                "country",
+                "region",
+              ]}
               onSortOrder={setSortOrder}
               onSortProperty={setSortProperty}
               properties={[
+                "updatedAt",
                 "name",
                 "status",
                 "grade",

--- a/frontend/src/types/AssessmentTypes.ts
+++ b/frontend/src/types/AssessmentTypes.ts
@@ -20,4 +20,5 @@ export type AssessmentProperties = {
   assessmentType: UseCase;
   curriculumCountry: string;
   curriculumRegion: string;
+  updatedAt: string;
 };

--- a/frontend/src/utils/AssessmentUtils.ts
+++ b/frontend/src/utils/AssessmentUtils.ts
@@ -19,6 +19,7 @@ export const getAssessments = (
     assessmentType: assessment.assessmentType,
     curriculumCountry: assessment.curriculumCountry,
     curriculumRegion: assessment.curriculumRegion,
+    updatedAt: assessment.updatedAt,
   };
 };
 


### PR DESCRIPTION
## Notion ticket link
[Display assessments by last updated](https://www.notion.so/uwblueprintexecs/Display-Assessments-by-Last-Updated-ee48600f04294f458a2ef30758ea0aba)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Added `updatedAt` field to all types, then exposed sorting functionality on the FE.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Load the admin assessment panel locally and verify things are sorted initially by "last updated" rather than name.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
