### PR TITLE
feat: get mark distribution for test session

### DIFF
--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -402,7 +402,10 @@ describe("mongo testSessionService", (): void => {
     const markDistribution: Array<number> = await testSessionService.getMarkDistribution(
       testSession.id
     );
-    expect(markDistribution).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    // Scores: 80, 80, 40, 80, 20
+    // Counts: [0, 0, 1, 0, 1, 0, 0, 0, 3, 0, 0]
+    expect(markDistribution).toEqual([0, 0, 20, 0, 20, 0, 0, 0, 60, 0, 0])
   });
 
   it("getMarkDistribution for test session with no results", async () => {

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -19,6 +19,7 @@ import {
   mockTestSessionsWithOneValid,
   mockTestSessionWithInvalidStartDate,
   mockTestSessionWithInvalidEndDate,
+  mockTestSessionsWithEvenNumberOfResults,
 } from "../../../testUtils/testSession";
 import type {
   TestSessionRequestDTO,
@@ -394,5 +395,35 @@ describe("mongo testSessionService", (): void => {
         mockUngradedTestResult,
       );
     }).rejects.toThrowError(`Test Session id ${invalidId} not found`);
+  });
+
+  it("getMarkDistribution", async () => {
+    const testSession = await MgTestSession.create(mockTestSessionsWithEvenNumberOfResults[0]);
+    const markDistribution: Array<number> = await testSessionService.getMarkDistribution(
+      testSession.id
+    );
+    expect(markDistribution).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+  });
+
+  it("getMarkDistribution for test session with no results", async () => {
+    const testSession = await MgTestSession.create({
+      ...mockTestSession,
+      results: [],
+    });
+    await expect(async () => {
+      await testSessionService.getMarkDistribution(
+        testSession.id,
+      );
+    }).rejects.toThrowError(`There are no results for the test session with id ${testSession.id}`);
+  });
+
+  it("getMarkDistribution for non-existing ID", async () => {
+    const invalidId = "62c248c0f79d6c3c9ebbea94";
+
+    await expect(async () => {
+      await testSessionService.getMarkDistribution(
+        invalidId,
+      );
+    }).rejects.toThrowError(`Failed to get mark distribution for the test session with id ${invalidId}`);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -398,14 +398,15 @@ describe("mongo testSessionService", (): void => {
   });
 
   it("getMarkDistribution", async () => {
-    const testSession = await MgTestSession.create(mockTestSessionsWithEvenNumberOfResults[0]);
-    const markDistribution: Array<number> = await testSessionService.getMarkDistribution(
-      testSession.id
+    const testSession = await MgTestSession.create(
+      mockTestSessionsWithEvenNumberOfResults[0],
     );
+    const markDistribution: Array<number> =
+      await testSessionService.getMarkDistribution(testSession.id);
 
     // Scores: 80, 80, 40, 80, 20
     // Counts: [0, 0, 1, 0, 1, 0, 0, 0, 3, 0, 0]
-    expect(markDistribution).toEqual([0, 0, 20, 0, 20, 0, 0, 0, 60, 0, 0])
+    expect(markDistribution).toEqual([0, 0, 20, 0, 20, 0, 0, 0, 60, 0, 0]);
   });
 
   it("getMarkDistribution for test session with no results", async () => {
@@ -414,19 +415,17 @@ describe("mongo testSessionService", (): void => {
       results: [],
     });
     await expect(async () => {
-      await testSessionService.getMarkDistribution(
-        testSession.id,
-      );
-    }).rejects.toThrowError(`There are no results for the test session with id ${testSession.id}`);
+      await testSessionService.getMarkDistribution(testSession.id);
+    }).rejects.toThrowError(
+      `There are no results for the test session with id ${testSession.id}`,
+    );
   });
 
   it("getMarkDistribution for non-existing ID", async () => {
     const invalidId = "62c248c0f79d6c3c9ebbea94";
 
     await expect(async () => {
-      await testSessionService.getMarkDistribution(
-        invalidId,
-      );
+      await testSessionService.getMarkDistribution(invalidId);
     }).rejects.toThrowError(`Test Session id ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -424,6 +424,6 @@ describe("mongo testSessionService", (): void => {
       await testSessionService.getMarkDistribution(
         invalidId,
       );
-    }).rejects.toThrowError(`Failed to get mark distribution for the test session with id ${invalidId}`);
+    }).rejects.toThrowError(`Test Session id ${invalidId} not found`);
   });
 });

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -244,8 +244,8 @@ class TestSessionService implements ITestSessionService {
         ++markDistribution[bucket];
       })
 
-      markDistribution.forEach(count => {
-        count = (count / totalStudents) * 100;
+      markDistribution.forEach((count, i, arr) => {
+        arr[i] = (count / totalStudents) * 100;
       })
     } catch (error: unknown) {
       Logger.error(

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -237,12 +237,12 @@ class TestSessionService implements ITestSessionService {
         );
       }
 
-      const totalStudents = results?.length;
       results.forEach((result) => {
         const bucket = Math.round(result.score / 10);
         markDistributionCount[bucket] += 1;
       });
 
+      const totalStudents = results?.length;
       markDistribution = markDistributionCount.map((count) => {
         return (count / totalStudents) * 100;
       });

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -239,8 +239,6 @@ class TestSessionService implements ITestSessionService {
       const totalStudents = results?.length;
       results.forEach(result => {
         const bucket = Math.round(result.score / 10);
-        console.log("score: ", result);
-        console.log("bucket: ", bucket);
         ++markDistribution[bucket];
       })
 

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -238,7 +238,7 @@ class TestSessionService implements ITestSessionService {
 
       const totalStudents = results?.length;
       results.forEach(result => {
-        const bucket = Math.round(result.score / 10) * 10;
+        const bucket = Math.round(result.score / 10);
         console.log("score: ", result);
         console.log("bucket: ", bucket);
         ++markDistribution[bucket];

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -230,7 +230,7 @@ class TestSessionService implements ITestSessionService {
     try {
       const { results } = await this.getTestSessionById(id);
 
-      if (!results) {
+      if (!results?.length) {
         throw new Error(
           `There are no results for the test session with id ${id}`,
         );
@@ -239,6 +239,8 @@ class TestSessionService implements ITestSessionService {
       const totalStudents = results?.length;
       results.forEach(result => {
         const bucket = Math.round(result.score / 10) * 10;
+        console.log("score: ", result);
+        console.log("bucket: ", bucket);
         ++markDistribution[bucket];
       })
 

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -224,6 +224,39 @@ class TestSessionService implements ITestSessionService {
     }
   }
 
+  async getMarkDistribution(id: string): Promise<Array<number>> {
+    let markDistribution: Array<number> = Array(11).fill(0);
+
+    try {
+      const { results } = await this.getTestSessionById(id);
+
+      if (!results) {
+        throw new Error(
+          `There are no results for the test session with id ${id}`,
+        );
+      }
+
+      const totalStudents = results?.length;
+      results.forEach(result => {
+        const bucket = Math.round(result.score / 10) * 10;
+        ++markDistribution[bucket];
+      })
+
+      markDistribution.forEach(count => {
+        count = (count / totalStudents) * 100;
+      })
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to get mark distribution for the test session with id ${id}. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+
+    return markDistribution;
+  }
+
   async updateTestSession(
     id: string,
     testSession: TestSessionRequestDTO,

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -225,7 +225,8 @@ class TestSessionService implements ITestSessionService {
   }
 
   async getMarkDistribution(id: string): Promise<Array<number>> {
-    let markDistribution: Array<number> = Array(11).fill(0);
+    const markDistributionCount: Array<number> = Array(11).fill(0);
+    let markDistribution: Array<number>;
 
     try {
       const { results } = await this.getTestSessionById(id);
@@ -237,14 +238,14 @@ class TestSessionService implements ITestSessionService {
       }
 
       const totalStudents = results?.length;
-      results.forEach(result => {
+      results.forEach((result) => {
         const bucket = Math.round(result.score / 10);
-        ++markDistribution[bucket];
-      })
+        markDistributionCount[bucket] += 1;
+      });
 
-      markDistribution.forEach((count, i, arr) => {
-        arr[i] = (count / totalStudents) * 100;
-      })
+      markDistribution = markDistributionCount.map((count) => {
+        return (count / totalStudents) * 100;
+      });
     } catch (error: unknown) {
       Logger.error(
         `Failed to get mark distribution for the test session with id ${id}. Reason = ${getErrorMessage(

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -238,7 +238,7 @@ class TestSessionService implements ITestSessionService {
       }
 
       results.forEach((result) => {
-        const bucket = Math.round(result.score / 10);
+        const bucket = Math.trunc(result.score / 10);
         markDistributionCount[bucket] += 1;
       });
 

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -175,13 +175,11 @@ export interface ITestSessionService {
   ): Promise<Array<TestSessionResponseDTO>>;
 
   /**
-   * This method gets the mark distribution of the results for a 
+   * This method gets the mark distribution of the results for a
    * test session given the id
    * @param id The unique identifier of the Test Session document
    */
-  getMarkDistribution(
-    id: string,
-  ): Promise<Array<number>>;
+  getMarkDistribution(id: string): Promise<Array<number>>;
 
   /**
    * Update a test session given the id

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -175,6 +175,15 @@ export interface ITestSessionService {
   ): Promise<Array<TestSessionResponseDTO>>;
 
   /**
+   * This method gets the mark distribution of the results for a 
+   * test session given the id
+   * @param id The unique identifier of the Test Session document
+   */
+  getMarkDistribution(
+    id: string,
+  ): Promise<Array<number>>;
+
+  /**
    * Update a test session given the id
    * This method updates a Test Session document by its unique identifier in
    * the database (auto-grading all ungraded Results before updating).


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Compute Mark Distribution](https://www.notion.so/uwblueprintexecs/Compute-Mark-Distribution-68fd3f69bcb442abb5dea2998c0b8be9?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add new function `getMarkDistribution` to calculate the mark distribution of a given test session
   * Mark distribution: % of students who scored 0%, 10%, ..., 90%, 100%
* Add unit tests


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. `yarn test`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I considered using an aggregation pipeline instead of raw javascript, but i think readability > optimization


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
