### PR TITLE
fix: classroom card spacing

### DIFF
--- a/frontend/src/components/pages/teacher/ClassroomsPage.tsx
+++ b/frontend/src/components/pages/teacher/ClassroomsPage.tsx
@@ -5,8 +5,7 @@ import { useQuery } from "@apollo/client";
 import {
   Box,
   Center,
-  Grid,
-  GridItem,
+  Flex,
   Tab,
   TabList,
   TabPanel,
@@ -124,7 +123,7 @@ const ClassroomsPage = (): React.ReactElement => {
                 </TabList>
                 <TabPanels>
                   <TabPanel padding="0">
-                    <Grid gap={4} templateColumns="repeat(4, 1fr)">
+                    <Flex flexWrap="wrap">
                       {paginatedData?.map(
                         ({
                           id,
@@ -135,7 +134,7 @@ const ClassroomsPage = (): React.ReactElement => {
                           startDate,
                           studentCount,
                         }) => (
-                          <GridItem key={id} flex="1" paddingTop="4">
+                          <Flex key={id} paddingLeft="4" paddingTop="4">
                             <ClassroomCard
                               key={id}
                               activeAssessments={activeAssessments}
@@ -146,10 +145,10 @@ const ClassroomsPage = (): React.ReactElement => {
                               startDate={startDate}
                               studentCount={studentCount}
                             />
-                          </GridItem>
+                          </Flex>
                         ),
                       )}
-                    </Grid>
+                    </Flex>
                     <VStack
                       alignItems="center"
                       paddingBottom="6"

--- a/frontend/src/components/pages/teacher/ClassroomsPage.tsx
+++ b/frontend/src/components/pages/teacher/ClassroomsPage.tsx
@@ -123,7 +123,7 @@ const ClassroomsPage = (): React.ReactElement => {
                 </TabList>
                 <TabPanels>
                   <TabPanel padding="0">
-                    <Flex flexWrap="wrap">
+                    <Flex alignItems="left" flexWrap="wrap">
                       {paginatedData?.map(
                         ({
                           id,
@@ -134,7 +134,7 @@ const ClassroomsPage = (): React.ReactElement => {
                           startDate,
                           studentCount,
                         }) => (
-                          <Flex key={id} paddingLeft="4" paddingTop="4">
+                          <Flex key={id} paddingRight="4" paddingTop="4">
                             <ClassroomCard
                               key={id}
                               activeAssessments={activeAssessments}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix spacing on classroom cards](https://www.notion.so/uwblueprintexecs/Fix-Spacing-on-Classroom-Cards-a646025e969c485db2fcba97b8c3f93e?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Using Flexbox to adapt the # of columns based on screen size
[i.e](https://drive.google.com/file/d/13hSZ6NJ1347nrTHsP8-F3Rkuv4UyFAtG/view?usp=sharing)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. UI renders as expected