### PR TITLE
fix: hide data visualization behind a ff

### DIFF
--- a/frontend/src/checkFeatureFlag.ts
+++ b/frontend/src/checkFeatureFlag.ts
@@ -1,5 +1,7 @@
 const flags = {
   ENABLE_CLASSROOM_ARCHIVING: () => true,
+  ENABLE_TEACHER_DATA_VIZ: () => false,
+  ENABLE_ADMIN_DATA_VIZ: () => false,
 } as const;
 
 export default (flag: keyof typeof flags): boolean => {

--- a/frontend/src/components/admin/view-assessments/AssessmentsTable.tsx
+++ b/frontend/src/components/admin/view-assessments/AssessmentsTable.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useHistory } from "react-router-dom";
 import { Text } from "@chakra-ui/react";
 
+import checkFeatureFlag from "../../../checkFeatureFlag";
 import type {
   AssessmentProperties,
   Status,
@@ -18,6 +20,8 @@ interface AssessmentsTableProps {
 const AssessmentsTable = ({
   assessments,
 }: AssessmentsTableProps): React.ReactElement => {
+  const history = useHistory();
+
   const headers = ["Status", "Name", "Grade", "Type", "Country", "Region"];
   const rows: TableRow[] = assessments.map((assessment, i) => ({
     values: [
@@ -36,6 +40,12 @@ const AssessmentsTable = ({
         assessmentStatus={assessment.status}
       />
     ),
+    onClick: () => {
+      if (checkFeatureFlag("ENABLE_ADMIN_DATA_VIZ")) {
+        // TODO fill this in
+        history.push("TBD");
+      }
+    },
   }));
 
   return <Table headers={headers} rows={rows} />;

--- a/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
@@ -15,8 +15,8 @@ import NotFound from "../../NotFound";
 import DisplayAssessmentResultsByStudentPage from "./DisplayAssessmentResultsByStudentPage";
 import DisplayAssessmentResultsSummaryPage from "./DisplayAssessmentResultsSummaryPage";
 
-const makeTabConfig = (enableTeacherDataViz: boolean) => [
-  ...(enableTeacherDataViz
+const makeTabConfig = (isTeacherDataVizEnabled: boolean) => [
+  ...(isTeacherDataVizEnabled
     ? [
         {
           name: "Summary",
@@ -36,7 +36,7 @@ const makeTabConfig = (enableTeacherDataViz: boolean) => [
     element: (
       <RedirectTo
         pathname={
-          enableTeacherDataViz
+          isTeacherDataVizEnabled
             ? Routes.DISPLAY_ASSESSMENT_RESULTS_SUMMARY_PAGE
             : Routes.DISPLAY_ASSESSMENT_RESULTS_BY_STUDENT_PAGE
         }
@@ -72,10 +72,10 @@ const DisplayAssessmentResults = () => {
     skip: !!sessionTitle,
   });
 
-  const enableTeacherDataViz = checkFeatureFlag("ENABLE_TEACHER_DATA_VIZ");
+  const isTeacherDataVizEnabled = checkFeatureFlag("ENABLE_TEACHER_DATA_VIZ");
   const TAB_CONFIG = useMemo(
-    () => makeTabConfig(enableTeacherDataViz),
-    [enableTeacherDataViz],
+    () => makeTabConfig(isTeacherDataVizEnabled),
+    [isTeacherDataVizEnabled],
   );
 
   const displayTitle = data?.testSession.test.name ?? sessionTitle;

--- a/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 import { Box, Flex, Skeleton, Text } from "@chakra-ui/react";
 
 import { GET_TEST_SESSION_TITLE } from "../../../../APIClients/queries/TestSessionQueries";
 import type { TestSessionTitleData } from "../../../../APIClients/types/TestSessionClientTypes";
+import checkFeatureFlag from "../../../../checkFeatureFlag";
 import * as Routes from "../../../../constants/Routes";
 import RedirectTo from "../../../auth/RedirectTo";
 import BackButton from "../../../common/navigation/BackButton";
@@ -14,12 +15,16 @@ import NotFound from "../../NotFound";
 import DisplayAssessmentResultsByStudentPage from "./DisplayAssessmentResultsByStudentPage";
 import DisplayAssessmentResultsSummaryPage from "./DisplayAssessmentResultsSummaryPage";
 
-const TAB_CONFIG = [
-  {
-    name: "Summary",
-    path: Routes.DISPLAY_ASSESSMENT_RESULTS_SUMMARY_PAGE(),
-    Component: DisplayAssessmentResultsSummaryPage,
-  },
+const makeTabConfig = (enableTeacherDataViz: boolean) => [
+  ...(enableTeacherDataViz
+    ? [
+        {
+          name: "Summary",
+          path: Routes.DISPLAY_ASSESSMENT_RESULTS_SUMMARY_PAGE(),
+          Component: DisplayAssessmentResultsSummaryPage,
+        },
+      ]
+    : []),
   {
     name: "Student",
     path: Routes.DISPLAY_ASSESSMENT_RESULTS_BY_STUDENT_PAGE(),
@@ -29,7 +34,13 @@ const TAB_CONFIG = [
     path: Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE(),
     exact: true,
     element: (
-      <RedirectTo pathname={Routes.DISPLAY_ASSESSMENT_RESULTS_SUMMARY_PAGE} />
+      <RedirectTo
+        pathname={
+          enableTeacherDataViz
+            ? Routes.DISPLAY_ASSESSMENT_RESULTS_SUMMARY_PAGE
+            : Routes.DISPLAY_ASSESSMENT_RESULTS_BY_STUDENT_PAGE
+        }
+      />
     ),
   },
   {
@@ -60,6 +71,12 @@ const DisplayAssessmentResults = () => {
     variables: { id: sessionId },
     skip: !!sessionTitle,
   });
+
+  const enableTeacherDataViz = checkFeatureFlag("ENABLE_TEACHER_DATA_VIZ");
+  const TAB_CONFIG = useMemo(
+    () => makeTabConfig(enableTeacherDataViz),
+    [enableTeacherDataViz],
+  );
 
   const displayTitle = data?.testSession.test.name ?? sessionTitle;
   return (

--- a/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
@@ -15,7 +15,7 @@ import NotFound from "../../NotFound";
 import DisplayAssessmentResultsByStudentPage from "./DisplayAssessmentResultsByStudentPage";
 import DisplayAssessmentResultsSummaryPage from "./DisplayAssessmentResultsSummaryPage";
 
-const makeTabConfig = (isTeacherDataVizEnabled: boolean) => [
+const getTabConfig = (isTeacherDataVizEnabled: boolean) => [
   ...(isTeacherDataVizEnabled
     ? [
         {
@@ -74,7 +74,7 @@ const DisplayAssessmentResults = () => {
 
   const isTeacherDataVizEnabled = checkFeatureFlag("ENABLE_TEACHER_DATA_VIZ");
   const TAB_CONFIG = useMemo(
-    () => makeTabConfig(isTeacherDataVizEnabled),
+    () => getTabConfig(isTeacherDataVizEnabled),
     [isTeacherDataVizEnabled],
   );
 


### PR DESCRIPTION

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Hide data visualization (teacher & admin) features](https://www.notion.so/uwblueprintexecs/Hide-data-visualization-teacher-admin-features-617d4e21942e40d9a5cff1fd0b6b9375)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Gate teacher data viz behind feature flag
- Gate admin data viz behind feature flag


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. View admin homepage and teacher assessment drilldown page.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
