### PR TITLE
fix: remove archived classes from test distribution

### DIFF
--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -86,6 +86,22 @@ describe("mongo testSessionService", (): void => {
     expect(updatedClass?.testSessions.map(String)).toEqual([res.id]);
   });
 
+  it("createTestSession for archived class id", async () => {
+    const classObj: Class = await MgClass.create({
+      ...testClassAfterCreation,
+      isActive: false,
+    });
+    await expect(async () => {
+      await testSessionService.createTestSession({
+        ...mockTestSession,
+        class: classObj.id,
+      });
+    }).rejects.toThrowError(
+      `Test session could not be added to class with id ${classObj.id}`,
+    );
+    await expect(MgClass.exists({ _id: classObj.id })).resolves.toBeTruthy();
+  });
+
   it("createTestSession for invalid class id", async () => {
     const invalidClassId = "62c248c0f79d6c3c9ebbea92";
     await expect(async () => {

--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -516,8 +516,8 @@ class TestSessionService implements ITestSessionService {
     testSessionId: string,
   ): Promise<void> {
     try {
-      const classObj: Class | null = await MgClass.findByIdAndUpdate(
-        id,
+      const classObj: Class | null = await MgClass.findOneAndUpdate(
+        { _id: id, isActive: { $in: [true, undefined] } },
         {
           $push: {
             testSessions: testSessionId,

--- a/frontend/src/components/teacher/session-creation/steps/ChooseClass.tsx
+++ b/frontend/src/components/teacher/session-creation/steps/ChooseClass.tsx
@@ -23,7 +23,7 @@ const ChooseClass = ({
   setClassId,
   setClassName,
 }: ChooseClassProps): ReactElement => {
-  const { loading, error, data } = useClassDataQuery();
+  const { loading, error, data } = useClassDataQuery({ excludeArchived: true });
 
   const { paginatedData, totalPages, currentPage, setCurrentPage } =
     usePaginatedData(data);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Filter archived classrooms out of the assessment edit/create flow](https://www.notion.so/uwblueprintexecs/Filter-archived-classrooms-out-of-the-assessment-edit-create-flow-c7a2df10d4714721a4ddefbb5232103e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove archived classrooms from distribution query
* Check for archived classrooms upon submission


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. View distribution page.
2. Verify there are no archived classrooms there.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
