### PR TITLE
fix: increase student list item gap to match designs

### DIFF
--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -77,7 +77,7 @@ const TestSessionListItem = ({
         <HStack
           as={status === "past" ? "button" : undefined}
           flex={1}
-          gap={2}
+          gap={4}
           onClick={() =>
             status === "past" &&
             history.push(


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Chakra-UI seems to have released a breaking change for their `Stack` components which modifies the way the inter-component padding (gap) is handled. The change reduced the gap in the list item component, so this commit increases the gap again to reflect the designs.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
