### PR TITLE
feat: filter out completed students from name selection

### DIFF
--- a/backend/graphql/resolvers/classResolvers.ts
+++ b/backend/graphql/resolvers/classResolvers.ts
@@ -6,11 +6,9 @@ import type {
 } from "../../services/interfaces/classService";
 
 import ClassService from "../../services/implementations/classService";
-import type { ISchoolService } from "../../services/interfaces/schoolService";
 import type { ITestService } from "../../services/interfaces/testService";
 import type { ITestSessionService } from "../../services/interfaces/testSessionService";
 import type IUserService from "../../services/interfaces/userService";
-import SchoolService from "../../services/implementations/schoolService";
 import TestService from "../../services/implementations/testService";
 import TestSessionService from "../../services/implementations/testSessionService";
 import UserService from "../../services/implementations/userService";
@@ -18,11 +16,8 @@ import type { QueryOptions } from "../../types";
 
 const userService: IUserService = new UserService();
 const testService: ITestService = new TestService();
-const schoolService: ISchoolService = new SchoolService(userService);
 const testSessionService: ITestSessionService = new TestSessionService(
   testService,
-  userService,
-  schoolService,
 );
 const classService: IClassService = new ClassService(
   userService,

--- a/backend/graphql/resolvers/classResolvers.ts
+++ b/backend/graphql/resolvers/classResolvers.ts
@@ -3,6 +3,7 @@ import type {
   ClassResponseDTO,
   IClassService,
   StudentRequestDTO,
+  TestableStudentsDTO,
 } from "../../services/interfaces/classService";
 
 import ClassService from "../../services/implementations/classService";
@@ -30,11 +31,11 @@ const classResolvers = {
       _req: undefined,
       { id }: { id: string },
     ): Promise<ClassResponseDTO> => classService.getClassById(id),
-    classByTestSession: async (
+    testableStudentsByTestSessionId: async (
       _req: undefined,
       { testSessionId }: { testSessionId: string },
-    ): Promise<ClassResponseDTO> => {
-      return classService.getClassByTestSessionId(testSessionId);
+    ): Promise<TestableStudentsDTO> => {
+      return classService.getTestableStudentsByTestSessionId(testSessionId);
     },
     classesByTeacher: async (
       _req: undefined,

--- a/backend/graphql/resolvers/testSessionResolvers.ts
+++ b/backend/graphql/resolvers/testSessionResolvers.ts
@@ -20,8 +20,6 @@ const schoolService: ISchoolService = new SchoolService(userService);
 const testService: ITestService = new TestService();
 const testSessionService: ITestSessionService = new TestSessionService(
   testService,
-  userService,
-  schoolService,
 );
 const classService: IClassService = new ClassService(
   userService,

--- a/backend/graphql/types/classType.ts
+++ b/backend/graphql/types/classType.ts
@@ -32,6 +32,12 @@ const classType = gql`
     isActive: Boolean!
   }
 
+  type TestableStudentsDTO {
+    id: String!
+    className: String!
+    students: [StudentResponseDTO]!
+  }
+
   input ClassQuerySort {
     updatedAt: SortDirection
   }
@@ -45,7 +51,7 @@ const classType = gql`
 
   extend type Query {
     class(id: ID!): ClassResponseDTO!
-    classByTestSession(testSessionId: ID!): ClassResponseDTO!
+    testableStudentsByTestSessionId(testSessionId: ID!): TestableStudentsDTO!
     classesByTeacher(
       teacherId: ID!
       queryOptions: ClassQueryOptions

--- a/backend/services/implementations/__tests__/classService.test.ts
+++ b/backend/services/implementations/__tests__/classService.test.ts
@@ -15,6 +15,7 @@ import {
   assertResponseMatchesExpected,
   assertArrayResponseMatchesExpected,
   assertStudentResponseMatchesExpected,
+  assertTestableStudentsResponseMatchesExpected,
 } from "../../../testUtils/classAssertions";
 import UserService from "../userService";
 import { mockTeacher } from "../../../testUtils/users";
@@ -114,19 +115,19 @@ describe("mongo classService", (): void => {
     );
   });
 
-  describe("getClassByTestSessionId", () => {
-    it("getClassByTestSessionId for valid testSessionId", async () => {
+  describe("getTestableStudentsByTestSessionId", () => {
+    it("getTestableStudentsByTestSessionId for valid testSessionId", async () => {
       const savedClass = await ClassModel.create(testClassWithTestSessions);
-      const res = await classService.getClassByTestSessionId(
+      const res = await classService.getTestableStudentsByTestSessionId(
         savedClass.testSessions[0],
       );
-      assertResponseMatchesExpected(savedClass, res);
+      assertTestableStudentsResponseMatchesExpected(savedClass, res);
     });
 
     it("for non-existing testSessionId", async () => {
       const notFoundId = "86cb91bdc3464f14678934cd";
       await expect(async () => {
-        await classService.getClassByTestSessionId(notFoundId);
+        await classService.getTestableStudentsByTestSessionId(notFoundId);
       }).rejects.toThrowError(
         `Class with test session id ${notFoundId} not found`,
       );
@@ -137,7 +138,7 @@ describe("mongo classService", (): void => {
       await ClassModel.create(testClassWithTestSessions);
       const testSessionId = testClassWithTestSessions.testSessions[0];
       await expect(async () => {
-        await classService.getClassByTestSessionId(testSessionId);
+        await classService.getTestableStudentsByTestSessionId(testSessionId);
       }).rejects.toThrowError(
         `More than one class has the same Test Session of id ${testSessionId}`,
       );
@@ -159,10 +160,11 @@ describe("mongo classService", (): void => {
         ],
       });
 
-      const res = await classService.getClassByTestSessionId(
+      const res = await classService.getTestableStudentsByTestSessionId(
         savedClass.testSessions[0],
       );
-      assertResponseMatchesExpected(savedClass, res);
+      expect(savedClass.id).not.toBeNull();
+      expect(savedClass.className).toEqual(res.className);
       assertStudentResponseMatchesExpected(res.students, [
         savedClass.students[1],
       ]);

--- a/backend/services/implementations/__tests__/classService.test.ts
+++ b/backend/services/implementations/__tests__/classService.test.ts
@@ -20,8 +20,10 @@ import UserService from "../userService";
 import { mockTeacher } from "../../../testUtils/users";
 import TestSessionService from "../testSessionService";
 import type TestService from "../testService";
-import type SchoolService from "../schoolService";
-import { mockTestSessionWithId } from "../../../testUtils/testSession";
+import {
+  mockGradedTestResult,
+  mockTestSessionWithId,
+} from "../../../testUtils/testSession";
 
 const testClassWithTestSessions = {
   ...testClass[0],
@@ -33,7 +35,6 @@ describe("mongo classService", (): void => {
   let userService: UserService;
   let testSessionService: TestSessionService;
   let testService: TestService;
-  let schoolService: SchoolService;
 
   beforeAll(async () => {
     await db.connect();
@@ -45,11 +46,7 @@ describe("mongo classService", (): void => {
 
   beforeEach(async () => {
     userService = new UserService();
-    testSessionService = new TestSessionService(
-      testService,
-      userService,
-      schoolService,
-    );
+    testSessionService = new TestSessionService(testService);
     classService = new ClassService(userService, testSessionService);
     userService.getUserById = jest.fn().mockReturnValue(mockTeacher);
     testSessionService.getTestSessionById = jest
@@ -117,32 +114,59 @@ describe("mongo classService", (): void => {
     );
   });
 
-  it("getClassByTestSessionId for valid testSessionId", async () => {
-    const savedClass = await ClassModel.create(testClassWithTestSessions);
-    const res = await classService.getClassByTestSessionId(
-      savedClass.testSessions[0],
-    );
-    assertResponseMatchesExpected(savedClass, res);
-  });
+  describe("getClassByTestSessionId", () => {
+    it("getClassByTestSessionId for valid testSessionId", async () => {
+      const savedClass = await ClassModel.create(testClassWithTestSessions);
+      const res = await classService.getClassByTestSessionId(
+        savedClass.testSessions[0],
+      );
+      assertResponseMatchesExpected(savedClass, res);
+    });
 
-  it("getClassByTestSessionId for non-existing testSessionId", async () => {
-    const notFoundId = "86cb91bdc3464f14678934cd";
-    await expect(async () => {
-      await classService.getClassByTestSessionId(notFoundId);
-    }).rejects.toThrowError(
-      `Class with test session id ${notFoundId} not found`,
-    );
-  });
+    it("for non-existing testSessionId", async () => {
+      const notFoundId = "86cb91bdc3464f14678934cd";
+      await expect(async () => {
+        await classService.getClassByTestSessionId(notFoundId);
+      }).rejects.toThrowError(
+        `Class with test session id ${notFoundId} not found`,
+      );
+    });
 
-  it("getClassByTestSessionId for classes with same testSessionId", async () => {
-    await ClassModel.create(testClassWithTestSessions);
-    await ClassModel.create(testClassWithTestSessions);
-    const testSessionId = testClassWithTestSessions.testSessions[0];
-    await expect(async () => {
-      await classService.getClassByTestSessionId(testSessionId);
-    }).rejects.toThrowError(
-      `More than one class has the same Test Session of id ${testSessionId}`,
-    );
+    it("for classes with same testSessionId", async () => {
+      await ClassModel.create(testClassWithTestSessions);
+      await ClassModel.create(testClassWithTestSessions);
+      const testSessionId = testClassWithTestSessions.testSessions[0];
+      await expect(async () => {
+        await classService.getClassByTestSessionId(testSessionId);
+      }).rejects.toThrowError(
+        `More than one class has the same Test Session of id ${testSessionId}`,
+      );
+    });
+
+    it("for test session with existing results", async () => {
+      const savedClass = await ClassModel.create({
+        ...testClassWithStudents,
+        testSessions: [mockTestSessionWithId.id],
+      });
+
+      testSessionService.getTestSessionById = jest.fn().mockReturnValue({
+        ...mockTestSessionWithId,
+        results: [
+          {
+            ...mockGradedTestResult,
+            student: savedClass.students[0].id,
+          },
+        ],
+      });
+
+      const res = await classService.getClassByTestSessionId(
+        savedClass.testSessions[0],
+      );
+      assertResponseMatchesExpected(savedClass, res);
+      assertStudentResponseMatchesExpected(res.students, [
+        savedClass.students[1],
+      ]);
+    });
   });
 
   it("getClassesByTeacherId for valid testSessionId", async () => {

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -57,11 +57,7 @@ describe("mongo testSessionService", (): void => {
     userService = new UserService();
     schoolService = new SchoolService(userService);
     testService = new TestService();
-    testSessionService = new TestSessionService(
-      testService,
-      userService,
-      schoolService,
-    );
+    testSessionService = new TestSessionService(testService);
     classService = new ClassService(userService, testSessionService);
 
     if (expect.getState().currentTestName.includes("exclude mock values"))

--- a/backend/services/implementations/classService.ts
+++ b/backend/services/implementations/classService.ts
@@ -9,6 +9,7 @@ import type {
   ClassResponseDTO,
   StudentRequestDTO,
   ClassQueryOptions,
+  TestableStudentsDTO,
 } from "../interfaces/classService";
 import type IUserService from "../interfaces/userService";
 import type { ITestSessionService } from "../interfaces/testSessionService";
@@ -84,9 +85,9 @@ class ClassService implements IClassService {
     return mapDocumentToDTO(classObj);
   }
 
-  async getClassByTestSessionId(
+  async getTestableStudentsByTestSessionId(
     testSessionId: string,
-  ): Promise<ClassResponseDTO> {
+  ): Promise<TestableStudentsDTO> {
     let classes: Class[];
     try {
       classes = await MgClass.find({ testSessions: { $eq: testSessionId } });
@@ -114,7 +115,9 @@ class ClassService implements IClassService {
       Logger.error(`Failed to get Class. Reason = ${getErrorMessage(error)}`);
       throw error;
     }
-    return mapDocumentToDTO(classes[0]);
+
+    const { id, className, students } = classes[0];
+    return { id, className, students };
   }
 
   async getClassesByTeacherId(

--- a/backend/services/implementations/classService.ts
+++ b/backend/services/implementations/classService.ts
@@ -99,6 +99,17 @@ class ClassService implements IClassService {
           `More than one class has the same Test Session of id ${testSessionId}`,
         );
       }
+
+      // Filter out students who have already completed the test
+      const testSession = await this.testSessionService.getTestSessionById(
+        testSessionId,
+      );
+      const completedStudents = new Set(
+        testSession.results?.map((result) => result.student),
+      );
+      classes[0].students = classes[0].students.filter(
+        (student) => !completedStudents.has(student.id),
+      );
     } catch (error: unknown) {
       Logger.error(`Failed to get Class. Reason = ${getErrorMessage(error)}`);
       throw error;

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -12,8 +12,6 @@ import type {
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
 import type { ITestService, TestResponseDTO } from "../interfaces/testService";
-import type IUserService from "../interfaces/userService";
-import type { ISchoolService } from "../interfaces/schoolService";
 import type { QuestionComponent } from "../../types/questionTypes";
 import { QuestionComponentType } from "../../types/questionTypes";
 import type {
@@ -36,18 +34,8 @@ const Logger = logger(__filename);
 class TestSessionService implements ITestSessionService {
   testService: ITestService;
 
-  userService: IUserService;
-
-  schoolService: ISchoolService;
-
-  constructor(
-    testService: ITestService,
-    userService: IUserService,
-    schoolService: ISchoolService,
-  ) {
+  constructor(testService: ITestService) {
     this.testService = testService;
-    this.userService = userService;
-    this.schoolService = schoolService;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/backend/services/interfaces/classService.ts
+++ b/backend/services/interfaces/classService.ts
@@ -31,6 +31,11 @@ export interface ClassResponseDTO {
   isActive: boolean;
 }
 
+export type TestableStudentsDTO = Pick<
+  ClassResponseDTO,
+  "id" | "className" | "students"
+>;
+
 export interface ClassQueryOptions extends QueryOptions {
   excludeArchived?: boolean;
 }
@@ -53,12 +58,14 @@ export interface IClassService {
   getClassById(id: string): Promise<ClassResponseDTO>;
 
   /**
-   * This method retrieves the class with given test session id.
+   * This method retrieves the students that can be tested in the given test session.
    * @param id test session id
    * @returns requested class
    * @throws Error if retrieval fails
    */
-  getClassByTestSessionId(testSessionId: string): Promise<ClassResponseDTO>;
+  getTestableStudentsByTestSessionId(
+    testSessionId: string,
+  ): Promise<TestableStudentsDTO>;
 
   /**
    * This method retrieves the classes associated with given teacher id.

--- a/backend/testUtils/classAssertions.ts
+++ b/backend/testUtils/classAssertions.ts
@@ -3,6 +3,7 @@ import type {
   ClassRequestDTO,
   ClassResponseDTO,
   StudentResponseDTO,
+  TestableStudentsDTO,
 } from "../services/interfaces/classService";
 import { mockTestSessionWithId } from "./testSession";
 
@@ -45,4 +46,13 @@ export const assertStudentResponseMatchesExpected = (
     expect(student.lastName).toEqual(expected[index].lastName);
     expect(student.studentNumber).toEqual(expected[index].studentNumber);
   });
+};
+
+export const assertTestableStudentsResponseMatchesExpected = (
+  expected: TestableStudentsDTO,
+  result: TestableStudentsDTO,
+): void => {
+  expect(result.id).not.toBeNull();
+  expect(result.className).toEqual(expected.className);
+  assertStudentResponseMatchesExpected(expected.students, result.students);
 };

--- a/frontend/src/APIClients/queries/ClassQueries.ts
+++ b/frontend/src/APIClients/queries/ClassQueries.ts
@@ -43,9 +43,9 @@ export const GET_CLASS_TEST_SESSIONS_BY_ID = gql`
   }
 `;
 
-export const GET_CLASS_BY_TEST_SESSION = gql`
-  query ClassByTestSession($testSessionId: ID!) {
-    classByTestSession(testSessionId: $testSessionId) {
+export const GET_TESTABLE_STUDENTS_BY_TEST_SESSION = gql`
+  query TestableStudentsByTestSession($testSessionId: ID!) {
+    getTestableStudentsByTestSessionId(testSessionId: $testSessionId) {
       id
       className
       students {

--- a/frontend/src/APIClients/queries/ClassQueries.ts
+++ b/frontend/src/APIClients/queries/ClassQueries.ts
@@ -45,7 +45,7 @@ export const GET_CLASS_TEST_SESSIONS_BY_ID = gql`
 
 export const GET_TESTABLE_STUDENTS_BY_TEST_SESSION = gql`
   query TestableStudentsByTestSession($testSessionId: ID!) {
-    getTestableStudentsByTestSessionId(testSessionId: $testSessionId) {
+    testableStudentsByTestSessionId(testSessionId: $testSessionId) {
       id
       className
       students {

--- a/frontend/src/components/auth/student-login/NameSelection.tsx
+++ b/frontend/src/components/auth/student-login/NameSelection.tsx
@@ -10,7 +10,7 @@ import {
 import type { SingleValue } from "chakra-react-select";
 import { Select } from "chakra-react-select";
 
-import { GET_CLASS_BY_TEST_SESSION } from "../../../APIClients/queries/ClassQueries";
+import { GET_TESTABLE_STUDENTS_BY_TEST_SESSION } from "../../../APIClients/queries/ClassQueries";
 import type { StudentResponse } from "../../../APIClients/types/ClassClientTypes";
 import type { TestSessionSetupData } from "../../../APIClients/types/TestSessionClientTypes";
 import { STUDENT_SIGNUP_IMAGE } from "../../../assets/images";
@@ -30,7 +30,7 @@ const NameSelection = ({
   testSession,
 }: NameSelectionProps): React.ReactElement => {
   const { setAuthenticatedUser } = useContext(AuthContext);
-  const { loading, data } = useQuery(GET_CLASS_BY_TEST_SESSION, {
+  const { loading, data } = useQuery(GET_TESTABLE_STUDENTS_BY_TEST_SESSION, {
     variables: { testSessionId: testSession.id },
   });
   const students: StudentResponse[] = data?.classByTestSession.students ?? [];

--- a/frontend/src/components/auth/student-login/NameSelection.tsx
+++ b/frontend/src/components/auth/student-login/NameSelection.tsx
@@ -33,8 +33,9 @@ const NameSelection = ({
   const { loading, data } = useQuery(GET_TESTABLE_STUDENTS_BY_TEST_SESSION, {
     variables: { testSessionId: testSession.id },
   });
-  const students: StudentResponse[] = data?.classByTestSession.students ?? [];
-  const className = data?.classByTestSession.className ?? "";
+  const students: StudentResponse[] =
+    data?.testableStudentsByTestSessionId.students ?? [];
+  const className = data?.testableStudentsByTestSessionId.className ?? "";
 
   const [selectedStudent, setSelectedStudent] = useState<StudentOption>();
   const [error, setError] = useState(false);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update getClassByTestSession to support completed tests](https://www.notion.so/uwblueprintexecs/Update-getClassByTestSession-to-support-completed-tests-852efb2999cb4033884362b9993605e4?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added logic to filter out students with existing results in a given test session
* Considered storing a field of all remaining student names, but data may become inconsistent if students are added / deleted


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. `yarn test`
2. **Local testing**
Before
<img width="618" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/53c0e835-1cc1-4fd1-be6e-e0319fd65e5b">

After
<img width="707" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/1612a80b-385f-4b2f-8c6f-f9f958db2393">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
