### PR TITLE
fix: convert string to date on student assessment page

### DIFF
--- a/frontend/src/components/pages/student/StudentLoginPage.tsx
+++ b/frontend/src/components/pages/student/StudentLoginPage.tsx
@@ -31,7 +31,7 @@ const StudentLoginPage = (): React.ReactElement => {
       setTestId(result.test.id);
       setTestSession({
         id: result.id,
-        startDate: result.startDate,
+        startDate: new Date(result.startDate),
         notes: result.notes ?? "",
       });
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Student exp page fails to load](https://www.notion.so/uwblueprintexecs/Student-exp-page-fails-to-load-e63691d5d1f349d2b645bcbfe2debe02)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* `startDate` -> `new Date(startDate)`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
