### PR TITLE
fix: only delete upcoming test sessions

### DIFF
--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -276,20 +276,33 @@ describe("mongo testSessionService", (): void => {
     expect(res.length).toEqual(0);
   });
 
-  it("deleteTestSession", async () => {
-    const savedTestSession = await MgTestSession.create(mockTestSession);
+  describe("deleteTestSession", () => {
+    it("with valid test session id and upcoming start date", async () => {
+      const savedTestSession = await MgTestSession.create(mockTestSession);
 
-    const deletedTestSessionId = await testSessionService.deleteTestSession(
-      savedTestSession.id,
-    );
-    expect(deletedTestSessionId).toBe(savedTestSession.id);
-  });
+      const deletedTestSessionId = await testSessionService.deleteTestSession(
+        savedTestSession.id,
+        new Date("2020-09-01T09:00:00.000Z"),
+      );
+      expect(deletedTestSessionId).toBe(savedTestSession.id);
+    });
 
-  it("deleteTestSession not found", async () => {
-    const notFoundId = "62cf26998b7308f775a572aa";
-    await expect(async () => {
-      await testSessionService.deleteTestSession(notFoundId);
-    }).rejects.toThrowError(`Test Session id ${notFoundId} not found`);
+    it("with test session that already started", async () => {
+      const savedTestSession = await MgTestSession.create(mockTestSession);
+
+      await expect(async () => {
+        await testSessionService.deleteTestSession(savedTestSession.id);
+      }).rejects.toThrowError(
+        `Test Session id ${savedTestSession.id} not found or test session has already started`,
+      );
+    });
+
+    it("with invalid test session id", async () => {
+      const notFoundId = "62cf26998b7308f775a572aa";
+      await expect(async () => {
+        await testSessionService.deleteTestSession(notFoundId);
+      }).rejects.toThrowError(`Test Session id ${notFoundId} not found or test session has already started`);
+    });
   });
 
   it("computeTestGrades", async () => {

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -114,11 +114,16 @@ class TestSessionService implements ITestSessionService {
     }
   }
 
-  async deleteTestSession(id: string): Promise<string> {
+  async deleteTestSession(id: string, now?: Date): Promise<string> {
     try {
-      const deletedTestSession = await MgTestSession.findByIdAndDelete(id);
-      if (!deletedTestSession) {
-        throw new Error(`Test Session id ${id} not found`);
+      const result = await MgTestSession.deleteOne({
+        _id: id,
+        startDate: { $gt: now ?? new Date() },
+      });
+      if (!result.deletedCount) {
+        throw new Error(
+          `Test Session id ${id} not found or test session has already started`,
+        );
       }
       return id;
     } catch (error: unknown) {

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -128,7 +128,7 @@ export interface ITestSessionService {
    * delete a TestSession with the given id, return deleted id
    * @param id id to delete
    * @returns deleted id
-   * @throws Error if deletion fails
+   * @throws Error if deletion fails or given test session has already started
    */
   deleteTestSession(id: string): Promise<string>;
 

--- a/backend/services/interfaces/testSessionService.ts
+++ b/backend/services/interfaces/testSessionService.ts
@@ -127,10 +127,11 @@ export interface ITestSessionService {
   /**
    * delete a TestSession with the given id, return deleted id
    * @param id id to delete
+   * @param now optional date to use as the current date
    * @returns deleted id
    * @throws Error if deletion fails or given test session has already started
    */
-  deleteTestSession(id: string): Promise<string>;
+  deleteTestSession(id: string, now?: Date): Promise<string>;
 
   /**
    * This method fetches all the test sessions from the database.

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -202,12 +202,14 @@ const TestSessionListItem = ({
           )}
         </HStack>
       </Tooltip>
-      <Box ml={1}>
-        <TestSessionListItemPopover
-          status={status}
-          testSessionId={testSessionId}
-        />
-      </Box>
+      {status !== "past" && (
+        <Box ml={1}>
+          <TestSessionListItemPopover
+            status={status}
+            testSessionId={testSessionId}
+          />
+        </Box>
+      )}
     </HStack>
   );
 };

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -65,20 +65,21 @@ const TestSessionListItemPopover = ({
       onClose={onPopoverClose}
       onOpen={onPopoverOpen}
     >
-      <VStack spacing={0}>
+      <VStack divider={<Divider />} spacing={0}>
         {status !== "past" && (
           <>
             <PopoverButton name="Edit" onClick={() => {}} />
-            <Divider />
           </>
         )}
-        <PopoverButton name="Delete" onClick={openDeleteModal} />
-        <DeleteModal
-          deleteAssessment={deleteTestSession}
-          isOpen={isDeleteModalOpen}
-          onClose={onDeleteModalClose}
-        />
+        {status === "upcoming" && (
+          <PopoverButton name="Delete" onClick={openDeleteModal} />
+        )}
       </VStack>
+      <DeleteModal
+        deleteAssessment={deleteTestSession}
+        isOpen={isDeleteModalOpen}
+        onClose={onDeleteModalClose}
+      />
     </Popover>
   );
 };

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -66,11 +66,7 @@ const TestSessionListItemPopover = ({
       onOpen={onPopoverOpen}
     >
       <VStack divider={<Divider />} spacing={0}>
-        {status !== "past" && (
-          <>
-            <PopoverButton name="Edit" onClick={() => {}} />
-          </>
-        )}
+        <PopoverButton name="Edit" onClick={() => {}} />
         {status === "upcoming" && (
           <PopoverButton name="Delete" onClick={openDeleteModal} />
         )}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete Test Session](https://www.notion.so/uwblueprintexecs/Delete-Test-Session-917c97c2802743fb88f93268d5fc8bdc?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Restrict test session deletion to upcoming sessions (where start date > current date)
* Remove popover for past test sessions


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
<img width="1148" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/b1c5ddfb-a60c-4f9a-bc19-62f576e63945">
<img width="1142" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/ad38317d-3976-4049-add3-0a8361379f35">
<img width="781" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/3b231d6d-e33f-4640-add9-94f06ff0b838">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
