### PR TITLE
fix: bugs surrounding edit-classroom modal

### DIFF
--- a/frontend/src/APIClients/queries/ClassQueries.ts
+++ b/frontend/src/APIClients/queries/ClassQueries.ts
@@ -62,6 +62,7 @@ export const GET_CLASSES_BY_TEACHER = gql`
   query ClassesByTeacher($teacherId: ID!, $queryOptions: ClassQueryOptions) {
     classesByTeacher(teacherId: $teacherId, queryOptions: $queryOptions) {
       id
+      startDate
       gradeLevel
       className
       testSessions {

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
@@ -77,18 +77,12 @@ const classroomFormDefaultValues: ClassroomForm = {
 
 const getLocationState = (
   state: unknown,
-): { className?: string; startDate?: Date; gradeLevel?: Grade } => {
-  const result = {
-    className: undefined,
-    startDate: undefined,
-    gradeLevel: undefined,
-    ...(typeof state === "object" ? state : {}),
-  };
-  return {
-    ...result,
-    startDate: result.startDate ? new Date(result.startDate) : undefined,
-  };
-};
+): { className?: string; startDate?: Date; gradeLevel?: Grade } => ({
+  className: undefined,
+  startDate: undefined,
+  gradeLevel: undefined,
+  ...(typeof state === "object" ? state : {}),
+});
 
 const DisplayClassroomsPage = () => {
   const history = useHistory();
@@ -105,7 +99,12 @@ const DisplayClassroomsPage = () => {
   );
   const displayTitle = data?.class.className ?? className;
   const displayStartDate = useMemo(
-    () => (data?.class.startDate ? new Date(data.class.startDate) : startDate),
+    () =>
+      data?.class.startDate
+        ? new Date(data.class.startDate)
+        : startDate
+        ? new Date(startDate)
+        : startDate,
     [data?.class.startDate, startDate],
   );
   const displayGradeLevel = data?.class.gradeLevel ?? gradeLevel;

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
@@ -100,7 +100,7 @@ const DisplayClassroomsPage = () => {
     GET_CLASS_DETAILS_BY_ID,
     {
       variables: { classroomId },
-      skip: !!className,
+      skip: !!className && !!startDate && !!gradeLevel,
     },
   );
   const displayTitle = data?.class.className ?? className;

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
@@ -184,10 +184,7 @@ const DisplayClassroomsPage = () => {
           <IconButton
             aria-label="Edit classroom"
             icon={<EditOutlineIcon />}
-            onClick={() => {
-              classroomFormMethods.reset();
-              onClassroomModalOpen();
-            }}
+            onClick={onClassroomModalOpen}
             size="icon"
             variant="icon"
           />

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
@@ -131,6 +131,8 @@ const DisplayClassroomsPage = () => {
   });
 
   useEffect(() => {
+    // We need to reset the form values in case we had to fetch the class data
+    // from the server.
     classroomFormMethods.reset(
       {
         className: displayTitle,

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -29,7 +29,6 @@ import {
   GET_CLASSES_BY_TEACHER,
 } from "../../../../APIClients/queries/ClassQueries";
 import type { ClassResponse } from "../../../../APIClients/types/ClassClientTypes";
-import { Grade } from "../../../../APIClients/types/UserClientTypes";
 import AuthContext from "../../../../contexts/AuthContext";
 import type {
   ClassroomForm,
@@ -60,6 +59,7 @@ const AddOrEditClassroomModal = ({
     handleSubmit,
     watch,
     setValue,
+    reset: resetForm,
     formState: { dirtyFields, errors },
   } = useFormContext<ClassroomForm>();
   const { authenticatedUser } = useContext(AuthContext);
@@ -119,9 +119,7 @@ const AddOrEditClassroomModal = ({
   };
 
   const onModalClose = () => {
-    setValue("className", "");
-    setValue("startDate", undefined);
-    setValue("gradeLevel", Grade.KINDERGARTEN);
+    resetForm();
     setShowRequestError(false);
     setRequestErrorMessage("");
     onClose();

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -35,6 +35,7 @@ import type {
   ClassroomInput,
 } from "../../../../types/ClassroomTypes";
 import { gradeOptions } from "../../../../utils/AssessmentUtils";
+import { getQueryName } from "../../../../utils/GeneralUtils";
 import DatePicker from "../../../common/DatePicker";
 import ErrorToast from "../../../common/info/toasts/ErrorToast";
 import useToast from "../../../common/info/useToast";
@@ -70,22 +71,15 @@ const AddOrEditClassroomModal = ({
   const [createClass] = useMutation<{ createClass: ClassResponse }>(
     CREATE_CLASS,
     {
-      refetchQueries: [
-        {
-          query: GET_CLASSES_BY_TEACHER,
-          variables: { teacherId: authenticatedUser?.id },
-        },
-      ],
+      refetchQueries: [getQueryName(GET_CLASSES_BY_TEACHER)],
     },
   );
   const [updateClass] = useMutation<{ updateClass: ClassResponse }>(
     UPDATE_CLASS,
     {
       refetchQueries: [
-        {
-          query: GET_CLASS_DETAILS_BY_ID,
-          variables: { classroomId },
-        },
+        getQueryName(GET_CLASSES_BY_TEACHER),
+        getQueryName(GET_CLASS_DETAILS_BY_ID),
       ],
     },
   );

--- a/frontend/src/components/teacher/student-management/classroom-summary/ClassroomCard.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/ClassroomCard.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { type ReactElement } from "react";
+import { FormProvider, useForm } from "react-hook-form";
 import { Link as RouterLink } from "react-router-dom";
 import {
   HStack,
@@ -16,6 +17,7 @@ import {
   PeopleIcon,
 } from "../../../../assets/icons";
 import * as Routes from "../../../../constants/Routes";
+import type { ClassroomForm } from "../../../../types/ClassroomTypes";
 import { removeUnderscore, titleCase } from "../../../../utils/GeneralUtils";
 
 import ClassroomPopover from "./ClassroomPopover";
@@ -34,7 +36,7 @@ interface ClassroomCardProps {
 }
 
 interface ClassroomCardBodyProps {
-  icon: React.ReactElement;
+  icon: ReactElement;
   text: string;
 }
 
@@ -49,7 +51,16 @@ const ClassroomCard = ({
   clickDisabled = false,
   selected = false,
   isDashboardVariant = false,
-}: ClassroomCardProps): React.ReactElement => {
+}: ClassroomCardProps): ReactElement => {
+  const classroomFormMethods = useForm<ClassroomForm>({
+    defaultValues: {
+      className: name,
+      startDate: startDate ? new Date(startDate) : undefined,
+      gradeLevel: grade,
+    },
+    mode: "onChange",
+  });
+
   const classroomTitle = (
     <Text color="grey.400" textStyle="mobileHeader3">
       {name}
@@ -98,7 +109,12 @@ const ClassroomCard = ({
               >
                 {classroomTitle}
               </LinkOverlay>
-              {!isDashboardVariant && <ClassroomPopover classId={id} />}
+
+              {!isDashboardVariant && (
+                <FormProvider {...classroomFormMethods}>
+                  <ClassroomPopover classId={id} />
+                </FormProvider>
+              )}
             </>
           )}
         </HStack>

--- a/frontend/src/utils/GeneralUtils.ts
+++ b/frontend/src/utils/GeneralUtils.ts
@@ -1,4 +1,6 @@
 import { isSameDay } from "date-fns";
+import type { DocumentNode } from "graphql";
+import { getOperationAST } from "graphql";
 
 export const titleCase = (input: string): string => {
   const words = input.trim().split(/\s+/);
@@ -93,4 +95,12 @@ export const getLetterFromNumber = (number: number): string => {
   const secondLetter = String.fromCharCode((number % 26) + 97);
 
   return firstLetter + secondLetter;
+};
+
+export const getQueryName = (query: DocumentNode): string => {
+  const name = getOperationAST(query)?.name?.value;
+  if (!name) {
+    throw new Error("Query name not found. This is probably a bug.");
+  }
+  return name;
 };


### PR DESCRIPTION
## Notion ticket link
No ticket - bugs I noticed in the course of using the platform


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Fetch missing `startDate` field
- Fix classroom page constantly rerendering
- Reset form data to default values rather than empty state
- Hydrate default values on classrooms page
- Refetch correct queries upon update


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open the modals on the classrooms page and classroom drilldown page several times.
2. Verify that the values are reset to default (current) values each time.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
