### PR TITLE
fix: minor auth fixes

### DIFF
--- a/backend/graphql/resolvers/authResolvers.ts
+++ b/backend/graphql/resolvers/authResolvers.ts
@@ -57,8 +57,7 @@ const authResolvers = {
 
       if (user.school.id) {
         const school = await schoolService.getSchoolById(user.school.id);
-        const teacherIds = school.teachers.map((teacher) => teacher.id);
-        teacherIds.push(createdUser.id);
+        const teacherIds = [...school.teachers, createdUser.id];
         await schoolService.updateSchool(school.id, {
           ...school,
           teachers: teacherIds,

--- a/backend/graphql/resolvers/schoolResolvers.ts
+++ b/backend/graphql/resolvers/schoolResolvers.ts
@@ -19,6 +19,10 @@ const schoolResolvers = {
       return schoolService.getAllSchools();
     },
   },
+  SchoolResponseDTO: {
+    teachers: ({ teachers }: SchoolResponseDTO) =>
+      userService.findAllUsersByIds(teachers),
+  },
 };
 
 export default schoolResolvers;

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -9,6 +9,10 @@ import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
 import type { UserDTO } from "../../types";
 import type IUserService from "../interfaces/userService";
+import {
+  mapDocumentsToDTOs,
+  mapDocumentToDTO,
+} from "../../utilities/generalUtils";
 
 const Logger = logger(__filename);
 
@@ -26,7 +30,8 @@ class SchoolService implements ISchoolService {
    */
   async getAllSchools(): Promise<Array<SchoolResponseDTO>> {
     try {
-      return await MgSchool.find();
+      const schools = await MgSchool.find();
+      return mapDocumentsToDTOs(schools);
     } catch (error: unknown) {
       Logger.error(`Failed to get schools. Reason = ${getErrorMessage(error)}`);
       throw error;
@@ -45,7 +50,7 @@ class SchoolService implements ISchoolService {
       throw error;
     }
 
-    return school;
+    return mapDocumentToDTO(school);
   }
 
   async getSchoolByTeacherId(teacherId: string): Promise<SchoolResponseDTO> {
@@ -64,7 +69,7 @@ class SchoolService implements ISchoolService {
       throw error;
     }
 
-    return school[0];
+    return mapDocumentToDTO(school[0]);
   }
 
   /**
@@ -95,13 +100,13 @@ class SchoolService implements ISchoolService {
     }
 
     return {
-      id: newSchool.id,
+      id: newSchool.id.toString(),
       name: newSchool.name,
       country: newSchool.country,
       subRegion: newSchool.subRegion,
       city: newSchool.city,
       address: newSchool.address,
-      teachers: teacherDTOs.map((teacher) => teacher.id),
+      teachers: teacherDTOs.map((teacher) => teacher.id.toString()),
     };
   }
 
@@ -119,7 +124,7 @@ class SchoolService implements ISchoolService {
       if (!updatedSchool) {
         throw new Error(`School id ${id} not found`);
       }
-      return updatedSchool;
+      return mapDocumentToDTO(updatedSchool);
     } catch (error: unknown) {
       Logger.error(
         `Failed to update school. Reason = ${getErrorMessage(error)}`,

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -26,8 +26,7 @@ class SchoolService implements ISchoolService {
    */
   async getAllSchools(): Promise<Array<SchoolResponseDTO>> {
     try {
-      const schools: Array<School> = await MgSchool.find();
-      return await this.mapSchoolsToSchoolResponseDTOs(schools);
+      return await MgSchool.find();
     } catch (error: unknown) {
       Logger.error(`Failed to get schools. Reason = ${getErrorMessage(error)}`);
       throw error;
@@ -46,7 +45,7 @@ class SchoolService implements ISchoolService {
       throw error;
     }
 
-    return (await this.mapSchoolsToSchoolResponseDTOs([school]))[0];
+    return school;
   }
 
   async getSchoolByTeacherId(teacherId: string): Promise<SchoolResponseDTO> {
@@ -65,28 +64,7 @@ class SchoolService implements ISchoolService {
       throw error;
     }
 
-    return (await this.mapSchoolsToSchoolResponseDTOs([school[0]]))[0];
-  }
-
-  private async mapSchoolsToSchoolResponseDTOs(
-    schools: Array<School>,
-  ): Promise<Array<SchoolResponseDTO>> {
-    return Promise.all(
-      schools.map(async (school) => {
-        const teacherDTOs: Array<UserDTO> =
-          await this.userService.findAllUsersByIds(school.teachers);
-
-        return {
-          id: school.id,
-          name: school.name,
-          country: school.country,
-          subRegion: school.subRegion,
-          city: school.city,
-          address: school.address,
-          teachers: teacherDTOs,
-        };
-      }),
-    );
+    return school[0];
   }
 
   /**
@@ -123,7 +101,7 @@ class SchoolService implements ISchoolService {
       subRegion: newSchool.subRegion,
       city: newSchool.city,
       address: newSchool.address,
-      teachers: teacherDTOs,
+      teachers: teacherDTOs.map((teacher) => teacher.id),
     };
   }
 
@@ -141,9 +119,7 @@ class SchoolService implements ISchoolService {
       if (!updatedSchool) {
         throw new Error(`School id ${id} not found`);
       }
-      return (
-        await this.mapSchoolsToSchoolResponseDTOs([updatedSchool as School])
-      )[0];
+      return updatedSchool;
     } catch (error: unknown) {
       Logger.error(
         `Failed to update school. Reason = ${getErrorMessage(error)}`,

--- a/backend/services/implementations/schoolService.ts
+++ b/backend/services/implementations/schoolService.ts
@@ -100,13 +100,13 @@ class SchoolService implements ISchoolService {
     }
 
     return {
-      id: newSchool.id.toString(),
+      id: newSchool.id,
       name: newSchool.name,
       country: newSchool.country,
       subRegion: newSchool.subRegion,
       city: newSchool.city,
       address: newSchool.address,
-      teachers: teacherDTOs.map((teacher) => teacher.id.toString()),
+      teachers: teacherDTOs.map((teacher) => teacher.id),
     };
   }
 

--- a/backend/services/interfaces/schoolService.ts
+++ b/backend/services/interfaces/schoolService.ts
@@ -1,5 +1,3 @@
-import type { UserDTO } from "../../types";
-
 /**
  * This interface contains the request object that is fed into
  * the school service to create or update the school in the database.
@@ -36,8 +34,8 @@ export interface SchoolResponseDTO {
   city: string;
   /** the address of the school */
   address: string;
-  /** the teachers that teach at the school */
-  teachers: UserDTO[];
+  /** the IDs of teachers that teach at the school */
+  teachers: string[];
 }
 
 /**

--- a/backend/testUtils/school.ts
+++ b/backend/testUtils/school.ts
@@ -66,7 +66,9 @@ export const assertResponseMatchesExpected = (
   expect(result.subRegion).toEqual(expected.subRegion);
   expect(result.city).toEqual(expected.city);
   expect(result.address).toEqual(expected.address);
-  expect(result.teachers).toEqual(testUsers);
+  result.teachers.forEach((teacher, i) => {
+    expect(teacher.toString()).toEqual(expected.teachers[i].toString());
+  });
 };
 
 export const createSchoolWithCountry = async (

--- a/frontend/src/APIClients/queries/SchoolQueries.ts
+++ b/frontend/src/APIClients/queries/SchoolQueries.ts
@@ -17,13 +17,6 @@ export const GET_ALL_SCHOOLS = gql`
       subRegion
       city
       address
-      teachers {
-        id
-        firstName
-        lastName
-        email
-        role
-      }
     }
   }
 `;

--- a/frontend/src/APIClients/types/SchoolClientTypes.ts
+++ b/frontend/src/APIClients/types/SchoolClientTypes.ts
@@ -1,5 +1,3 @@
-import type { UserResponse } from "./UserClientTypes";
-
 export interface SchoolRequest {
   /** the name of the school */
   name: string;
@@ -28,6 +26,4 @@ export interface SchoolResponse {
   city: string;
   /** the address of the school */
   address: string;
-  /** the teachers that teach at the school */
-  teachers: UserResponse[];
 }

--- a/frontend/src/components/auth/password/PasswordForm.tsx
+++ b/frontend/src/components/auth/password/PasswordForm.tsx
@@ -108,12 +108,14 @@ const PasswordForm = ({
       {displayRequirementError && (
         <FormError message="Password does not meet all of the requirements" />
       )}
-      {version === "AdminSignup" && (
-        <FormControl isRequired pb={6}>
-          <FormLabel color="grey.400">Email Address</FormLabel>
-          <Input disabled type="email" value={email} />
-        </FormControl>
-      )}
+      <FormControl
+        display={version === "AdminSignup" ? undefined : "none"}
+        isRequired
+        pb={6}
+      >
+        <FormLabel color="grey.400">Email Address</FormLabel>
+        <Input disabled name="email" type="email" value={email} />
+      </FormControl>
       <FormControl isRequired pb={6}>
         <FormLabel color="grey.400">Password</FormLabel>
         <Input

--- a/frontend/src/components/auth/teacher-signup/NavigationButtons.tsx
+++ b/frontend/src/components/auth/teacher-signup/NavigationButtons.tsx
@@ -25,6 +25,7 @@ const NavigationButtons = ({
       <Button
         leftIcon={<ArrowBackOutlineIcon />}
         onClick={onBackClick}
+        type="button"
         variant="tertiary"
       >
         {backButtonText}

--- a/frontend/src/components/auth/teacher-signup/steps/TeacherSignUpOne.tsx
+++ b/frontend/src/components/auth/teacher-signup/steps/TeacherSignUpOne.tsx
@@ -153,6 +153,7 @@ const TeacherSignupOne = ({
       <FormControl isInvalid={acceptEmailError || emailError} isRequired>
         <FormLabel color="grey.400">Email Address</FormLabel>
         <Input
+          name="email"
           onChange={(e) => handleChange(e, "email")}
           placeholder="Enter Email Address"
           type="email"

--- a/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
+++ b/frontend/src/components/auth/teacher-signup/steps/TeacherSignupFour.tsx
@@ -20,6 +20,7 @@ const TeacherSignupFour = ({
   const image = TEACHER_SIGNUP_IMAGE;
   const form = (
     <PasswordForm
+      email={watch("email")}
       handleSubmitCallback={handleSubmitCallback}
       setStep={() => {
         if (watch("school.name")) {


### PR DESCRIPTION

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix autofill on password signup pages](https://www.notion.so/uwblueprintexecs/Fix-autofill-on-password-signup-pages-a7d10d0e43584c66b2872cf6be380c2a)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
This PR fixes a few minor papercuts surrounding auth. Originally I was just going to fix autofill but I found a few other papercut-y things.
- Fix front-end error fetching schools
- Fix reset password UI
- Fix autofill on all password pages


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
Please try making accounts locally and make sure autofill works for you!


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
If you can figure out a way to make it so pressing the back button after filling in the last part of the teacher sign-up page DOESN'T offer to save your password, I'm all ears!


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
