### PR TITLE
fix: test session limiting and sorting on dashboard

### DIFF
--- a/backend/graphql/types/scalarType.ts
+++ b/backend/graphql/types/scalarType.ts
@@ -8,6 +8,12 @@ const commonType = gql`
     ASC
     DESC
   }
+
+  enum TestSessionStatus {
+    PAST
+    UPCOMING
+    ACTIVE
+  }
 `;
 
 export default commonType;

--- a/backend/graphql/types/testSessionType.ts
+++ b/backend/graphql/types/testSessionType.ts
@@ -33,6 +33,7 @@ const testSessionType = gql`
     accessCode: String!
     startDate: Date!
     endDate: Date!
+    status: TestSessionStatus!
     notes: String
   }
 

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -242,6 +242,49 @@ describe("mongo testSessionService", (): void => {
     );
   });
 
+  it("getTestSessionsByTeacherId for valid teacher id with limit", async () => {
+    const activeTestSession = mockTestSession;
+    const upcomingTestSession = {
+      ...mockTestSession,
+      startDate: new Date("2022-09-10T09:00:00.000Z"),
+    };
+    const pastTestSession = {
+      ...mockTestSession,
+      endDate: new Date("2020-09-10T09:00:00.000Z"),
+    };
+
+    await Promise.all(
+      Array(3)
+        .fill(0)
+        .map(() =>
+          Promise.all([
+            MgTestSession.create(activeTestSession),
+            MgTestSession.create(upcomingTestSession),
+            MgTestSession.create(pastTestSession),
+          ]),
+        ),
+    );
+
+    // execute
+    const res = await testSessionService.getTestSessionsByTeacherId(
+      mockTestSession.teacher,
+      2,
+      new Date("2022-01-01T09:00:00.000Z"),
+    );
+
+    // assert
+    const countByStatus = res.reduce(
+      (acc, testSession) => {
+        acc[testSession.status] += 1;
+        return acc;
+      },
+      { ACTIVE: 0, UPCOMING: 0, PAST: 0 },
+    );
+    expect(countByStatus.ACTIVE).toEqual(2);
+    expect(countByStatus.UPCOMING).toEqual(2);
+    expect(countByStatus.PAST).toEqual(2);
+  });
+
   it("getTestSessionsByTeacherId for invalid teacher id", async () => {
     await MgTestSession.create(mockTestSession);
     const invalidId = "56cb91bdc3464f14678934ca";

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -196,17 +196,17 @@ class TestSessionService implements ITestSessionService {
             teacher: { $eq: teacherId },
             endDate: { $gte: now },
             startDate: { $lte: now },
-          }),
+          }).sort({ endDate: 1 }),
           // upcoming
           MgTestSession.find({
             teacher: { $eq: teacherId },
             startDate: { $gt: now },
-          }),
+          }).sort({ startDate: 1 }),
           // past
           MgTestSession.find({
             teacher: { $eq: teacherId },
             endDate: { $lt: now },
-          }),
+          }).sort({ startDate: -1 }),
         ];
 
         queries.forEach((query) => query.limit(limit));

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -28,8 +28,29 @@ import {
   roundTwoDecimals,
 } from "../../utilities/generalUtils";
 import calculateMarkDistribution from "../../utilities/dataVisualizationUtils";
+import { getSessionStatus } from "../../utilities/testSessionUtils";
 
 const Logger = logger(__filename);
+
+const formatTestSession =
+  (now?: Date) =>
+  (testSession: TestSession): TestSessionResponseDTO => {
+    const nowDate = now ?? new Date();
+    const sessionDTO = mapDocumentToDTO(testSession);
+
+    return {
+      ...sessionDTO,
+      status: getSessionStatus(
+        sessionDTO.startDate,
+        sessionDTO.endDate,
+        nowDate,
+      ),
+    };
+  };
+
+const formatTestSessions = (
+  testSessions: TestSession[],
+): TestSessionResponseDTO[] => testSessions.map(formatTestSession(new Date()));
 
 class TestSessionService implements ITestSessionService {
   testService: ITestService;
@@ -169,7 +190,7 @@ class TestSessionService implements ITestSessionService {
       }
       const testSessions: TestSession[] = await query;
 
-      return mapDocumentsToDTOs(testSessions);
+      return formatTestSessions(testSessions);
     } catch (error: unknown) {
       Logger.error(
         `Failed to get test sessions for teacherId=${teacherId}. Reason = ${getErrorMessage(
@@ -188,7 +209,7 @@ class TestSessionService implements ITestSessionService {
         class: { $eq: classId },
       });
 
-      return mapDocumentsToDTOs(testSessions);
+      return formatTestSessions(testSessions);
     } catch (error: unknown) {
       Logger.error(
         `Failed to get test sessions for classId=${classId}. Reason = ${getErrorMessage(

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -184,9 +184,10 @@ class TestSessionService implements ITestSessionService {
   async getTestSessionsByTeacherId(
     teacherId: string,
     limit?: number,
+    now?: Date,
   ): Promise<Array<TestSessionResponseDTO>> {
     try {
-      const now = new Date();
+      const nowDate = now ?? new Date();
 
       let testSessions: TestSession[];
       if (limit !== undefined) {
@@ -194,18 +195,18 @@ class TestSessionService implements ITestSessionService {
           // active
           MgTestSession.find({
             teacher: { $eq: teacherId },
-            endDate: { $gte: now },
-            startDate: { $lte: now },
+            endDate: { $gte: nowDate },
+            startDate: { $lte: nowDate },
           }).sort({ endDate: 1 }),
           // upcoming
           MgTestSession.find({
             teacher: { $eq: teacherId },
-            startDate: { $gt: now },
+            startDate: { $gt: nowDate },
           }).sort({ startDate: 1 }),
           // past
           MgTestSession.find({
             teacher: { $eq: teacherId },
-            endDate: { $lt: now },
+            endDate: { $lt: nowDate },
           }).sort({ startDate: -1 }),
         ];
 
@@ -221,7 +222,7 @@ class TestSessionService implements ITestSessionService {
         });
       }
 
-      return formatTestSessions(testSessions, now);
+      return formatTestSessions(testSessions, nowDate);
     } catch (error: unknown) {
       Logger.error(
         `Failed to get test sessions for teacherId=${teacherId}. Reason = ${getErrorMessage(

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -1,3 +1,5 @@
+import type { TestSessionStatus } from "../../utilities/testSessionUtils";
+
 /**
  * This interface contains the request object that is fed into
  * the test session service to create or update the test session in the database.
@@ -45,6 +47,8 @@ export interface TestSessionResponseDTO {
   startDate: Date;
   /** after this date, the test is no longer available to students */
   endDate: Date;
+  /** the status of the test session */
+  status: TestSessionStatus;
   /** notes inputted by teacher to show students prior to commencing the test */
   notes?: string;
 }

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -6,6 +6,7 @@ import type {
   TestSessionRequestDTO,
   TestSessionResponseDTO,
 } from "../services/interfaces/testSessionService";
+import { TestSessionStatus } from "../utilities/testSessionUtils";
 import { mockClassWithId, mockClassWithId2 } from "./class";
 import { mockSchoolWithId, mockSchoolWithId2 } from "./school";
 import { mockTestWithId } from "./tests";
@@ -186,7 +187,7 @@ export const mockTestSessionWithId: TestSessionResponseDTO = {
   teacher: mockTeacher.id,
   school: mockSchoolWithId.id,
   class: mockClassWithId.id,
-  status: "ACTIVE",
+  status: TestSessionStatus.ACTIVE,
 };
 
 export const mockTestSessionWithNoResults: TestSessionDTO = {

--- a/backend/testUtils/testSession.ts
+++ b/backend/testUtils/testSession.ts
@@ -186,6 +186,7 @@ export const mockTestSessionWithId: TestSessionResponseDTO = {
   teacher: mockTeacher.id,
   school: mockSchoolWithId.id,
   class: mockClassWithId.id,
+  status: "ACTIVE",
 };
 
 export const mockTestSessionWithNoResults: TestSessionDTO = {

--- a/backend/utilities/testSessionUtils.ts
+++ b/backend/utilities/testSessionUtils.ts
@@ -1,0 +1,12 @@
+export type TestSessionStatus = "PAST" | "UPCOMING" | "ACTIVE";
+
+export const getSessionStatus = (
+  startDate: string | Date,
+  endDate: string | Date,
+  now?: Date,
+): TestSessionStatus => {
+  const nowDate = now ?? new Date();
+  if (new Date(endDate) < nowDate) return "PAST";
+  if (new Date(startDate) > nowDate) return "UPCOMING";
+  return "ACTIVE";
+};

--- a/backend/utilities/testSessionUtils.ts
+++ b/backend/utilities/testSessionUtils.ts
@@ -1,4 +1,8 @@
-export type TestSessionStatus = "PAST" | "UPCOMING" | "ACTIVE";
+export const enum TestSessionStatus {
+  PAST = "PAST",
+  UPCOMING = "UPCOMING",
+  ACTIVE = "ACTIVE",
+}
 
 export const getSessionStatus = (
   startDate: string | Date,
@@ -6,7 +10,7 @@ export const getSessionStatus = (
   now?: Date,
 ): TestSessionStatus => {
   const nowDate = now ?? new Date();
-  if (new Date(endDate) < nowDate) return "PAST";
-  if (new Date(startDate) > nowDate) return "UPCOMING";
-  return "ACTIVE";
+  if (new Date(endDate) < nowDate) return TestSessionStatus.PAST;
+  if (new Date(startDate) > nowDate) return TestSessionStatus.UPCOMING;
+  return TestSessionStatus.ACTIVE;
 };

--- a/frontend/src/APIClients/queries/ClassQueries.ts
+++ b/frontend/src/APIClients/queries/ClassQueries.ts
@@ -68,6 +68,7 @@ export const GET_CLASSES_BY_TEACHER = gql`
         id
         startDate
         endDate
+        status
       }
       students {
         id

--- a/frontend/src/APIClients/queries/TestSessionQueries.ts
+++ b/frontend/src/APIClients/queries/TestSessionQueries.ts
@@ -79,6 +79,7 @@ export const GET_TEST_SESSIONS_BY_TEACHER_ID = gql`
       }
       startDate
       endDate
+      status
       accessCode
     }
   }

--- a/frontend/src/APIClients/types/TestSessionClientTypes.ts
+++ b/frontend/src/APIClients/types/TestSessionClientTypes.ts
@@ -1,3 +1,5 @@
+import type { TestSessionStatus } from "../../types/TestSessionTypes";
+
 import type { ClassResponse, StudentResponse } from "./ClassClientTypes";
 import type { Test } from "./TestClientTypes";
 
@@ -36,6 +38,8 @@ export interface TestSessionOverviewData extends TestSessionMetadata {
   class: Pick<ClassResponse, "className">;
   /** after this date, the test is no longer available to students */
   endDate: Date;
+  /** the status of the test session */
+  status: TestSessionStatus;
   /** the access code that students use to access the test session */
   accessCode: string;
 }

--- a/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
@@ -11,8 +11,8 @@ import {
 } from "@chakra-ui/react";
 
 import * as Routes from "../../../constants/Routes";
-import type { TestSessionStatus } from "../../../types/TestSessionTypes";
-import { STATUSES } from "../../../types/TestSessionTypes";
+import { TestSessionStatus } from "../../../types/TestSessionTypes";
+import { ALL_TEST_SESSION_STATUSES } from "../../../types/TestSessionTypes";
 import { titleCase } from "../../../utils/GeneralUtils";
 import HeaderWithButton from "../../common/HeaderWithButton";
 import ErrorState from "../../common/info/ErrorState";
@@ -24,8 +24,7 @@ import TestSessionListItem from "../../teacher/view-sessions/TestSessionListItem
 import useAssessmentDataQuery from "../../teacher/view-sessions/useAssessmentDataQuery";
 
 const DisplayAssessmentsPage = (): React.ReactElement => {
-  const [currentTab, setCurrentTab] =
-    React.useState<TestSessionStatus>("ACTIVE");
+  const [currentTab, setCurrentTab] = React.useState(TestSessionStatus.ACTIVE);
 
   const { loading, error, data } = useAssessmentDataQuery();
 
@@ -69,14 +68,19 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
       )}
       {!!data?.length && !loading && !error && (
         <>
-          <Tabs mt={3} onChange={(index) => setCurrentTab(STATUSES[index])}>
+          <Tabs
+            mt={3}
+            onChange={(index) =>
+              setCurrentTab(ALL_TEST_SESSION_STATUSES[index])
+            }
+          >
             <TabList>
-              {STATUSES.map((status) => (
+              {ALL_TEST_SESSION_STATUSES.map((status) => (
                 <Tab key={status}>{titleCase(status)}</Tab>
               ))}
             </TabList>
             <TabPanels>
-              {STATUSES.map((status) => (
+              {ALL_TEST_SESSION_STATUSES.map((status) => (
                 <TabPanel key={status} pl={0} pr={0}>
                   {paginatedData?.map((session) => (
                     <TestSessionListItem

--- a/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
@@ -25,7 +25,7 @@ import useAssessmentDataQuery from "../../teacher/view-sessions/useAssessmentDat
 
 const DisplayAssessmentsPage = (): React.ReactElement => {
   const [currentTab, setCurrentTab] =
-    React.useState<TestSessionStatus>("active");
+    React.useState<TestSessionStatus>("ACTIVE");
 
   const { loading, error, data } = useAssessmentDataQuery();
 
@@ -34,7 +34,7 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
   }, [data, currentTab]);
 
   const sortedData = useMemo(() => {
-    const invertSort = currentTab === "past";
+    const invertSort = currentTab === "PAST";
     return filteredData?.sort((a, b) => {
       return (
         (invertSort ? -1 : 1) *

--- a/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentsPage.tsx
@@ -12,7 +12,7 @@ import {
 
 import * as Routes from "../../../constants/Routes";
 import { TestSessionStatus } from "../../../types/TestSessionTypes";
-import { ALL_TEST_SESSION_STATUSES } from "../../../types/TestSessionTypes";
+import { TEST_SESSION_STATUSES } from "../../../types/TestSessionTypes";
 import { titleCase } from "../../../utils/GeneralUtils";
 import HeaderWithButton from "../../common/HeaderWithButton";
 import ErrorState from "../../common/info/ErrorState";
@@ -33,7 +33,7 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
   }, [data, currentTab]);
 
   const sortedData = useMemo(() => {
-    const invertSort = currentTab === "PAST";
+    const invertSort = currentTab === TestSessionStatus.PAST;
     return filteredData?.sort((a, b) => {
       return (
         (invertSort ? -1 : 1) *
@@ -70,17 +70,15 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
         <>
           <Tabs
             mt={3}
-            onChange={(index) =>
-              setCurrentTab(ALL_TEST_SESSION_STATUSES[index])
-            }
+            onChange={(index) => setCurrentTab(TEST_SESSION_STATUSES[index])}
           >
             <TabList>
-              {ALL_TEST_SESSION_STATUSES.map((status) => (
+              {TEST_SESSION_STATUSES.map((status) => (
                 <Tab key={status}>{titleCase(status)}</Tab>
               ))}
             </TabList>
             <TabPanels>
-              {ALL_TEST_SESSION_STATUSES.map((status) => (
+              {TEST_SESSION_STATUSES.map((status) => (
                 <TabPanel key={status} pl={0} pr={0}>
                   {paginatedData?.map((session) => (
                     <TestSessionListItem

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
@@ -8,7 +8,6 @@ import type { ClassTestSessionData } from "../../../../APIClients/types/ClassCli
 import { sortArray } from "../../../../utils/GeneralUtils";
 import {
   filterTestSessionsBySearch,
-  getSessionStatus,
   getSessionTargetDate,
 } from "../../../../utils/TestSessionUtils";
 import ErrorState from "../../../common/info/ErrorState";
@@ -43,18 +42,18 @@ const DisplayClassroomAssessmentsPage = () => {
     },
   );
 
-  const formattedData = useMemo(() => {
-    const now = new Date();
-    return data?.class.testSessions.map(
-      ({ id, startDate, endDate, test, ...session }) => ({
-        ...session,
-        testSessionId: id,
-        testName: test.name,
-        status: getSessionStatus(startDate, endDate, now),
-        targetDate: getSessionTargetDate(startDate, endDate, now),
-      }),
-    );
-  }, [data]);
+  const formattedData = useMemo(
+    () =>
+      data?.class.testSessions.map(
+        ({ id, startDate, endDate, test, ...session }) => ({
+          ...session,
+          testSessionId: id,
+          testName: test.name,
+          targetDate: getSessionTargetDate(startDate, endDate, session.status),
+        }),
+      ),
+    [data],
+  );
 
   const searchedData = useMemo(() => {
     if (!formattedData) return [];

--- a/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
+++ b/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 
 import {
-  ALL_TEST_SESSION_STATUSES,
+  TEST_SESSION_STATUSES,
   TestSessionStatus,
 } from "../../../types/TestSessionTypes";
 import { titleCase } from "../../../utils/GeneralUtils";
@@ -34,7 +34,7 @@ const AssessmentsSection = () => {
   }, [data, currentTab]);
 
   const sortedData = useMemo(() => {
-    const invertSort = currentTab === "PAST";
+    const invertSort = currentTab === TestSessionStatus.PAST;
     return filteredData?.sort((a, b) => {
       return (
         (invertSort ? -1 : 1) *
@@ -56,11 +56,9 @@ const AssessmentsSection = () => {
         </Box>
       )}
       {!!data?.length && !error && !loading && (
-        <Tabs
-          onChange={(index) => setCurrentTab(ALL_TEST_SESSION_STATUSES[index])}
-        >
+        <Tabs onChange={(index) => setCurrentTab(TEST_SESSION_STATUSES[index])}>
           <TabList border="none" gap={8}>
-            {ALL_TEST_SESSION_STATUSES.map((status) => (
+            {TEST_SESSION_STATUSES.map((status) => (
               <Tab
                 key={status}
                 _focus={{ background: "none" }}
@@ -74,7 +72,7 @@ const AssessmentsSection = () => {
             ))}
           </TabList>
           <TabPanels>
-            {ALL_TEST_SESSION_STATUSES.map((status) => (
+            {TEST_SESSION_STATUSES.map((status) => (
               <TabPanel key={status} p={0}>
                 {sortedData?.map((session) => (
                   <TestSessionListItem

--- a/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
+++ b/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
@@ -10,8 +10,8 @@ import {
 } from "@chakra-ui/react";
 
 import {
-  STATUSES,
-  type TestSessionStatus,
+  ALL_TEST_SESSION_STATUSES,
+  TestSessionStatus,
 } from "../../../types/TestSessionTypes";
 import { titleCase } from "../../../utils/GeneralUtils";
 import ErrorState from "../../common/info/ErrorState";
@@ -23,7 +23,7 @@ import useAssessmentDataQuery from "../view-sessions/useAssessmentDataQuery";
 const QUERY_DATA_LIMIT_PER_STATUS = 6;
 
 const AssessmentsSection = () => {
-  const [currentTab, setCurrentTab] = useState<TestSessionStatus>("ACTIVE");
+  const [currentTab, setCurrentTab] = useState(TestSessionStatus.ACTIVE);
 
   const { loading, error, data } = useAssessmentDataQuery(
     QUERY_DATA_LIMIT_PER_STATUS,
@@ -56,9 +56,11 @@ const AssessmentsSection = () => {
         </Box>
       )}
       {!!data?.length && !error && !loading && (
-        <Tabs onChange={(index) => setCurrentTab(STATUSES[index])}>
+        <Tabs
+          onChange={(index) => setCurrentTab(ALL_TEST_SESSION_STATUSES[index])}
+        >
           <TabList border="none" gap={8}>
-            {STATUSES.map((status) => (
+            {ALL_TEST_SESSION_STATUSES.map((status) => (
               <Tab
                 key={status}
                 _focus={{ background: "none" }}
@@ -72,7 +74,7 @@ const AssessmentsSection = () => {
             ))}
           </TabList>
           <TabPanels>
-            {STATUSES.map((status) => (
+            {ALL_TEST_SESSION_STATUSES.map((status) => (
               <TabPanel key={status} p={0}>
                 {sortedData?.map((session) => (
                   <TestSessionListItem

--- a/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
+++ b/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
@@ -27,7 +27,7 @@ const QUERY_DATA_LIMIT_PER_STATUS = 6;
 const QUERY_DATA_LIMIT = QUERY_DATA_LIMIT_PER_STATUS * STATUSES.length;
 
 const AssessmentsSection = () => {
-  const [currentTab, setCurrentTab] = useState<TestSessionStatus>("active");
+  const [currentTab, setCurrentTab] = useState<TestSessionStatus>("ACTIVE");
 
   const { loading, error, data } = useAssessmentDataQuery(QUERY_DATA_LIMIT);
 

--- a/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
+++ b/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
@@ -22,19 +22,15 @@ import useAssessmentDataQuery from "../view-sessions/useAssessmentDataQuery";
 
 const QUERY_DATA_LIMIT_PER_STATUS = 6;
 
-// 3 tabs - this is a quick way of limiting the number of assessments
-// fetched without having complex backend logic
-const QUERY_DATA_LIMIT = QUERY_DATA_LIMIT_PER_STATUS * STATUSES.length;
-
 const AssessmentsSection = () => {
   const [currentTab, setCurrentTab] = useState<TestSessionStatus>("ACTIVE");
 
-  const { loading, error, data } = useAssessmentDataQuery(QUERY_DATA_LIMIT);
+  const { loading, error, data } = useAssessmentDataQuery(
+    QUERY_DATA_LIMIT_PER_STATUS,
+  );
 
   const filteredData = useMemo(() => {
-    return data
-      ?.filter((session) => session.status === currentTab)
-      .slice(0, QUERY_DATA_LIMIT_PER_STATUS);
+    return data?.filter((session) => session.status === currentTab);
   }, [data, currentTab]);
 
   return (

--- a/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
+++ b/frontend/src/components/teacher/dashboard/AssessmentsSection.tsx
@@ -33,6 +33,16 @@ const AssessmentsSection = () => {
     return data?.filter((session) => session.status === currentTab);
   }, [data, currentTab]);
 
+  const sortedData = useMemo(() => {
+    const invertSort = currentTab === "PAST";
+    return filteredData?.sort((a, b) => {
+      return (
+        (invertSort ? -1 : 1) *
+        (a.targetDate.getTime() - b.targetDate.getTime())
+      );
+    });
+  }, [filteredData, currentTab]);
+
   return (
     <Box flex="1">
       {loading && (
@@ -64,7 +74,7 @@ const AssessmentsSection = () => {
           <TabPanels>
             {STATUSES.map((status) => (
               <TabPanel key={status} p={0}>
-                {filteredData?.map((session) => (
+                {sortedData?.map((session) => (
                   <TestSessionListItem
                     key={session.testSessionId}
                     {...session}

--- a/frontend/src/components/teacher/session-creation/steps/ChooseClass.tsx
+++ b/frontend/src/components/teacher/session-creation/steps/ChooseClass.tsx
@@ -1,70 +1,37 @@
-import React, { useContext, useMemo } from "react";
-import { useQuery } from "@apollo/client";
+import React, {
+  type Dispatch,
+  type ReactElement,
+  type SetStateAction,
+} from "react";
 import { Box, Flex, VStack } from "@chakra-ui/react";
 
-import { GET_CLASSES_BY_TEACHER } from "../../../../APIClients/queries/ClassQueries";
-import type { ClassResponse } from "../../../../APIClients/types/ClassClientTypes";
-import AuthContext from "../../../../contexts/AuthContext";
-import { getSessionStatus } from "../../../../utils/TestSessionUtils";
 import EmptyClassroomsGoToPageMessage from "../../../common/info/messages/EmptyClassroomsGoToPage";
 import Pagination from "../../../common/table/Pagination";
 import usePaginatedData from "../../../common/table/usePaginatedData";
 import ClassroomCard from "../../student-management/classroom-summary/ClassroomCard";
+import useClassDataQuery from "../../student-management/classroom-summary/useClassDataQuery";
 import DistributeAssessmentWrapper from "../DistributeAssessmentWrapper";
 
 interface ChooseClassProps {
   selectedClassId: string;
-  setClassId: React.Dispatch<React.SetStateAction<string>>;
-  setClassName: React.Dispatch<React.SetStateAction<string>>;
+  setClassId: Dispatch<SetStateAction<string>>;
+  setClassName: Dispatch<SetStateAction<string>>;
 }
 
 const ChooseClass = ({
   selectedClassId,
   setClassId,
   setClassName,
-}: ChooseClassProps): React.ReactElement => {
-  const { authenticatedUser } = useContext(AuthContext);
-  const { id: teacherId } = authenticatedUser ?? {};
-
-  const { loading, error, data } = useQuery<{
-    classesByTeacher: ClassResponse[];
-  }>(GET_CLASSES_BY_TEACHER, {
-    fetchPolicy: "cache-and-network",
-    variables: { teacherId },
-    skip: !teacherId,
-  });
-
-  const classCards = useMemo(() => {
-    const now = new Date();
-    return data?.classesByTeacher.map(
-      ({ testSessions, students, ...classCard }) => {
-        let activeAssessments = 0;
-        testSessions.forEach((session) => {
-          if (
-            getSessionStatus(session.startDate, session.endDate, now) ===
-            "active"
-          ) {
-            activeAssessments += 1;
-          }
-        });
-
-        return {
-          ...classCard,
-          activeAssessments,
-          assessmentCount: testSessions.length,
-          studentCount: students.length,
-        };
-      },
-    );
-  }, [data]);
+}: ChooseClassProps): ReactElement => {
+  const { loading, error, data } = useClassDataQuery();
 
   const { paginatedData, totalPages, currentPage, setCurrentPage } =
-    usePaginatedData(classCards);
+    usePaginatedData(data);
 
   return (
     <DistributeAssessmentWrapper
       emptyState={<EmptyClassroomsGoToPageMessage />}
-      isEmpty={classCards?.length === 0}
+      isEmpty={data?.length === 0}
       isError={Boolean(error)}
       isLoading={Boolean(loading)}
       subtitle="Please choose classrooms you want this assessment to be distributed to."

--- a/frontend/src/components/teacher/student-management/classroom-summary/useClassDataQuery.ts
+++ b/frontend/src/components/teacher/student-management/classroom-summary/useClassDataQuery.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@apollo/client";
 import { GET_CLASSES_BY_TEACHER } from "../../../../APIClients/queries/ClassQueries";
 import type { ClassResponse } from "../../../../APIClients/types/ClassClientTypes";
 import AuthContext from "../../../../contexts/AuthContext";
+import { TestSessionStatus } from "../../../../types/TestSessionTypes";
 
 export type QueryOptions = {
   limit?: number;
@@ -32,7 +33,7 @@ const useClassDataQuery = (queryOptions?: QueryOptions) => {
         ({ testSessions, students, ...classCard }) => ({
           ...classCard,
           activeAssessments: testSessions.filter(
-            ({ status }) => status === "ACTIVE",
+            ({ status }) => status === TestSessionStatus.ACTIVE,
           ).length,
           assessmentCount: testSessions.length,
           studentCount: students.length,

--- a/frontend/src/components/teacher/student-management/classroom-summary/useClassDataQuery.ts
+++ b/frontend/src/components/teacher/student-management/classroom-summary/useClassDataQuery.ts
@@ -4,7 +4,6 @@ import { useQuery } from "@apollo/client";
 import { GET_CLASSES_BY_TEACHER } from "../../../../APIClients/queries/ClassQueries";
 import type { ClassResponse } from "../../../../APIClients/types/ClassClientTypes";
 import AuthContext from "../../../../contexts/AuthContext";
-import { getSessionStatus } from "../../../../utils/TestSessionUtils";
 
 export type QueryOptions = {
   limit?: number;
@@ -27,29 +26,20 @@ const useClassDataQuery = (queryOptions?: QueryOptions) => {
     skip: !teacherId,
   });
 
-  const classCards = useMemo(() => {
-    const now = new Date();
-    return data?.classesByTeacher.map(
-      ({ testSessions, students, ...classCard }) => {
-        let activeAssessments = 0;
-        testSessions.forEach((session) => {
-          if (
-            getSessionStatus(session.startDate, session.endDate, now) ===
-            "active"
-          ) {
-            activeAssessments += 1;
-          }
-        });
-
-        return {
+  const classCards = useMemo(
+    () =>
+      data?.classesByTeacher.map(
+        ({ testSessions, students, ...classCard }) => ({
           ...classCard,
-          activeAssessments,
+          activeAssessments: testSessions.filter(
+            ({ status }) => status === "ACTIVE",
+          ).length,
           assessmentCount: testSessions.length,
           studentCount: students.length,
-        };
-      },
-    );
-  }, [data]);
+        }),
+      ),
+    [data],
+  );
 
   return { loading, error, data: classCards };
 };

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -36,19 +36,19 @@ export type TestSessionListItemProps = {
 };
 
 const STATUS_LABELS = {
-  active: "Until",
-  upcoming: "Scheduled",
-  past: "Assigned",
+  ACTIVE: "Until",
+  UPCOMING: "Scheduled",
+  PAST: "Assigned",
 };
 const STATUS_BACKGROUND_COLORS = {
-  active: "green.50",
-  upcoming: "yellow.50",
-  past: "grey.100",
+  ACTIVE: "green.50",
+  UPCOMING: "yellow.50",
+  PAST: "grey.100",
 };
 const STATUS_COLORS = {
-  active: "green.400",
-  upcoming: "yellow.300",
-  past: "grey.400",
+  ACTIVE: "green.400",
+  UPCOMING: "yellow.300",
+  PAST: "grey.400",
 };
 const ACCESS_CODE_GROUP_SIZE = 3;
 
@@ -70,7 +70,7 @@ const TestSessionListItem = ({
 
   return (
     <HStack
-      _hover={{ bg: status === "past" ? "grey.100" : undefined }}
+      _hover={{ bg: status === "PAST" ? "grey.100" : undefined }}
       borderRadius={16}
       gap={0}
       pr={4}
@@ -80,17 +80,17 @@ const TestSessionListItem = ({
         bg="blue.300"
         borderRadius={4}
         hasArrow
-        isDisabled={status !== "past"}
+        isDisabled={status !== "PAST"}
         label="Click to view statistics of this assessment and each student's performance."
         p={2}
         placement="bottom"
       >
         <HStack
-          as={status === "past" ? "button" : undefined}
+          as={status === "PAST" ? "button" : undefined}
           flex={1}
           gap={4}
           onClick={() =>
-            status === "past" &&
+            status === "PAST" &&
             history.push(
               Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE({
                 sessionId: testSessionId,
@@ -145,19 +145,19 @@ const TestSessionListItem = ({
           )}
           <VStack align="start">
             <Text
-              color={status === "past" ? "grey.300" : "blue.300"}
+              color={status === "PAST" ? "grey.300" : "blue.300"}
               textStyle="subtitle2"
             >
               {testName}
             </Text>
             <Text
-              color={status === "past" ? "grey.200" : "blue.200"}
+              color={status === "PAST" ? "grey.200" : "blue.200"}
               textStyle="mobileParagraph"
             >
               {STATUS_LABELS[status]} {formatDate(targetDate)}
             </Text>
           </VStack>
-          {status !== "past" && (
+          {status !== "PAST" && (
             <Copyable
               displayedValue={formattedAccessCode}
               label="Access Code"
@@ -181,7 +181,7 @@ const TestSessionListItem = ({
               </Text>
             </>
           )}
-          {status !== "past" && classroomName == null && (
+          {status !== "PAST" && classroomName == null && (
             <Tag
               bg={STATUS_BACKGROUND_COLORS[status]}
               borderRadius="full"

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -14,10 +14,8 @@ import {
 
 import { BookIcon } from "../../../assets/icons";
 import * as Routes from "../../../constants/Routes";
-import type {
-  TestSessionItemStats,
-  TestSessionStatus,
-} from "../../../types/TestSessionTypes";
+import type { TestSessionItemStats } from "../../../types/TestSessionTypes";
+import { TestSessionStatus } from "../../../types/TestSessionTypes";
 import { formatDate, titleCase } from "../../../utils/GeneralUtils";
 import Copyable from "../../common/Copyable";
 
@@ -70,7 +68,9 @@ const TestSessionListItem = ({
 
   return (
     <HStack
-      _hover={{ bg: status === "PAST" ? "grey.100" : undefined }}
+      _hover={{
+        bg: status === TestSessionStatus.PAST ? "grey.100" : undefined,
+      }}
       borderRadius={16}
       gap={0}
       pr={4}
@@ -80,17 +80,17 @@ const TestSessionListItem = ({
         bg="blue.300"
         borderRadius={4}
         hasArrow
-        isDisabled={status !== "PAST"}
+        isDisabled={status !== TestSessionStatus.PAST}
         label="Click to view statistics of this assessment and each student's performance."
         p={2}
         placement="bottom"
       >
         <HStack
-          as={status === "PAST" ? "button" : undefined}
+          as={status === TestSessionStatus.PAST ? "button" : undefined}
           flex={1}
           gap={4}
           onClick={() =>
-            status === "PAST" &&
+            status === TestSessionStatus.PAST &&
             history.push(
               Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE({
                 sessionId: testSessionId,
@@ -145,19 +145,23 @@ const TestSessionListItem = ({
           )}
           <VStack align="start">
             <Text
-              color={status === "PAST" ? "grey.300" : "blue.300"}
+              color={
+                status === TestSessionStatus.PAST ? "grey.300" : "blue.300"
+              }
               textStyle="subtitle2"
             >
               {testName}
             </Text>
             <Text
-              color={status === "PAST" ? "grey.200" : "blue.200"}
+              color={
+                status === TestSessionStatus.PAST ? "grey.200" : "blue.200"
+              }
               textStyle="mobileParagraph"
             >
               {STATUS_LABELS[status]} {formatDate(targetDate)}
             </Text>
           </VStack>
-          {status !== "PAST" && (
+          {status !== TestSessionStatus.PAST && (
             <Copyable
               displayedValue={formattedAccessCode}
               label="Access Code"
@@ -181,7 +185,7 @@ const TestSessionListItem = ({
               </Text>
             </>
           )}
-          {status !== "PAST" && classroomName == null && (
+          {status !== TestSessionStatus.PAST && classroomName == null && (
             <Tag
               bg={STATUS_BACKGROUND_COLORS[status]}
               borderRadius="full"

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -66,7 +66,7 @@ const TestSessionListItemPopover = ({
       onOpen={onPopoverOpen}
     >
       <VStack spacing={0}>
-        {status !== "past" && (
+        {status !== "PAST" && (
           <>
             <PopoverButton name="Edit" onClick={() => {}} />
             <Divider />

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -5,7 +5,7 @@ import { Divider, useDisclosure, VStack } from "@chakra-ui/react";
 import { DELETE_TEST_SESSION } from "../../../APIClients/mutations/TestSessionMutations";
 import { GET_TEST_SESSIONS_BY_TEACHER_ID } from "../../../APIClients/queries/TestSessionQueries";
 import AuthContext from "../../../contexts/AuthContext";
-import type { TestSessionStatus } from "../../../types/TestSessionTypes";
+import { TestSessionStatus } from "../../../types/TestSessionTypes";
 import DeleteModal from "../../admin/assessment-status/EditStatusModals/DeleteModal";
 import useToast from "../../common/info/useToast";
 import Popover from "../../common/popover/Popover";
@@ -66,7 +66,7 @@ const TestSessionListItemPopover = ({
       onOpen={onPopoverOpen}
     >
       <VStack spacing={0}>
-        {status !== "PAST" && (
+        {status !== TestSessionStatus.PAST && (
           <>
             <PopoverButton name="Edit" onClick={() => {}} />
             <Divider />

--- a/frontend/src/components/teacher/view-sessions/useAssessmentDataQuery.ts
+++ b/frontend/src/components/teacher/view-sessions/useAssessmentDataQuery.ts
@@ -4,10 +4,7 @@ import { useQuery } from "@apollo/client";
 import { GET_TEST_SESSIONS_BY_TEACHER_ID } from "../../../APIClients/queries/TestSessionQueries";
 import type { TestSessionOverviewData } from "../../../APIClients/types/TestSessionClientTypes";
 import AuthContext from "../../../contexts/AuthContext";
-import {
-  getSessionStatus,
-  getSessionTargetDate,
-} from "../../../utils/TestSessionUtils";
+import { getSessionTargetDate } from "../../../utils/TestSessionUtils";
 
 const useAssessmentDataQuery = (limit?: number) => {
   const { authenticatedUser } = useContext(AuthContext);
@@ -21,19 +18,19 @@ const useAssessmentDataQuery = (limit?: number) => {
     skip: !teacherId,
   });
 
-  const formattedData = useMemo(() => {
-    const now = new Date();
-    return data?.testSessionsByTeacherId?.map(
-      ({ id, startDate, endDate, test, class: classroom, ...session }) => ({
-        ...session,
-        testSessionId: id,
-        testName: test.name,
-        classroomName: classroom.className,
-        status: getSessionStatus(startDate, endDate, now),
-        targetDate: getSessionTargetDate(startDate, endDate, now),
-      }),
-    );
-  }, [data]);
+  const formattedData = useMemo(
+    () =>
+      data?.testSessionsByTeacherId?.map(
+        ({ id, startDate, endDate, test, class: classroom, ...session }) => ({
+          ...session,
+          testSessionId: id,
+          testName: test.name,
+          classroomName: classroom.className,
+          targetDate: getSessionTargetDate(startDate, endDate, session.status),
+        }),
+      ),
+    [data],
+  );
 
   return {
     loading,

--- a/frontend/src/types/TestSessionTypes.ts
+++ b/frontend/src/types/TestSessionTypes.ts
@@ -1,5 +1,13 @@
-export const STATUSES = ["ACTIVE", "UPCOMING", "PAST"] as const;
-export type TestSessionStatus = (typeof STATUSES)[number];
+export const enum TestSessionStatus {
+  ACTIVE = "ACTIVE",
+  UPCOMING = "UPCOMING",
+  PAST = "PAST",
+}
+export const ALL_TEST_SESSION_STATUSES = [
+  TestSessionStatus.ACTIVE,
+  TestSessionStatus.UPCOMING,
+  TestSessionStatus.PAST,
+] as const;
 
 export type TestSessionItemStats = {
   mean: number;

--- a/frontend/src/types/TestSessionTypes.ts
+++ b/frontend/src/types/TestSessionTypes.ts
@@ -3,7 +3,7 @@ export const enum TestSessionStatus {
   UPCOMING = "UPCOMING",
   PAST = "PAST",
 }
-export const ALL_TEST_SESSION_STATUSES = [
+export const TEST_SESSION_STATUSES = [
   TestSessionStatus.ACTIVE,
   TestSessionStatus.UPCOMING,
   TestSessionStatus.PAST,

--- a/frontend/src/types/TestSessionTypes.ts
+++ b/frontend/src/types/TestSessionTypes.ts
@@ -1,4 +1,4 @@
-export const STATUSES = ["active", "upcoming", "past"] as const;
+export const STATUSES = ["ACTIVE", "UPCOMING", "PAST"] as const;
 export type TestSessionStatus = (typeof STATUSES)[number];
 
 export type TestSessionItemStats = {

--- a/frontend/src/utils/TestSessionUtils.ts
+++ b/frontend/src/utils/TestSessionUtils.ts
@@ -1,4 +1,4 @@
-import type { TestSessionStatus } from "../types/TestSessionTypes";
+import { TestSessionStatus } from "../types/TestSessionTypes";
 
 import { includesIgnoreCase } from "./GeneralUtils";
 
@@ -6,7 +6,8 @@ export const getSessionTargetDate = (
   startDate: string | Date,
   endDate: string | Date,
   status: TestSessionStatus,
-): Date => (status === "ACTIVE" ? new Date(endDate) : new Date(startDate));
+): Date =>
+  status === TestSessionStatus.ACTIVE ? new Date(endDate) : new Date(startDate);
 
 type SearchableTestSession = {
   testName: string;

--- a/frontend/src/utils/TestSessionUtils.ts
+++ b/frontend/src/utils/TestSessionUtils.ts
@@ -2,25 +2,11 @@ import type { TestSessionStatus } from "../types/TestSessionTypes";
 
 import { includesIgnoreCase } from "./GeneralUtils";
 
-export const getSessionStatus = (
-  startDate: string | Date,
-  endDate: string | Date,
-  now?: Date,
-): TestSessionStatus => {
-  const nowDate = now ?? new Date();
-  if (new Date(endDate) < nowDate) return "past";
-  if (new Date(startDate) > nowDate) return "upcoming";
-  return "active";
-};
-
 export const getSessionTargetDate = (
   startDate: string | Date,
   endDate: string | Date,
-  now?: Date,
-): Date =>
-  getSessionStatus(startDate, endDate, now) === "active"
-    ? new Date(endDate)
-    : new Date(startDate);
+  status: TestSessionStatus,
+): Date => (status === "ACTIVE" ? new Date(endDate) : new Date(startDate));
 
 type SearchableTestSession = {
   testName: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
Follow-up to #492


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Compute test session status on backend
- Limit by assessment status on backend
- Sort assessments by target date on frontend


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
