### PR TITLE
fix: rename kindergarten enum

### DIFF
--- a/backend/graphql/resolvers/scalarResolvers.ts
+++ b/backend/graphql/resolvers/scalarResolvers.ts
@@ -2,6 +2,9 @@ import { GraphQLUpload } from "../../lib/graphql-upload";
 
 const scalarResolvers = async () => ({
   FileUpload: await GraphQLUpload(),
+  GradeEnum: {
+    KINDERGARTEN: "K",
+  },
 });
 
 export default scalarResolvers;

--- a/backend/graphql/types/testType.ts
+++ b/backend/graphql/types/testType.ts
@@ -24,7 +24,7 @@ const testType = gql`
   }
 
   enum GradeEnum {
-    K
+    KINDERGARTEN
     GRADE_1
     GRADE_2
     GRADE_3

--- a/backend/models/class.model.ts
+++ b/backend/models/class.model.ts
@@ -62,7 +62,7 @@ const ClassSchema: Schema = new Schema({
   },
   gradeLevel: {
     type: String,
-    enum: Object.keys(Grade),
+    enum: Object.values(Grade),
     required: true,
   },
   teacher: {

--- a/backend/models/test.model.ts
+++ b/backend/models/test.model.ts
@@ -53,7 +53,7 @@ const TestSchema: Schema = new Schema(
     grade: {
       type: String,
       required: true,
-      enum: Object.keys(Grade),
+      enum: Object.values(Grade),
     },
     curriculumCountry: {
       type: String,
@@ -66,12 +66,12 @@ const TestSchema: Schema = new Schema(
     assessmentType: {
       type: String,
       required: true,
-      enum: Object.keys(AssessmentType),
+      enum: Object.values(AssessmentType),
     },
     status: {
       type: String,
       required: true,
-      enum: Object.keys(AssessmentStatus),
+      enum: Object.values(AssessmentStatus),
     },
   },
   { timestamps: { createdAt: false, updatedAt: true } },

--- a/backend/models/user.model.ts
+++ b/backend/models/user.model.ts
@@ -45,7 +45,7 @@ const UserSchema: Schema = new Schema({
       {
         type: String,
         required: false,
-        enum: Object.keys(Grade),
+        enum: Object.values(Grade),
       },
     ],
     required: false,

--- a/backend/services/implementations/__tests__/userService.test.ts
+++ b/backend/services/implementations/__tests__/userService.test.ts
@@ -27,7 +27,7 @@ const testUsers = [
     authId: "321",
     role: "Teacher",
     email: "wendy@gmail.com",
-    grades: [Grade.K, Grade.GRADE_1, Grade.GRADE_2, Grade.GRADE_3],
+    grades: [Grade.KINDERGARTEN, Grade.GRADE_1, Grade.GRADE_2, Grade.GRADE_3],
     currentlyTeachingJM: true,
   },
 ];

--- a/backend/testUtils/class.ts
+++ b/backend/testUtils/class.ts
@@ -45,7 +45,7 @@ export const testClass: ClassRequestDTO[] = [
   {
     className: "class1",
     startDate: new Date("2020-09-01T09:00:00.000Z"),
-    gradeLevel: Grade.K,
+    gradeLevel: Grade.KINDERGARTEN,
     teacher: mockTeacher.id,
   },
   {
@@ -77,7 +77,7 @@ export const updatedTestClass: ClassRequestDTO = {
 export const updatedTestClassWithStudent = {
   className: "class1",
   startDate: new Date("2020-09-01T09:00:00.000Z"),
-  gradeLevel: Grade.K,
+  gradeLevel: Grade.KINDERGARTEN,
   teacher: mockTeacher.id,
   students: updatedTestStudents,
 };

--- a/backend/testUtils/users.ts
+++ b/backend/testUtils/users.ts
@@ -16,7 +16,7 @@ export const mockTeacher: UserDTO = {
   lastName: "One",
   email: "teacher@gmail.com",
   role: "Teacher",
-  grades: [Grade.K, Grade.GRADE_1, Grade.GRADE_2, Grade.GRADE_3],
+  grades: [Grade.KINDERGARTEN, Grade.GRADE_1, Grade.GRADE_2, Grade.GRADE_3],
   currentlyTeachingJM: true,
 };
 

--- a/backend/types/index.ts
+++ b/backend/types/index.ts
@@ -6,7 +6,7 @@ export type Token = {
 };
 
 export enum Grade {
-  K = "K",
+  KINDERGARTEN = "K",
   GRADE_1 = "GRADE_1",
   GRADE_2 = "GRADE_2",
   GRADE_3 = "GRADE_3",

--- a/frontend/src/APIClients/types/UserClientTypes.ts
+++ b/frontend/src/APIClients/types/UserClientTypes.ts
@@ -1,7 +1,7 @@
 import type { Role } from "../../types/AuthTypes";
 
 export enum Grade {
-  K = "K",
+  KINDERGARTEN = "KINDERGARTEN",
   GRADE_1 = "GRADE_1",
   GRADE_2 = "GRADE_2",
   GRADE_3 = "GRADE_3",

--- a/frontend/src/components/admin/view-assessments/AssessmentsTable.tsx
+++ b/frontend/src/components/admin/view-assessments/AssessmentsTable.tsx
@@ -25,9 +25,7 @@ const AssessmentsTable = ({
       <Text key={i} fontWeight="bold">
         {assessment.name}
       </Text>,
-      assessment.grade === "K"
-        ? "Kindergarten"
-        : titleCase(removeUnderscore(assessment.grade)),
+      titleCase(removeUnderscore(assessment.grade)),
       titleCase(assessment.assessmentType),
       assessment.curriculumCountry,
       assessment.curriculumRegion,

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -21,7 +21,7 @@ import ClassroomCard from "../teacher/student-management/classroom-summary/Class
 const defaultValues = {
   className: "",
   startDate: new Date(),
-  gradeLevel: Grade.K,
+  gradeLevel: Grade.KINDERGARTEN,
 } as ClassroomForm;
 
 const MOCK_STUDENTS = [

--- a/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
+++ b/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
@@ -37,9 +37,7 @@ const AssessmentsTable = ({
       <Text key={i} fontWeight="bold">
         {assessment.name}
       </Text>,
-      assessment.grade === "K"
-        ? "Kindergarten"
-        : titleCase(removeUnderscore(assessment.grade)),
+      titleCase(removeUnderscore(assessment.grade)),
       titleCase(assessment.assessmentType),
       assessment.curriculumCountry,
       assessment.curriculumRegion,

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddClassroomModal.tsx
@@ -121,7 +121,7 @@ const AddOrEditClassroomModal = ({
   const onModalClose = () => {
     setValue("className", "");
     setValue("startDate", undefined);
-    setValue("gradeLevel", Grade.K);
+    setValue("gradeLevel", Grade.KINDERGARTEN);
     setShowRequestError(false);
     setRequestErrorMessage("");
     onClose();

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -121,7 +121,7 @@ const AddOrEditClassroomModal = ({
   const onModalClose = () => {
     setValue("className", "");
     setValue("startDate", undefined);
-    setValue("gradeLevel", Grade.K);
+    setValue("gradeLevel", Grade.KINDERGARTEN);
     setShowRequestError(false);
     setRequestErrorMessage("");
     onClose();

--- a/frontend/src/utils/AssessmentUtils.ts
+++ b/frontend/src/utils/AssessmentUtils.ts
@@ -103,12 +103,7 @@ export const filterAssessmentsBySearch = (
     filteredTests = filteredTests.filter(
       (assessment: AssessmentProperties) =>
         includesIgnoreCase(assessment.name, search) ||
-        includesIgnoreCase(
-          assessment.grade === "K"
-            ? "Kindergarten"
-            : removeUnderscore(assessment.grade),
-          search,
-        ) ||
+        includesIgnoreCase(removeUnderscore(assessment.grade), search) ||
         includesIgnoreCase(assessment.curriculumCountry, search) ||
         includesIgnoreCase(assessment.curriculumRegion, search) ||
         includesIgnoreCase(assessment.assessmentType, search),


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Rename Kindergarten enum to “KINDERGARTEN”](https://www.notion.so/uwblueprintexecs/Rename-Kindergarten-enum-to-KINDERGARTEN-82a48355a99143d882b67139c0cc508d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
This was useful to work on because it fixed the UI in a lot of places where just "K" was displayed, which might be confusing in some cases.

The data-model change is purely a front-end change, so no database migration is necessary.

- Rename symbol `K` to `KINDERGARTEN` in code
- Map "K" string to "KINDERGARTEN" when passing it to the FE
- Remove checks for the enum special case


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. View any page that displays a grade level (e.g., the classroom page).
2. Verify that for any Kindergarten-level classroom, the grade level is displayed correctly.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
