### PR TITLE
fix: add [COPY] suffix to duplicated tests

### DIFF
--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -91,20 +91,23 @@ describe("mongo testService", (): void => {
     const test = await MgTest.create(mockPublishedTest);
 
     const duplicateTest = await testService.duplicateTest(test.id);
-    assertResponseMatchesExpected(mockTestWithId, duplicateTest);
+    assertResponseMatchesExpected(mockTestWithId, duplicateTest, true);
     expect(test.id).not.toEqual(duplicateTest.id);
+    expect(`${test.name} [COPY]`).toEqual(duplicateTest.name);
 
     const originalTest = await testService.getTestById(test.id);
     assertResponseMatchesExpected(mockPublishedTest, originalTest);
     expect(test.id).toEqual(originalTest.id);
+    expect(test.name).toEqual(originalTest.name);
   });
 
   it("unarchiveTest", async () => {
     const test = await MgTest.create(mockArchivedTest);
 
     const unarchivedTest = await testService.unarchiveTest(test.id);
-    assertResponseMatchesExpected(mockTestWithId, unarchivedTest);
+    assertResponseMatchesExpected(mockTestWithId, unarchivedTest, true);
     expect(test.id).not.toEqual(unarchivedTest.id);
+    expect(`${test.name} [COPY]`).toEqual(unarchivedTest.name);
 
     const originalTest = await MgTest.findById(test.id);
     expect(originalTest?.status).toBe(AssessmentStatus.DELETED);

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -227,6 +227,7 @@ class TestService implements ITestService {
       }
       // eslint-disable-next-line no-underscore-dangle
       test._id = new mongoose.Types.ObjectId();
+      test.name += " [COPY]";
       test.isNew = true;
       test.status = AssessmentStatus.DRAFT;
       test.save();

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -162,9 +162,12 @@ export const mockTestArray: Array<TestResponseDTO> = [
 export const assertResponseMatchesExpected = (
   expected: TestResponseDTO,
   result: TestResponseDTO,
+  omitNameMatch = false,
 ): void => {
   expect(result.id).not.toBeNull();
-  expect(result.name).toEqual(expected.name);
+  if (!omitNameMatch) {
+    expect(result.name).toEqual(expected.name);
+  }
   expect(result.assessmentType).toEqual(expected.assessmentType);
   expect(result.curriculumCountry).toEqual(expected.curriculumCountry);
   expect(result.curriculumRegion).toEqual(expected.curriculumRegion);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add copy to duplicate title](https://www.notion.so/uwblueprintexecs/Add-copy-to-duplicate-title-5e7db10789c74f458bd7955d523382a7?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add [COPY] suffix to duplicated tests for user clarity

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* works as expected
* no breaking changes