### PR TITLE
feat: query for school by teacher id

### DIFF
--- a/backend/graphql/resolvers/schoolResolvers.ts
+++ b/backend/graphql/resolvers/schoolResolvers.ts
@@ -17,6 +17,10 @@ const schoolResolvers = {
     ): Promise<SchoolResponseDTO> => {
       return schoolService.getSchoolById(id);
     },
+    schoolByTeacherId: (
+      _parent: undefined,
+      { teacherId }: { teacherId: string },
+    ) => schoolService.getSchoolByTeacherId(teacherId),
     schools: async (): Promise<SchoolResponseDTO[]> => {
       return schoolService.getAllSchools();
     },

--- a/backend/graphql/types/schoolType.ts
+++ b/backend/graphql/types/schoolType.ts
@@ -13,6 +13,7 @@ const schoolType = gql`
 
   extend type Query {
     school(id: ID!): SchoolResponseDTO!
+    schoolByTeacherId(teacherId: ID!): SchoolResponseDTO!
     schools: [SchoolResponseDTO!]
   }
 `;

--- a/backend/services/implementations/__tests__/schoolService.test.ts
+++ b/backend/services/implementations/__tests__/schoolService.test.ts
@@ -168,6 +168,29 @@ describe("mongo schoolService", (): void => {
     );
   });
 
+  it("getSchoolByTeacherId for valid teacherId", async () => {
+    // mock return value of user service
+    userService.findAllUsersByIds = jest.fn().mockReturnValue(testUsers);
+
+    // execute and assert
+    const savedSchool = await SchoolModel.create(testSchools[0]);
+    const teacherId = testSchools[0].teachers[0];
+    const res = await schoolService.getSchoolByTeacherId(teacherId);
+    assertResponseMatchesExpected(savedSchool, res);
+  });
+
+  it("getSchoolByTeacherId for invalid teacherId", async () => {
+    // mock return value of user service
+    userService.findAllUsersByIds = jest.fn().mockReturnValue(testUsers);
+
+    // execute and assert
+    await SchoolModel.create(testSchools[0]);
+    const invalidTeacherId = "56cb91bdc3464f14678934cd";
+    expect(
+      schoolService.getSchoolByTeacherId(invalidTeacherId),
+    ).rejects.toThrowError(`School with teacher ${invalidTeacherId} not found`);
+  });
+
   it("deleteSchool", async () => {
     const savedSchool = await SchoolModel.create(testSchools[0]);
 

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -92,6 +92,25 @@ class SchoolService implements ISchoolService {
     return (await this.mapSchoolsToSchoolResponseDTOs([school]))[0];
   }
 
+  async getSchoolByTeacherId(teacherId: string): Promise<SchoolResponseDTO> {
+    let school: School[];
+    try {
+      school = await MgSchool.find({ teachers: { $in: teacherId } });
+      if (!school.length) {
+        throw new Error(`School with teacher ${teacherId} not found`);
+      } else if (school.length > 1) {
+        throw new Error(
+          `More than one school has the same teacher of id ${teacherId}`,
+        );
+      }
+    } catch (error: unknown) {
+      Logger.error(`Failed to get School. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    return (await this.mapSchoolsToSchoolResponseDTOs([school[0]]))[0];
+  }
+
   private async mapSchoolsToSchoolResponseDTOs(
     schools: Array<School>,
   ): Promise<Array<SchoolResponseDTO>> {

--- a/backend/services/interfaces/schoolService.ts
+++ b/backend/services/interfaces/schoolService.ts
@@ -95,6 +95,12 @@ export interface ISchoolService {
   getSchoolById(id: string): Promise<SchoolResponseDTO>;
 
   /**
+   * This method retrieves the school related to a given teacher.
+   * @param teacherId The unique identifier for a teacher
+   */
+  getSchoolByTeacherId(teacherId: string): Promise<SchoolResponseDTO>;
+
+  /**
    * This method deletes a school given its unique identifer
    * @param id The unique identifier of the school to delete
    */

--- a/frontend/src/APIClients/queries/SchoolQueries.ts
+++ b/frontend/src/APIClients/queries/SchoolQueries.ts
@@ -20,6 +20,14 @@ export const GET_SCHOOL = gql`
   }
 `;
 
+export const GET_SCHOOL_BY_TEACHER_ID = gql`
+  query GetSchoolByTeacherId($id: ID!) {
+    schoolByTeacherId(id: $teacherId) {
+      id
+    }
+  }
+`;
+
 export const GET_ALL_SCHOOLS = gql`
   query GetAllSchools {
     schools {

--- a/frontend/src/APIClients/queries/SchoolQueries.ts
+++ b/frontend/src/APIClients/queries/SchoolQueries.ts
@@ -1,25 +1,5 @@
 import { gql } from "@apollo/client";
 
-export const GET_SCHOOL = gql`
-  query GetSchool($id: ID!) {
-    school(id: $id) {
-      id
-      name
-      country
-      subRegion
-      city
-      address
-      teachers {
-        id
-        firstName
-        lastName
-        email
-        role
-      }
-    }
-  }
-`;
-
 export const GET_SCHOOL_BY_TEACHER_ID = gql`
   query GetSchoolByTeacherId($teacherId: ID!) {
     schoolByTeacherId(teacherId: $teacherId) {

--- a/frontend/src/APIClients/queries/SchoolQueries.ts
+++ b/frontend/src/APIClients/queries/SchoolQueries.ts
@@ -21,8 +21,8 @@ export const GET_SCHOOL = gql`
 `;
 
 export const GET_SCHOOL_BY_TEACHER_ID = gql`
-  query GetSchoolByTeacherId($id: ID!) {
-    schoolByTeacherId(id: $teacherId) {
+  query GetSchoolByTeacherId($teacherId: ID!) {
+    schoolByTeacherId(teacherId: $teacherId) {
       id
     }
   }

--- a/frontend/src/components/admin/user-management/admin/AdminUserTable.tsx
+++ b/frontend/src/components/admin/user-management/admin/AdminUserTable.tsx
@@ -2,7 +2,10 @@ import React, { useContext } from "react";
 import { Box } from "@chakra-ui/react";
 
 import AuthContext from "../../../../contexts/AuthContext";
-import type { AuthenticatedAdminOrTeacher } from "../../../../types/AuthTypes";
+import type {
+  AuthenticatedAdmin,
+  AuthenticatedTeacher,
+} from "../../../../types/AuthTypes";
 import type { TableRow } from "../../../common/table/Table";
 import { Table } from "../../../common/table/Table";
 import RemoveUserPopover from "../RemoveUserPopover";
@@ -17,7 +20,7 @@ const AdminUserTable = ({ users }: AdminTableProps): React.ReactElement => {
     values: [`${user.firstName} ${user.lastName}`, user.email],
     menu:
       authenticatedUser &&
-      (authenticatedUser as AuthenticatedAdminOrTeacher).email !==
+      (authenticatedUser as AuthenticatedAdmin | AuthenticatedTeacher).email !==
         user.email ? (
         <RemoveUserPopover
           email={user.email}

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -55,7 +55,11 @@ const Login = (): React.ReactElement => {
         setUnverifiedUser(true);
         return;
       }
-      setAuthenticatedUser(user);
+      if (user?.role === "Teacher") {
+        setAuthenticatedUser({ ...user, school: "testId" });
+      } else {
+        setAuthenticatedUser(user);
+      }
     } catch (error) {
       setLoginError(true);
     }

--- a/frontend/src/components/auth/teacher-signup/index.tsx
+++ b/frontend/src/components/auth/teacher-signup/index.tsx
@@ -67,7 +67,7 @@ const TeacherSignup = (): React.ReactElement => {
     {
       onCompleted(data: { register: AuthenticatedUser }) {
         setError("");
-        setAuthenticatedUser(data.register);
+        setAuthenticatedUser(data.register); // why do we set an authenticated user here?
         setPage(5);
       },
       onError: async () => {

--- a/frontend/src/components/auth/teacher-signup/index.tsx
+++ b/frontend/src/components/auth/teacher-signup/index.tsx
@@ -1,10 +1,9 @@
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useMutation } from "@apollo/client";
 
 import authAPIClient from "../../../APIClients/AuthAPIClient";
 import { REGISTER_TEACHER } from "../../../APIClients/mutations/AuthMutations";
-import AuthContext from "../../../contexts/AuthContext";
 import type { AuthenticatedUser } from "../../../types/AuthTypes";
 import type {
   TeacherSignupForm,
@@ -55,7 +54,6 @@ const renderPageComponent = (
 };
 
 const TeacherSignup = (): React.ReactElement => {
-  const { setAuthenticatedUser } = useContext(AuthContext);
   const methods = useForm<TeacherSignupForm>({
     defaultValues,
     mode: "onChange",
@@ -65,9 +63,8 @@ const TeacherSignup = (): React.ReactElement => {
   const [registerTeacher] = useMutation<{ register: AuthenticatedUser }>(
     REGISTER_TEACHER,
     {
-      onCompleted(data: { register: AuthenticatedUser }) {
+      onCompleted() {
         setError("");
-        setAuthenticatedUser(data.register); // why do we set an authenticated user here?
         setPage(5);
       },
       onError: async () => {

--- a/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
+++ b/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
@@ -23,8 +23,6 @@ const DistributeAssessmentPage = (): React.ReactElement => {
   const { id: teacherId, school: schoolId } =
     (authenticatedUser as AuthenticatedTeacher) ?? {};
 
-  console.log(authenticatedUser as AuthenticatedTeacher);
-
   const [page, setPage] = useState(0);
 
   const [testId, setTestId] = useState("");

--- a/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
+++ b/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
@@ -23,6 +23,8 @@ const DistributeAssessmentPage = (): React.ReactElement => {
   const { id: teacherId, school: schoolId } =
     (authenticatedUser as AuthenticatedTeacher) ?? {};
 
+  console.log(authenticatedUser as AuthenticatedTeacher);
+
   const [page, setPage] = useState(0);
 
   const [testId, setTestId] = useState("");

--- a/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
+++ b/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from "react";
 import { Button, HStack, Spacer, VStack } from "@chakra-ui/react";
 
 import AuthContext from "../../../contexts/AuthContext";
+import type { AuthenticatedTeacher } from "../../../types/AuthTypes";
 import type { BreadcrumbType } from "../../common/navigation/FormBreadcrumb";
 import FormBreadcrumb from "../../common/navigation/FormBreadcrumb";
 import DistributeAssessmentButton from "../../teacher/session-creation/DistributeAssessmentButton";
@@ -19,7 +20,8 @@ const BREADCRUMB_CONFIG: BreadcrumbType[] = [
 
 const DistributeAssessmentPage = (): React.ReactElement => {
   const { authenticatedUser } = useContext(AuthContext);
-  const { id: teacherId } = authenticatedUser ?? {};
+  const { id: teacherId, school: schoolId } =
+    (authenticatedUser as AuthenticatedTeacher) ?? {};
 
   const [page, setPage] = useState(0);
 
@@ -133,7 +135,7 @@ const DistributeAssessmentPage = (): React.ReactElement => {
                 testSession={{
                   test: testId,
                   teacher: teacherId,
-                  school: "639151a4d46e8c002a49f8d6",
+                  school: schoolId,
                   class: classId,
                   startDate,
                   endDate,

--- a/frontend/src/types/AuthTypes.ts
+++ b/frontend/src/types/AuthTypes.ts
@@ -12,9 +12,15 @@ type BaseUser = {
   role: Role;
 };
 
-export type AuthenticatedAdminOrTeacher = BaseUser & {
+export type AuthenticatedAdmin = BaseUser & {
   email: string;
   accessToken: string;
+};
+
+export type AuthenticatedTeacher = BaseUser & {
+  email: string;
+  accessToken: string;
+  school: string;
 };
 
 type AuthenticatedStudent = BaseUser & {
@@ -22,7 +28,8 @@ type AuthenticatedStudent = BaseUser & {
 };
 
 export type AuthenticatedUser =
-  | AuthenticatedAdminOrTeacher
+  | AuthenticatedAdmin
+  | AuthenticatedTeacher
   | AuthenticatedStudent
   | null;
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fetch school by teacher](https://www.notion.so/uwblueprintexecs/Fetch-school-by-teacher-55d781b80b2f414598f761b62d9168ea?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Originally, I wanted to update school to be a field in the data model, but it was quite a bit of work. I _think_ this is a decent alternative:
* Fetch school when teacher logs in and store it in the `AuthenticatedTeacher` object
* Use school stored in the `AuthenticatedTeacher` object to create test sessions

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a new test session
2. Check that the correct school is associated with the test session


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Functionality works as expected
* No breaking changes