### PR TITLE
fix: remove the ability to edit archived classrooms

### DIFF
--- a/backend/services/implementations/classService.ts
+++ b/backend/services/implementations/classService.ts
@@ -151,10 +151,14 @@ class ClassService implements IClassService {
   ): Promise<ClassResponseDTO> {
     let updatedClass: Class | null;
     try {
-      updatedClass = await MgClass.findByIdAndUpdate(id, classObj, {
-        new: true,
-        runValidators: true,
-      });
+      updatedClass = await MgClass.findOneAndUpdate(
+        { _id: id, isActive: { $in: [true, undefined] } },
+        classObj,
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
 
       if (!updatedClass) {
         throw new Error(`Class id ${id} not found`);
@@ -187,7 +191,7 @@ class ClassService implements IClassService {
     let archivedClass: Class | null;
     try {
       archivedClass = await MgClass.findOneAndUpdate(
-        { _id: id, isActive: true },
+        { _id: id, isActive: { $in: [true, undefined] } },
         { $set: { isActive: false } },
         {
           new: true,
@@ -218,8 +222,8 @@ class ClassService implements IClassService {
     let classObj: Class | null;
 
     try {
-      classObj = await MgClass.findByIdAndUpdate(
-        classId,
+      classObj = await MgClass.findOneAndUpdate(
+        { _id: classId, isActive: { $in: [true, undefined] } },
         {
           $push: { students: student },
         },

--- a/frontend/src/APIClients/queries/ClassQueries.ts
+++ b/frontend/src/APIClients/queries/ClassQueries.ts
@@ -39,6 +39,7 @@ export const GET_CLASS_TEST_SESSIONS_BY_ID = gql`
         startDate
         endDate
         accessCode
+        status
       }
     }
   }

--- a/frontend/src/APIClients/queries/ClassQueries.ts
+++ b/frontend/src/APIClients/queries/ClassQueries.ts
@@ -7,6 +7,7 @@ export const GET_CLASS_DETAILS_BY_ID = gql`
       className
       startDate
       gradeLevel
+      isActive
     }
   }
 `;
@@ -41,6 +42,7 @@ export const GET_CLASS_TEST_SESSIONS_BY_ID = gql`
         accessCode
         status
       }
+      isActive
     }
   }
 `;

--- a/frontend/src/APIClients/types/ClassClientTypes.ts
+++ b/frontend/src/APIClients/types/ClassClientTypes.ts
@@ -37,6 +37,8 @@ export type ClassTitleData = {
   startDate: Date;
   /** the grade level of the class */
   gradeLevel: Grade;
+  /** whether or not the class is active */
+  isActive: boolean;
 };
 
 export type ClassStudentData = {
@@ -51,4 +53,6 @@ export type ClassTestSessionData = {
   className: string;
   /** the test sessions for this class */
   testSessions: TestSessionOverviewData[];
+  /** whether or not the class is active */
+  isActive: boolean;
 };

--- a/frontend/src/checkFeatureFlag.ts
+++ b/frontend/src/checkFeatureFlag.ts
@@ -1,5 +1,5 @@
 const flags = {
-  ENABLE_CLASSROOM_ARCHIVING: () => true,
+  ENABLE_CLASSROOM_ARCHIVING: () => false,
 } as const;
 
 export default (flag: keyof typeof flags): boolean => {

--- a/frontend/src/checkFeatureFlag.ts
+++ b/frontend/src/checkFeatureFlag.ts
@@ -1,5 +1,5 @@
 const flags = {
-  ENABLE_CLASSROOM_ARCHIVING: () => false,
+  ENABLE_CLASSROOM_ARCHIVING: () => true,
 } as const;
 
 export default (flag: keyof typeof flags): boolean => {

--- a/frontend/src/components/common/info/messages/EmptyClassSessionsMessage.tsx
+++ b/frontend/src/components/common/info/messages/EmptyClassSessionsMessage.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Center, useStyleConfig } from "@chakra-ui/react";
+
+import { PlusOutlineIcon } from "../../../../assets/icons";
+import DistributeAssessmentsIllustration from "../../../../assets/illustrations/distribute-assessments.svg";
+import { DISTRIBUTE_ASSESSMENT_PAGE } from "../../../../constants/Routes";
+import MessageContainer from "../MessageContainer";
+
+const EmptyClassSessionsMessage = ({
+  classId,
+  isActive,
+}: {
+  classId?: string;
+  isActive?: boolean;
+}): React.ReactElement => {
+  const styles = useStyleConfig("Center", { variant: "emptyMessage" });
+  return (
+    <Center __css={styles} pb={14}>
+      <MessageContainer
+        buttonIcon={<PlusOutlineIcon />}
+        buttonRoute={{
+          pathname: DISTRIBUTE_ASSESSMENT_PAGE,
+          state: classId ? { classId } : {},
+        }}
+        buttonText={isActive ? "Create new assessment" : undefined}
+        image={DistributeAssessmentsIllustration}
+        paragraphs={
+          isActive ? ["Click on the button below to add an assessment."] : []
+        }
+        subtitle="There are no assessments in this classroom."
+        textColor="blue.300"
+      />
+    </Center>
+  );
+};
+
+export default EmptyClassSessionsMessage;

--- a/frontend/src/components/common/info/messages/EmptyClassStudentsMessage.tsx
+++ b/frontend/src/components/common/info/messages/EmptyClassStudentsMessage.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Center } from "@chakra-ui/react";
+
+import { PlusOutlineIcon } from "../../../../assets/icons";
+import DisplayStudentsIllustration from "../../../../assets/illustrations/display-students.svg";
+import MessageContainer from "../MessageContainer";
+
+type EmptyClassStudentsMessageProps = {
+  onClick?: () => void;
+  isActive?: boolean;
+};
+
+const EmptyClassStudentsMessage = ({
+  onClick,
+  isActive,
+}: EmptyClassStudentsMessageProps): React.ReactElement => {
+  return (
+    <Center
+      backgroundColor="blue.50"
+      borderRadius="1rem"
+      color="blue.300"
+      minWidth="100%"
+      pb={14}
+    >
+      <MessageContainer
+        buttonIcon={<PlusOutlineIcon />}
+        buttonText={isActive ? "Add a student" : undefined}
+        image={DisplayStudentsIllustration}
+        onClick={onClick}
+        paragraphs={
+          isActive ? ["Click on the button below to add a student."] : []
+        }
+        subtitle="There are no students in this classroom."
+        textColor="blue.300"
+      />
+    </Center>
+  );
+};
+
+export default EmptyClassStudentsMessage;

--- a/frontend/src/components/common/table/SearchableTablePage.tsx
+++ b/frontend/src/components/common/table/SearchableTablePage.tsx
@@ -37,11 +37,13 @@ const SearchableTablePage = <T, SortPropTypes extends readonly string[]>({
   return (
     <>
       <VStack pb={8} pt={4} spacing={6}>
-        <HStack width="100%">
-          {searchBarComponent}
-          {sortMenuComponent}
-          {filterMenuComponent}
-        </HStack>
+        {searchLength !== 0 && (
+          <HStack width="100%">
+            {searchBarComponent}
+            {sortMenuComponent}
+            {filterMenuComponent}
+          </HStack>
+        )}
         {search && (
           <Text color="grey.300" fontSize="16px" width="100%">
             Showing {searchLength} results for &quot;

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../utils/TestSessionUtils";
 import ErrorState from "../../../common/info/ErrorState";
 import LoadingState from "../../../common/info/LoadingState";
-import EmptySessionsMessage from "../../../common/info/messages/EmptySessionsMessage";
+import EmptyClassSessionsMessage from "../../../common/info/messages/EmptyClassSessionsMessage";
 import Pagination from "../../../common/table/Pagination";
 import SearchableTablePage from "../../../common/table/SearchableTablePage";
 import SearchBar from "../../../common/table/SearchBar";
@@ -105,7 +105,12 @@ const DisplayClassroomAssessmentsPage = () => {
         <SearchableTablePage
           nameOfTableItems="assessments"
           noResults={paginatedData.length === 0}
-          noResultsComponent={<EmptySessionsMessage classId={classroomId} />}
+          noResultsComponent={
+            <EmptyClassSessionsMessage
+              classId={classroomId}
+              isActive={data?.class.isActive}
+            />
+          }
           search={search}
           searchBarComponent={<SearchBar onSearch={setSearch} />}
           searchLength={paginatedData.length}

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
@@ -71,7 +71,11 @@ const DisplayClassroomAssessmentsPage = () => {
   const tableComponent = (
     <VStack w="100%">
       {paginatedData?.map((session) => (
-        <TestSessionListItem key={session.testSessionId} {...session} />
+        <TestSessionListItem
+          key={session.testSessionId}
+          {...session}
+          isReadOnly={!data?.class.isActive}
+        />
       ))}
       {totalPages > 1 && (
         <Center>

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomStudentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomStudentsPage.tsx
@@ -9,7 +9,7 @@ import { filterStudentsBySearch } from "../../../../utils/ClassroomUtils";
 import { sortArray } from "../../../../utils/GeneralUtils";
 import ErrorState from "../../../common/info/ErrorState";
 import LoadingState from "../../../common/info/LoadingState";
-import EmptyStudentsMessage from "../../../common/info/messages/EmptyStudentsMessage";
+import EmptyClassStudentsMessage from "../../../common/info/messages/EmptyClassStudentsMessage";
 import SearchableTablePage from "../../../common/table/SearchableTablePage";
 import SearchBar from "../../../common/table/SearchBar";
 import type { SortOrder } from "../../../common/table/SortMenu";
@@ -68,7 +68,10 @@ const DisplayClassroomStudentsPage = ({
           nameOfTableItems="students"
           noResults={isEmpty}
           noResultsComponent={
-            <EmptyStudentsMessage onClick={onCreateStudent} />
+            <EmptyClassStudentsMessage
+              isActive={data?.class.isActive}
+              onClick={onCreateStudent}
+            />
           }
           search={search}
           searchBarComponent={<SearchBar onSearch={setSearch} />}

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
@@ -77,10 +77,16 @@ const classroomFormDefaultValues: ClassroomForm = {
 
 const getLocationState = (
   state: unknown,
-): { className?: string; startDate?: Date; gradeLevel?: Grade } => ({
+): {
+  className?: string;
+  startDate?: Date;
+  gradeLevel?: Grade;
+  isActive?: boolean;
+} => ({
   className: undefined,
   startDate: undefined,
   gradeLevel: undefined,
+  isActive: undefined,
   ...(typeof state === "object" ? state : {}),
 });
 
@@ -88,13 +94,14 @@ const DisplayClassroomsPage = () => {
   const history = useHistory();
   const { classroomId } = useParams<{ classroomId: string }>();
   const { state } = useLocation();
-  const { className, startDate, gradeLevel } = getLocationState(state);
+  const { className, startDate, gradeLevel, isActive } =
+    getLocationState(state);
 
   const { data } = useQuery<{ class: ClassTitleData }>(
     GET_CLASS_DETAILS_BY_ID,
     {
       variables: { classroomId },
-      skip: !!className && !!startDate && !!gradeLevel,
+      skip: !!className && !!startDate && !!gradeLevel && !!isActive,
     },
   );
   const displayTitle = data?.class.className ?? className;
@@ -109,6 +116,7 @@ const DisplayClassroomsPage = () => {
   );
   const displayGradeLevel = data?.class.gradeLevel ?? gradeLevel;
   const loading = !displayTitle;
+  const isClassActive = data?.class.isActive ?? isActive;
 
   const {
     isOpen: isStudentModalOpen,
@@ -168,6 +176,7 @@ const DisplayClassroomsPage = () => {
           />
         }
         isLoading={loading}
+        showButton={isClassActive}
         title={displayTitle}
       >
         {displayStartDate && (
@@ -180,7 +189,7 @@ const DisplayClassroomsPage = () => {
             {titleCase(removeUnderscore(displayGradeLevel))}
           </Tag>
         )}
-        {!loading && (
+        {!loading && isClassActive && (
           <IconButton
             aria-label="Edit classroom"
             icon={<EditOutlineIcon />}

--- a/frontend/src/components/teacher/student-management/classroom-summary/ClassroomCard.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/ClassroomCard.tsx
@@ -106,7 +106,12 @@ const ClassroomCard = ({
                 as={RouterLink}
                 to={{
                   pathname: Routes.DISPLAY_CLASSROOM_PAGE({ classroomId: id }),
-                  state: { className: name, startDate, gradeLevel: grade },
+                  state: {
+                    className: name,
+                    startDate,
+                    gradeLevel: grade,
+                    isActive,
+                  },
                 }}
               >
                 {classroomTitle}

--- a/frontend/src/components/teacher/student-management/classroom-summary/ClassroomPopover.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/ClassroomPopover.tsx
@@ -98,7 +98,9 @@ const ClassroomPopover = ({
         onOpen={onPopoverOpen}
       >
         <VStack divider={<Divider />} spacing={0}>
-          <PopoverButton name="Edit" onClick={onEditModalOpen} />
+          {!isArchived && (
+            <PopoverButton name="Edit" onClick={onEditModalOpen} />
+          )}
           {!isArchived && checkFeatureFlag("ENABLE_CLASSROOM_ARCHIVING") && (
             <PopoverButton name="Archive" onClick={onArchiveModalOpen} />
           )}

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -30,6 +30,7 @@ export type TestSessionListItemProps = {
   targetDate: Date;
   accessCode: string;
   status: TestSessionStatus;
+  isReadOnly?: boolean;
   stats?: TestSessionItemStats;
 };
 
@@ -57,6 +58,7 @@ const TestSessionListItem = ({
   targetDate,
   accessCode,
   status,
+  isReadOnly = false,
   stats,
 }: TestSessionListItemProps): React.ReactElement => {
   const history = useHistory();
@@ -206,7 +208,7 @@ const TestSessionListItem = ({
           )}
         </HStack>
       </Tooltip>
-      {status !== TestSessionStatus.PAST && (
+      {status !== TestSessionStatus.PAST && !isReadOnly && (
         <Box ml={1}>
           <TestSessionListItemPopover
             status={status}


### PR DESCRIPTION
## Notion ticket link
[Hide all edit options on archived classrooms](https://www.notion.so/uwblueprintexecs/Hide-all-edit-options-on-archived-classrooms-89b3524ae0fd417485d91c69981e7d56)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Hide archive options on frontend
* Filter out archive options from backend methods


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
