### PR TITLE
feat: fetch data for test sessions page

### DIFF
--- a/backend/graphql/resolvers/classResolvers.ts
+++ b/backend/graphql/resolvers/classResolvers.ts
@@ -26,6 +26,7 @@ const classService: IClassService = new ClassService(
   userService,
   testSessionService,
 );
+testSessionService.bindClassService(classService);
 
 const classResolvers = {
   Query: {

--- a/backend/graphql/resolvers/testSessionResolvers.ts
+++ b/backend/graphql/resolvers/testSessionResolvers.ts
@@ -10,6 +10,8 @@ import {
 import { ITestService } from "../../services/interfaces/testService";
 import IUserService from "../../services/interfaces/userService";
 import { ISchoolService } from "../../services/interfaces/schoolService";
+import ClassService from "../../services/implementations/classService";
+import { IClassService } from "../../services/interfaces/classService";
 
 const userService: IUserService = new UserService();
 const schoolService: ISchoolService = new SchoolService(userService);
@@ -19,6 +21,11 @@ const testSessionService: ITestSessionService = new TestSessionService(
   userService,
   schoolService,
 );
+const classService: IClassService = new ClassService(
+  userService,
+  testSessionService,
+);
+testSessionService.bindClassService(classService);
 
 const testSessionResolvers = {
   Query: {
@@ -47,12 +54,9 @@ const testSessionResolvers = {
   Mutation: {
     createTestSession: async (
       _req: undefined,
-      {
-        classId,
-        testSession,
-      }: { classId: string; testSession: TestSessionRequestDTO },
+      { testSession }: { classId: string; testSession: TestSessionRequestDTO },
     ): Promise<TestSessionResponseDTO> => {
-      return testSessionService.createTestSession(classId, testSession);
+      return testSessionService.createTestSession(testSession);
     },
   },
 };

--- a/backend/graphql/types/testSessionType.ts
+++ b/backend/graphql/types/testSessionType.ts
@@ -18,6 +18,7 @@ const testSessionType = gql`
     test: TestResponseDTO!
     teacher: UserDTO!
     school: SchoolResponseDTO!
+    class: ClassResponseDTO!
     results: [ResultResponseDTO]
     accessCode: String!
     startDate: Date!
@@ -29,6 +30,7 @@ const testSessionType = gql`
     test: ID!
     teacher: ID!
     school: ID!
+    class: ID!
     accessCode: String!
     startDate: Date!
     endDate: Date!
@@ -44,7 +46,6 @@ const testSessionType = gql`
 
   extend type Mutation {
     createTestSession(
-      classId: String!
       testSession: TestSessionRequestDTO!
     ): TestSessionResponseDTO!
   }

--- a/backend/models/testSession.model.ts
+++ b/backend/models/testSession.model.ts
@@ -57,6 +57,8 @@ export interface TestSession extends Document {
   teacher: string;
   /** the ID of the school that's administering the test from the School collection */
   school: string;
+  /** the ID of the class that's taking the test from the Class collection */
+  class: string;
   /**
    * the result of the test session
    * there should be one entry here per student
@@ -87,6 +89,11 @@ const TestSessionSchema: Schema = new Schema(
     school: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "School",
+      required: true,
+    },
+    class: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Class",
       required: true,
     },
     results: {

--- a/backend/services/implementations/__tests__/classService.test.ts
+++ b/backend/services/implementations/__tests__/classService.test.ts
@@ -5,22 +5,28 @@ import db from "../../../testUtils/testDb";
 import {
   testClass,
   testClassInvalidTeacher,
-  assertResponseMatchesExpected,
   updatedTestClass,
   testStudents,
   testClassWithStudents,
   updatedTestClassWithStudent,
   updatedTestStudents,
-  assertStudentResponseMatchesExpected,
-  testClassWithTestSessions,
-  assertArrayResponseMatchesExpected,
 } from "../../../testUtils/class";
+import {
+  assertResponseMatchesExpected,
+  assertArrayResponseMatchesExpected,
+  assertStudentResponseMatchesExpected,
+} from "../../../testUtils/classAssertions";
 import UserService from "../userService";
 import { mockTeacher } from "../../../testUtils/users";
 import TestSessionService from "../testSessionService";
 import TestService from "../testService";
 import SchoolService from "../schoolService";
 import { mockTestSessionWithId } from "../../../testUtils/testSession";
+
+const testClassWithTestSessions = {
+  ...testClass[0],
+  testSessions: [mockTestSessionWithId.id],
+};
 
 describe("mongo classService", (): void => {
   let classService: ClassService;

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -29,13 +29,18 @@ import { mockTestWithId, mockTestWithId2 } from "../../../testUtils/tests";
 import { mockSchoolWithId } from "../../../testUtils/school";
 import SchoolService from "../schoolService";
 import { mockTeacher, testUsers } from "../../../testUtils/users";
-import { testClassAfterCreation } from "../../../testUtils/class";
+import {
+  mockClassWithId,
+  testClassAfterCreation,
+} from "../../../testUtils/class";
+import ClassService from "../classService";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
   let testService: TestService;
   let userService: UserService;
   let schoolService: SchoolService;
+  let classService: ClassService;
 
   beforeAll(async () => {
     await db.connect();
@@ -54,12 +59,15 @@ describe("mongo testSessionService", (): void => {
       userService,
       schoolService,
     );
+    classService = new ClassService(userService, testSessionService);
+    testSessionService.bindClassService(classService);
 
     if (expect.getState().currentTestName.includes("exclude mock values"))
       return;
     testService.getTestById = jest.fn().mockReturnValue(mockTestWithId);
     userService.getUserById = jest.fn().mockReturnValue(mockTeacher);
     schoolService.getSchoolById = jest.fn().mockReturnValue(mockSchoolWithId);
+    classService.getClassById = jest.fn().mockReturnValue(mockClassWithId);
   });
 
   afterEach(async () => {
@@ -68,10 +76,10 @@ describe("mongo testSessionService", (): void => {
 
   it("createTestSession for valid class id", async () => {
     const classObj: Class = await MgClass.create(testClassAfterCreation);
-    const res = await testSessionService.createTestSession(
-      classObj.id,
-      mockTestSession,
-    );
+    const res = await testSessionService.createTestSession({
+      ...mockTestSession,
+      class: classObj.id,
+    });
 
     assertResponseMatchesExpected(mockTestSession, res);
     expect(res.results).toEqual([]);
@@ -85,10 +93,10 @@ describe("mongo testSessionService", (): void => {
   it("createTestSession for invalid class id", async () => {
     const invalidClassId = "62c248c0f79d6c3c9ebbea92";
     await expect(async () => {
-      await testSessionService.createTestSession(
-        invalidClassId,
-        mockTestSession,
-      );
+      await testSessionService.createTestSession({
+        ...mockTestSession,
+        class: invalidClassId,
+      });
     }).rejects.toThrowError(
       `Test session could not be added to class with id ${invalidClassId}`,
     );
@@ -97,20 +105,20 @@ describe("mongo testSessionService", (): void => {
   it("create test session with invalid start date", async () => {
     const classObj: Class = await MgClass.create(testClassAfterCreation);
     await expect(async () => {
-      await testSessionService.createTestSession(
-        classObj.id,
-        mockTestSessionWithInvalidStartDate,
-      );
+      await testSessionService.createTestSession({
+        ...mockTestSessionWithInvalidStartDate,
+        class: classObj.id,
+      });
     }).rejects.toThrowError(`Test session start and end dates are not valid`);
   });
 
   it("create test session with invalid end date", async () => {
     const classObj: Class = await MgClass.create(testClassAfterCreation);
     await expect(async () => {
-      await testSessionService.createTestSession(
-        classObj.id,
-        mockTestSessionWithInvalidEndDate,
-      );
+      await testSessionService.createTestSession({
+        ...mockTestSessionWithInvalidEndDate,
+        class: classObj.id,
+      });
     }).rejects.toThrowError(`Test session start and end dates are not valid`);
   });
 
@@ -333,6 +341,7 @@ describe("mongo testSessionService", (): void => {
       test: mockTestWithId2.id,
       teacher: testUsers[0].id,
       school: "62c248c0f79d6c3c9ebbea92",
+      class: mockClassWithId.id,
       accessCode: "1235",
       startDate: new Date("2022-09-10T09:00:00.000Z"),
       endDate: new Date("2022-09-11T09:00:00.000Z"),

--- a/backend/services/interfaces/classService.ts
+++ b/backend/services/interfaces/classService.ts
@@ -1,4 +1,4 @@
-import { type UserDTO, type Grade } from "../../types";
+import type { UserDTO, Grade } from "../../types";
 import { type TestSessionResponseDTO } from "./testSessionService";
 
 export interface StudentRequestDTO {

--- a/backend/services/interfaces/classService.ts
+++ b/backend/services/interfaces/classService.ts
@@ -1,5 +1,5 @@
-import { UserDTO, Grade } from "../../types";
-import { TestSessionResponseDTO } from "./testSessionService";
+import { type UserDTO, type Grade } from "../../types";
+import { type TestSessionResponseDTO } from "./testSessionService";
 
 export interface StudentRequestDTO {
   firstName: string;
@@ -43,10 +43,14 @@ export interface IClassService {
   /**
    * This method retrieves the class with given id.
    * @param id class id
+   * @param populateTestSessions if true, test sessions will be populated
    * @returns requested class
    * @throws Error if retrieval fails
    */
-  getClassById(id: string): Promise<ClassResponseDTO>;
+  getClassById(
+    id: string,
+    populateTestSessions?: boolean,
+  ): Promise<ClassResponseDTO>;
 
   /**
    * This method retrieves the class with given test session id.

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -1,6 +1,7 @@
-import { UserDTO } from "../../types";
-import { SchoolResponseDTO } from "./schoolService";
-import { TestResponseDTO } from "./testService";
+import { type UserDTO } from "../../types";
+import { type ClassResponseDTO, type IClassService } from "./classService";
+import { type SchoolResponseDTO } from "./schoolService";
+import { type TestResponseDTO } from "./testService";
 
 /**
  * This interface contains the request object that is fed into
@@ -13,6 +14,8 @@ export interface TestSessionRequestDTO {
   teacher: string;
   /** the ID of the school that's administering the test from the School collection */
   school: string;
+  /** the ID of the class taking the test session */
+  class: string;
   /** the code that students can use to access the test when it is live */
   accessCode: string;
   /** on this date, the test becomes available to students */
@@ -36,6 +39,8 @@ export interface TestSessionResponseDTO {
   teacher: UserDTO;
   /** the school that's administering the test from the School collection */
   school: SchoolResponseDTO;
+  /** the class taking the test session */
+  class: ClassResponseDTO;
   /**
    * the result of the test session
    * there should be one entry here per student
@@ -98,6 +103,13 @@ export interface ResultResponseDTO {
 
 export interface ITestSessionService {
   /**
+   * This method binds the class service to the test session service.
+   * @param classService The class service to bind to the test session service
+   * @returns void
+   */
+  bindClassService(classService: IClassService): void;
+
+  /**
    * create a TestSession with the fields given in the DTO, return created TestSession
    * @param id of the class taking the test session
    * @param testSession new testSession
@@ -105,7 +117,6 @@ export interface ITestSessionService {
    * @throws Error if creation fails
    */
   createTestSession(
-    classId: string,
     testSession: TestSessionRequestDTO,
   ): Promise<TestSessionResponseDTO>;
 

--- a/backend/testUtils/class.ts
+++ b/backend/testUtils/class.ts
@@ -1,12 +1,10 @@
 import {
   StudentRequestDTO,
   ClassRequestDTO,
-  ClassResponseDTO,
   StudentResponseDTO,
 } from "../services/interfaces/classService";
 import { mockTeacher } from "./users";
 import { Grade } from "../types";
-import { mockTestSessionWithId } from "./testSession";
 
 // set up test students
 export const testStudents: StudentRequestDTO[] = [
@@ -69,11 +67,6 @@ export const testClassWithStudents = {
   students: testStudents,
 };
 
-export const testClassWithTestSessions = {
-  ...testClass[0],
-  testSessions: [mockTestSessionWithId.id],
-};
-
 export const updatedTestClass: ClassRequestDTO = {
   className: "class1changed",
   schoolYear: 4,
@@ -104,42 +97,4 @@ export const testClassAfterCreation = {
   ...testClass[0],
   students: [],
   testSessions: [],
-};
-
-export const assertResponseMatchesExpected = (
-  expected: ClassRequestDTO,
-  result: ClassResponseDTO,
-): void => {
-  expect(result.id).not.toBeNull();
-  expect(result.className).toEqual(expected.className);
-  expect(result.schoolYear).toEqual(expected.schoolYear);
-  expect(result.gradeLevel.toString).toEqual(expected.gradeLevel.toString);
-  expect(result.teacher).toEqual(mockTeacher);
-  if (result.testSessions.length !== 0) {
-    expect(result.testSessions).toEqual([mockTestSessionWithId]);
-  } else {
-    expect(result.testSessions).toEqual([]);
-  }
-};
-
-export const assertArrayResponseMatchesExpected = (
-  expected: ClassRequestDTO[],
-  result: ClassResponseDTO[],
-): void => {
-  expect(result.length).toEqual(expected.length);
-  for (let i = 0; i < result.length; i += 1) {
-    assertResponseMatchesExpected(expected[i], result[i]);
-  }
-};
-
-export const assertStudentResponseMatchesExpected = (
-  expected: StudentRequestDTO[],
-  result: StudentResponseDTO[],
-): void => {
-  result.forEach((student, index) => {
-    expect(student.id).not.toBeNull();
-    expect(student.firstName).toEqual(expected[index].firstName);
-    expect(student.lastName).toEqual(expected[index].lastName);
-    expect(student.studentNumber).toEqual(expected[index].studentNumber);
-  });
 };

--- a/backend/testUtils/classAssertions.ts
+++ b/backend/testUtils/classAssertions.ts
@@ -1,0 +1,46 @@
+import {
+  StudentRequestDTO,
+  ClassRequestDTO,
+  ClassResponseDTO,
+  StudentResponseDTO,
+} from "../services/interfaces/classService";
+import { mockTeacher } from "./users";
+import { mockTestSessionWithId } from "./testSession";
+
+export const assertResponseMatchesExpected = (
+  expected: ClassRequestDTO,
+  result: ClassResponseDTO,
+): void => {
+  expect(result.id).not.toBeNull();
+  expect(result.className).toEqual(expected.className);
+  expect(result.schoolYear).toEqual(expected.schoolYear);
+  expect(result.gradeLevel.toString).toEqual(expected.gradeLevel.toString);
+  expect(result.teacher).toEqual(mockTeacher);
+  if (result.testSessions.length !== 0) {
+    expect(result.testSessions).toEqual([mockTestSessionWithId]);
+  } else {
+    expect(result.testSessions).toEqual([]);
+  }
+};
+
+export const assertArrayResponseMatchesExpected = (
+  expected: ClassRequestDTO[],
+  result: ClassResponseDTO[],
+): void => {
+  expect(result.length).toEqual(expected.length);
+  for (let i = 0; i < result.length; i += 1) {
+    assertResponseMatchesExpected(expected[i], result[i]);
+  }
+};
+
+export const assertStudentResponseMatchesExpected = (
+  expected: StudentRequestDTO[],
+  result: StudentResponseDTO[],
+): void => {
+  result.forEach((student, index) => {
+    expect(student.id).not.toBeNull();
+    expect(student.firstName).toEqual(expected[index].firstName);
+    expect(student.lastName).toEqual(expected[index].lastName);
+    expect(student.studentNumber).toEqual(expected[index].studentNumber);
+  });
+};

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -5,6 +5,7 @@ import {
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
+import { mockClassWithId, mockClassWithId2 } from "./class";
 import { mockSchoolWithId, mockSchoolWithId2 } from "./school";
 import { mockTestWithId } from "./tests";
 import { mockTeacher } from "./users";
@@ -56,6 +57,7 @@ export const mockTestSession: TestSessionDTO = {
   test: mockTestWithId.id,
   teacher: mockTeacher.id,
   school: mockSchoolWithId.id,
+  class: mockClassWithId.id,
   results: [mockGradedTestResult],
   accessCode: "1234",
   startDate: new Date("2021-09-01T09:00:00.000Z"),
@@ -69,6 +71,7 @@ export const mockTestSessionsWithSameTestId: TestSessionDTO[] = [
     test: "62c248c0f79d6c3c9ebbea95",
     teacher: "62c248c0f79d6c3c9ebbea95",
     school: "62c248c0f79d6c3c9ebbea97",
+    class: mockClassWithId.id,
     results: [mockGradedTestResult],
     accessCode: "789",
     startDate: new Date("2021-09-01T09:00:00.000Z"),
@@ -78,6 +81,7 @@ export const mockTestSessionsWithSameTestId: TestSessionDTO[] = [
     test: "62c248c0f79d6c3c9ebbea95",
     teacher: "62c248c0f79d6c3c9ebbea94",
     school: "62c248c0f79d6c3c9ebbea93",
+    class: mockClassWithId2.id,
     results: [mockGradedTestResult],
     accessCode: "1234",
     startDate: new Date("2021-09-01T09:00:00.000Z"),
@@ -157,6 +161,7 @@ export const mockTestSessionWithId: TestSessionResponseDTO = {
   test: mockTestWithId,
   teacher: mockTeacher,
   school: mockSchoolWithId,
+  class: { ...mockClassWithId, teacher: mockTeacher, testSessions: [] },
 };
 
 export const mockTestSessions: TestSessionDTO[] = [

--- a/frontend/src/APIClients/mutations/TestSessionMutations.ts
+++ b/frontend/src/APIClients/mutations/TestSessionMutations.ts
@@ -1,11 +1,8 @@
 import { gql } from "@apollo/client";
 
 const CREATE_TEST_SESSION = gql`
-  mutation CreateTestSession(
-    $classId: String!
-    $testSession: TestSessionRequestDTO!
-  ) {
-    createTestSession(classId: $classId, testSession: $testSession) {
+  mutation CreateTestSession($testSession: TestSessionRequestDTO!) {
+    createTestSession(testSession: $testSession) {
       id
     }
   }

--- a/frontend/src/APIClients/queries/TestSessionQueries.ts
+++ b/frontend/src/APIClients/queries/TestSessionQueries.ts
@@ -14,13 +14,16 @@ export const GET_TEST_SESSION_BY_ACCESS_CODE = gql`
   }
 `;
 
-export const GET_TEST_SESSION_BY_TEACHER_ID = gql`
+export const GET_TEST_SESSIONS_BY_TEACHER_ID = gql`
   query TestSessionsByTeacherId($teacherId: String!) {
     testSessionsByTeacherId(teacherId: $teacherId) {
       id
       test {
-        id
+        name
       }
+      startDate
+      endDate
+      accessCode
     }
   }
 `;

--- a/frontend/src/APIClients/queries/TestSessionQueries.ts
+++ b/frontend/src/APIClients/queries/TestSessionQueries.ts
@@ -9,7 +9,6 @@ export const GET_TEST_SESSION_BY_ACCESS_CODE = gql`
       }
       notes
       startDate
-      endDate
     }
   }
 `;

--- a/frontend/src/APIClients/queries/TestSessionQueries.ts
+++ b/frontend/src/APIClients/queries/TestSessionQueries.ts
@@ -21,6 +21,9 @@ export const GET_TEST_SESSIONS_BY_TEACHER_ID = gql`
       test {
         name
       }
+      class {
+        className
+      }
       startDate
       endDate
       accessCode

--- a/frontend/src/APIClients/types/TestSessionClientTypes.ts
+++ b/frontend/src/APIClients/types/TestSessionClientTypes.ts
@@ -1,3 +1,4 @@
+import { ClassResponse } from "./ClassClientTypes";
 import { Test } from "./TestClientTypes";
 
 export interface TestSessionMetadata {
@@ -14,6 +15,8 @@ export interface TestSessionMetadata {
 export interface TestSession extends TestSessionMetadata {
   /** the name of the test that this test session is for */
   test: Pick<Test, "name">;
+  /** the name of the class that this test session is for */
+  class: Pick<ClassResponse, "className">;
   /** the access code that students use to access the test session */
   accessCode: string;
 }

--- a/frontend/src/APIClients/types/TestSessionClientTypes.ts
+++ b/frontend/src/APIClients/types/TestSessionClientTypes.ts
@@ -1,3 +1,5 @@
+import { Test } from "./TestClientTypes";
+
 export interface TestSessionMetadata {
   /** the unique identifier for the test session */
   id: string;
@@ -7,4 +9,11 @@ export interface TestSessionMetadata {
   endDate: Date;
   /** notes inputted by teacher to show students prior to commencing the test */
   notes?: string;
+}
+
+export interface TestSession extends TestSessionMetadata {
+  /** the name of the test that this test session is for */
+  test: Pick<Test, "name">;
+  /** the access code that students use to access the test session */
+  accessCode: string;
 }

--- a/frontend/src/APIClients/types/TestSessionClientTypes.ts
+++ b/frontend/src/APIClients/types/TestSessionClientTypes.ts
@@ -6,8 +6,6 @@ export interface TestSessionMetadata {
   id: string;
   /** on this date, the test becomes available to students */
   startDate: Date;
-  /** after this date, the test is no longer available to students */
-  endDate: Date;
   /** notes inputted by teacher to show students prior to commencing the test */
   notes?: string;
 }
@@ -17,6 +15,8 @@ export interface TestSession extends TestSessionMetadata {
   test: Pick<Test, "name">;
   /** the name of the class that this test session is for */
   class: Pick<ClassResponse, "className">;
+  /** after this date, the test is no longer available to students */
+  endDate: Date;
   /** the access code that students use to access the test session */
   accessCode: string;
 }

--- a/frontend/src/APIClients/types/TestSessionClientTypes.ts
+++ b/frontend/src/APIClients/types/TestSessionClientTypes.ts
@@ -1,7 +1,7 @@
 import { ClassResponse } from "./ClassClientTypes";
 import { Test } from "./TestClientTypes";
 
-export interface TestSessionMetadata {
+interface TestSessionMetadata {
   /** the unique identifier for the test session */
   id: string;
   /** on this date, the test becomes available to students */
@@ -10,7 +10,9 @@ export interface TestSessionMetadata {
   notes?: string;
 }
 
-export interface TestSession extends TestSessionMetadata {
+export type TestSessionSetupData = TestSessionMetadata;
+
+export interface TestSessionOverviewData extends TestSessionMetadata {
   /** the name of the test that this test session is for */
   test: Pick<Test, "name">;
   /** the name of the class that this test session is for */

--- a/frontend/src/components/auth/student-login/NameSelection.tsx
+++ b/frontend/src/components/auth/student-login/NameSelection.tsx
@@ -11,7 +11,7 @@ import { Select, SingleValue } from "chakra-react-select";
 
 import { GET_CLASS_BY_TEST_SESSION } from "../../../APIClients/queries/ClassQueries";
 import { StudentResponse } from "../../../APIClients/types/ClassClientTypes";
-import { TestSessionMetadata } from "../../../APIClients/types/TestSessionClientTypes";
+import { TestSessionSetupData } from "../../../APIClients/types/TestSessionClientTypes";
 import { STUDENT_SIGNUP_IMAGE } from "../../../assets/images";
 import { HOME_PAGE, STUDENT_LANDING_PAGE } from "../../../constants/Routes";
 import AuthContext from "../../../contexts/AuthContext";
@@ -21,7 +21,7 @@ import NavigationButtons from "../teacher-signup/NavigationButtons";
 
 interface NameSelectionProps {
   testId: string;
-  testSession: TestSessionMetadata;
+  testSession: TestSessionSetupData;
 }
 
 const NameSelection = ({

--- a/frontend/src/components/common/table/usePaginatedData.ts
+++ b/frontend/src/components/common/table/usePaginatedData.ts
@@ -1,16 +1,16 @@
 import { useMemo, useState } from "react";
 
-type PaginatedDataResult<E, Data extends Array<E> | undefined> = {
+type PaginatedDataResult<Entry, Data extends Array<Entry> | undefined> = {
   paginatedData: Data;
   currentPage: number;
   setCurrentPage: (page: number) => void;
   totalPages: number;
 };
 
-const usePaginatedData = <E, Data extends Array<E> | undefined>(
+const usePaginatedData = <Entry, Data extends Array<Entry> | undefined>(
   data: Data,
   pageSize = 8,
-): PaginatedDataResult<E, Data> => {
+): PaginatedDataResult<Entry, Data> => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const numElements = data?.length ?? 0;

--- a/frontend/src/components/common/table/usePaginatedData.ts
+++ b/frontend/src/components/common/table/usePaginatedData.ts
@@ -1,29 +1,32 @@
 import { useMemo, useState } from "react";
 
-type PaginatedDataResult<T> = {
-  paginatedData: T[];
+type PaginatedDataResult<E, Data extends Array<E> | undefined> = {
+  paginatedData: Data;
   currentPage: number;
   setCurrentPage: (page: number) => void;
   totalPages: number;
 };
 
-const usePaginatedData = <T>(
-  data: T[],
+const usePaginatedData = <E, Data extends Array<E> | undefined>(
+  data: Data,
   pageSize = 8,
-): PaginatedDataResult<T> => {
+): PaginatedDataResult<E, Data> => {
   const [currentPage, setCurrentPage] = useState(1);
+
+  const numElements = data?.length ?? 0;
 
   const paginatedData = useMemo(() => {
     const start = (currentPage - 1) * pageSize;
     const end = start + pageSize;
-    return data.slice(start, end);
+    return data?.slice(start, end);
   }, [data, currentPage, pageSize]);
 
   return {
-    paginatedData,
+    // Cast to Data to avoid having to check for undefined
+    paginatedData: paginatedData as Data,
     currentPage,
     setCurrentPage,
-    totalPages: Math.ceil(data.length / pageSize),
+    totalPages: Math.ceil(numElements / pageSize),
   };
 };
 

--- a/frontend/src/components/pages/student/StudentLoginPage.tsx
+++ b/frontend/src/components/pages/student/StudentLoginPage.tsx
@@ -3,7 +3,7 @@ import { useLazyQuery } from "@apollo/client";
 import { HStack, PinInput, PinInputField, Text } from "@chakra-ui/react";
 
 import { GET_TEST_SESSION_BY_ACCESS_CODE } from "../../../APIClients/queries/TestSessionQueries";
-import { TestSessionMetadata } from "../../../APIClients/types/TestSessionClientTypes";
+import { TestSessionSetupData } from "../../../APIClients/types/TestSessionClientTypes";
 import { STUDENT_SIGNUP_IMAGE } from "../../../assets/images";
 import AuthWrapper from "../../auth/AuthWrapper";
 import NameSelection from "../../auth/student-login/NameSelection";
@@ -18,7 +18,7 @@ const StudentLoginPage = (): React.ReactElement => {
   const [error, setError] = useState("");
 
   const [testId, setTestId] = useState("");
-  const [testSession, setTestSession] = useState<TestSessionMetadata | null>(
+  const [testSession, setTestSession] = useState<TestSessionSetupData | null>(
     null,
   );
 

--- a/frontend/src/components/pages/student/StudentLoginPage.tsx
+++ b/frontend/src/components/pages/student/StudentLoginPage.tsx
@@ -32,7 +32,6 @@ const StudentLoginPage = (): React.ReactElement => {
       setTestSession({
         id: result.id,
         startDate: result.startDate,
-        endDate: result.endDate,
         notes: result.notes ?? "",
       });
 

--- a/frontend/src/components/pages/student/StudentRouting.tsx
+++ b/frontend/src/components/pages/student/StudentRouting.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@apollo/client";
 
 import { GET_TEST } from "../../../APIClients/queries/TestQueries";
 import { TestResponse } from "../../../APIClients/types/TestClientTypes";
-import { TestSessionMetadata } from "../../../APIClients/types/TestSessionClientTypes";
+import { TestSessionSetupData } from "../../../APIClients/types/TestSessionClientTypes";
 import * as Routes from "../../../constants/Routes";
 import StudentContext from "../../../contexts/StudentContext";
 import PrivateRoute from "../../auth/PrivateRoute";
@@ -17,11 +17,11 @@ import AssessmentSummaryPage from "./AssessmentSummaryPage";
 const StudentRouting = (): React.ReactElement => {
   const { state } = useLocation<{
     testId: string;
-    testSession: TestSessionMetadata;
+    testSession: TestSessionSetupData;
     className: string;
   }>();
   const [testId, setTestId] = useState("");
-  const [testSession, setTestSession] = useState<TestSessionMetadata | null>(
+  const [testSession, setTestSession] = useState<TestSessionSetupData | null>(
     null,
   );
   const [className, setClassName] = useState("");

--- a/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
@@ -47,10 +47,10 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
   const formattedData = useMemo(() => {
     const now = new Date();
     return data?.testSessionsByTeacherId?.map(
-      ({ startDate, endDate, test, ...session }) => ({
+      ({ startDate, endDate, test, class: classroom, ...session }) => ({
         ...session,
         testName: test.name,
-        classroomName: "<tbd>",
+        classroomName: classroom.className,
         status: getSessionStatus(startDate, endDate, now),
         targetDate: getSessionTargetDate(startDate, endDate, now),
       }),

--- a/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import React, { useContext, useMemo } from "react";
+import { useQuery } from "@apollo/client";
 import {
   Center,
   Tab,
@@ -8,7 +9,10 @@ import {
   Tabs,
 } from "@chakra-ui/react";
 
+import { GET_TEST_SESSIONS_BY_TEACHER_ID } from "../../../APIClients/queries/TestSessionQueries";
+import { TestSession } from "../../../APIClients/types/TestSessionClientTypes";
 import * as Routes from "../../../constants/Routes";
+import AuthContext from "../../../contexts/AuthContext";
 import { STATUSES, TestSessionStatus } from "../../../types/TestSessionTypes";
 import { titleCase } from "../../../utils/GeneralUtils";
 import {
@@ -23,114 +27,43 @@ import usePaginatedData from "../../common/table/usePaginatedData";
 import EmptySessionsTableState from "../../sessions/EmptySessionsTableState";
 import TestSessionListItem from "../../sessions/TestSessionListItem";
 
-const mockData: {
-  id: string;
-  accessCode: string;
-  classroomName: string;
-  stats?: {
-    mean: number;
-    median: number;
-    completionRate: number;
-    submissions: number;
-  };
-  startDate: Date;
-  endDate: Date;
-  testName: string;
-}[] = [
-  ...[...Array(20)].map((_, i) => ({
-    id: i.toString(),
-    accessCode: "086731",
-    classroomName: "Counting and More",
-    startDate: new Date("2023-05-01"),
-    endDate: new Date("2023-08-31"),
-    testName: "Number Recognition Assessment",
-  })),
-  {
-    id: "20",
-    accessCode: "086731",
-    classroomName: "Counting and More 2",
-    startDate: new Date("2023-04-01"),
-    endDate: new Date("2023-06-31"),
-    testName: "Number Recognition Assessment 2",
-  },
-  {
-    id: "21",
-    accessCode: "123456",
-    classroomName: "Classroom Name",
-    startDate: new Date("2023-08-01"),
-    endDate: new Date("2023-08-31"),
-    testName: "Counting Assessment",
-  },
-  {
-    id: "22",
-    accessCode: "123456",
-    classroomName: "Classroom Name 2",
-    startDate: new Date("2023-07-01"),
-    endDate: new Date("2023-07-31"),
-    testName: "Counting Assessment 2",
-  },
-  {
-    id: "23",
-    accessCode: "123456",
-    classroomName: "Classroom Name",
-    stats: {
-      mean: 3.5,
-      median: 3,
-      completionRate: 30,
-      submissions: 10,
-    },
-    startDate: new Date("2021-08-01"),
-    endDate: new Date("2021-08-31"),
-    testName: "Assessment Name",
-  },
-  {
-    id: "24",
-    accessCode: "123456",
-    classroomName: "Classroom Name 2",
-    stats: {
-      mean: 97.3,
-      median: 3,
-      completionRate: 37.1,
-      submissions: 4930,
-    },
-    startDate: new Date("2022-08-01"),
-    endDate: new Date("2022-08-31"),
-    testName: "Assessment Name 2",
-  },
-];
-
 const DisplayAssessmentsPage = (): React.ReactElement => {
   const [currentTab, setCurrentTab] = React.useState<TestSessionStatus>(
     "active",
   );
 
-  // const data = useQuery(...);
-  const {
-    data,
-    loading,
-    error,
-  }: { data: typeof mockData; loading: boolean; error: boolean } = {
-    data: mockData,
-    loading: false,
-    error: false,
-  };
+  const { authenticatedUser } = useContext(AuthContext);
 
-  const dataWithStatus = useMemo(() => {
+  const { id: teacherId } = authenticatedUser ?? {};
+
+  const { loading, error, data } = useQuery<{
+    testSessionsByTeacherId: TestSession[];
+  }>(GET_TEST_SESSIONS_BY_TEACHER_ID, {
+    fetchPolicy: "cache-and-network",
+    variables: { teacherId },
+    skip: !teacherId,
+  });
+
+  const formattedData = useMemo(() => {
     const now = new Date();
-    return data.map(({ startDate, endDate, ...session }) => ({
-      ...session,
-      status: getSessionStatus(startDate, endDate, now),
-      targetDate: getSessionTargetDate(startDate, endDate, now),
-    }));
+    return data?.testSessionsByTeacherId?.map(
+      ({ startDate, endDate, test, ...session }) => ({
+        ...session,
+        testName: test.name,
+        classroomName: "<tbd>",
+        status: getSessionStatus(startDate, endDate, now),
+        targetDate: getSessionTargetDate(startDate, endDate, now),
+      }),
+    );
   }, [data]);
 
   const filteredData = useMemo(() => {
-    return dataWithStatus.filter((session) => session.status === currentTab);
-  }, [dataWithStatus, currentTab]);
+    return formattedData?.filter((session) => session.status === currentTab);
+  }, [formattedData, currentTab]);
 
   const sortedData = useMemo(() => {
     const invertSort = currentTab === "past";
-    return filteredData.sort((a, b) => {
+    return filteredData?.sort((a, b) => {
       return (
         (invertSort ? -1 : 1) *
         (a.targetDate.getTime() - b.targetDate.getTime())
@@ -149,7 +82,7 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
     <>
       <HeaderWithButton
         buttonText="Add Assessment"
-        showButton={!!data?.length}
+        showButton={!!formattedData?.length}
         targetRoute={Routes.DISTRIBUTE_ASSESSMENT_PAGE}
         title="Assessments"
       />
@@ -163,7 +96,7 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
           <ErrorState />
         </Center>
       )}
-      {!!data?.length && !loading && !error && (
+      {!!formattedData?.length && !loading && !error && (
         <>
           <Tabs mt={3}>
             <TabList>
@@ -176,7 +109,7 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
             <TabPanels>
               {STATUSES.map((status) => (
                 <TabPanel key={status}>
-                  {paginatedData.map((session) => (
+                  {paginatedData?.map((session) => (
                     <TestSessionListItem key={session.id} {...session} />
                   ))}
                 </TabPanel>
@@ -194,7 +127,9 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
           )}
         </>
       )}
-      {!data?.length && !loading && !error && <EmptySessionsTableState />}
+      {!formattedData?.length && !loading && !error && (
+        <EmptySessionsTableState />
+      )}
     </>
   );
 };

--- a/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 
 import { GET_TEST_SESSIONS_BY_TEACHER_ID } from "../../../APIClients/queries/TestSessionQueries";
-import { TestSession } from "../../../APIClients/types/TestSessionClientTypes";
+import { TestSessionOverviewData } from "../../../APIClients/types/TestSessionClientTypes";
 import * as Routes from "../../../constants/Routes";
 import AuthContext from "../../../contexts/AuthContext";
 import { STATUSES, TestSessionStatus } from "../../../types/TestSessionTypes";
@@ -37,7 +37,7 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
   const { id: teacherId } = authenticatedUser ?? {};
 
   const { loading, error, data } = useQuery<{
-    testSessionsByTeacherId: TestSession[];
+    testSessionsByTeacherId: TestSessionOverviewData[];
   }>(GET_TEST_SESSIONS_BY_TEACHER_ID, {
     fetchPolicy: "cache-and-network",
     variables: { teacherId },

--- a/frontend/src/contexts/StudentContext.ts
+++ b/frontend/src/contexts/StudentContext.ts
@@ -1,13 +1,13 @@
 import { createContext } from "react";
 
 import { TestResponse } from "../APIClients/types/TestClientTypes";
-import { TestSessionMetadata } from "../APIClients/types/TestSessionClientTypes";
+import { TestSessionSetupData } from "../APIClients/types/TestSessionClientTypes";
 
 type StudentContextType = {
   test: TestResponse | null;
   setTest: (_test: TestResponse) => void;
-  testSession: TestSessionMetadata | null;
-  setTestSession: (_testSession: TestSessionMetadata) => void;
+  testSession: TestSessionSetupData | null;
+  setTestSession: (_testSession: TestSessionSetupData) => void;
   className: string;
   setClassName: (_className: string) => void;
 };
@@ -16,7 +16,7 @@ const StudentContext = createContext<StudentContextType>({
   test: null,
   setTest: (_test: TestResponse): void => {},
   testSession: null,
-  setTestSession: (_testSession: TestSessionMetadata): void => {},
+  setTestSession: (_testSession: TestSessionSetupData): void => {},
   className: "",
   setClassName: (_className: string): void => {},
 });

--- a/frontend/src/utils/TestSessionUtils.ts
+++ b/frontend/src/utils/TestSessionUtils.ts
@@ -1,21 +1,21 @@
 import { TestSessionStatus } from "../types/TestSessionTypes";
 
 export const getSessionStatus = (
-  startDate: Date,
-  endDate: Date,
+  startDate: string | Date,
+  endDate: string | Date,
   now?: Date,
 ): TestSessionStatus => {
   const nowDate = now ?? new Date();
-  if (endDate < nowDate) return "past";
-  if (startDate > nowDate) return "upcoming";
+  if (new Date(endDate) < nowDate) return "past";
+  if (new Date(startDate) > nowDate) return "upcoming";
   return "active";
 };
 
 export const getSessionTargetDate = (
-  startDate: Date,
-  endDate: Date,
+  startDate: string | Date,
+  endDate: string | Date,
   now?: Date,
-): Date => {
-  const status = getSessionStatus(startDate, endDate, now);
-  return status === "active" ? endDate : startDate;
-};
+): Date =>
+  getSessionStatus(startDate, endDate, now) === "active"
+    ? new Date(endDate)
+    : new Date(startDate);

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,7 +4,13 @@ set -e
 
 # https://stackoverflow.com/a/32981392/3761440
 faketty () {
-    script -qefc "$(printf "%q " "$@")" /dev/null
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS
+        script -q /dev/null bash -c "$(printf "%q " "$@")"
+    else
+        # Linux
+        script -qefc "$(printf "%q " "$@")" /dev/null
+    fi
 }
 
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-# https://stackoverflow.com/a/32981392/3761440
 faketty () {
     if [[ "$(uname)" == "Darwin" ]]; then
         # macOS


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fetch data for Test Sessions page](https://www.notion.so/uwblueprintexecs/Fetch-data-for-Test-Sessions-page-29a10c0026654c0ab2ba0a19db62e86f)

Strongly suggest reviewing by commit!

- Fetch data from backend
- Fetch className from backend
- Fix linter script on Mac OS

<img width="1398" alt="image" src="https://github.com/uwblueprint/jump-math/assets/9922514/16749278-3747-4830-b311-60e07c61bfe6">



<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* As discussed on Slack, decided to add a reference to the classroom into the session object. Alternatively would require multiple fetches.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. View the teacher session page and verify that it loads and you see live data (probably nothing :P).


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
