### PR TITLE
fix: Remove test session field from class (1)

### DIFF
--- a/backend/graphql/resolvers/testSessionResolvers.ts
+++ b/backend/graphql/resolvers/testSessionResolvers.ts
@@ -45,7 +45,7 @@ const testSessionResolvers = {
   Mutation: {
     createTestSession: (
       _req: undefined,
-      { testSession }: { classId: string; testSession: TestSessionRequestDTO },
+      { testSession }: { testSession: TestSessionRequestDTO },
     ) => testSessionService.createTestSession(testSession),
     createTestSessionResult: (
       _req: undefined,

--- a/backend/models/class.model.ts
+++ b/backend/models/class.model.ts
@@ -17,8 +17,6 @@ export interface Class extends Document {
   gradeLevel: Grade;
   /** the id of the teacher that teaches the class  */
   teacher: string;
-  /** the ids of the test sessions assigned to the class */
-  testSessions: string[];
   /** the students of the class */
   students: Student[];
   /** whether the class is active or archived */
@@ -69,10 +67,6 @@ const ClassSchema: Schema = new Schema(
     teacher: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
-      required: true,
-    },
-    testSessions: {
-      type: [{ type: mongoose.Schema.Types.ObjectId, ref: "TestSession" }],
       required: true,
     },
     students: {

--- a/backend/services/implementations/__tests__/testSessionService.test.ts
+++ b/backend/services/implementations/__tests__/testSessionService.test.ts
@@ -36,14 +36,12 @@ import {
   mockClassWithId,
   testClassAfterCreation,
 } from "../../../testUtils/class";
-import ClassService from "../classService";
 
 describe("mongo testSessionService", (): void => {
   let testSessionService: TestSessionService;
   let testService: TestService;
   let userService: UserService;
   let schoolService: SchoolService;
-  let classService: ClassService;
 
   beforeAll(async () => {
     await db.connect();
@@ -58,14 +56,12 @@ describe("mongo testSessionService", (): void => {
     schoolService = new SchoolService(userService);
     testService = new TestService();
     testSessionService = new TestSessionService(testService);
-    classService = new ClassService(userService, testSessionService);
 
     if (expect.getState().currentTestName.includes("exclude mock values"))
       return;
     testService.getTestById = jest.fn().mockReturnValue(mockTestWithId);
     userService.getUserById = jest.fn().mockReturnValue(mockTeacher);
     schoolService.getSchoolById = jest.fn().mockReturnValue(mockSchoolWithId);
-    classService.getClassById = jest.fn().mockReturnValue(mockClassWithId);
   });
 
   afterEach(async () => {
@@ -81,9 +77,6 @@ describe("mongo testSessionService", (): void => {
 
     assertResponseMatchesExpected(mockTestSession, res);
     expect(res.results).toEqual([]);
-
-    const updatedClass = await MgClass.findById(classObj.id);
-    expect(updatedClass?.testSessions.map(String)).toEqual([res.id]);
   });
 
   it("createTestSession for archived class id", async () => {

--- a/backend/services/interfaces/classService.ts
+++ b/backend/services/interfaces/classService.ts
@@ -26,7 +26,6 @@ export interface ClassResponseDTO {
   startDate: Date;
   gradeLevel: Grade;
   teacher: string;
-  testSessions: string[];
   students: StudentResponseDTO[];
   isActive: boolean;
 }

--- a/backend/testUtils/class.ts
+++ b/backend/testUtils/class.ts
@@ -96,5 +96,4 @@ export const mockClassWithId2 = {
 export const testClassAfterCreation = {
   ...testClass[0],
   students: [],
-  testSessions: [],
 };

--- a/backend/testUtils/classAssertions.ts
+++ b/backend/testUtils/classAssertions.ts
@@ -5,7 +5,6 @@ import type {
   StudentResponseDTO,
   TestableStudentsDTO,
 } from "../services/interfaces/classService";
-import { mockTestSessionWithId } from "./testSession";
 
 export const assertResponseMatchesExpected = (
   expected: ClassRequestDTO,
@@ -18,12 +17,6 @@ export const assertResponseMatchesExpected = (
   expect(result.gradeLevel.toString()).toEqual(expected.gradeLevel.toString());
   expect(result.teacher.toString()).toEqual(expected.teacher.toString());
   expect(result.isActive).toEqual(isActive);
-  if (result.testSessions.length !== 0) {
-    expect(result.testSessions.length).toEqual(1);
-    expect(result.testSessions[0].toString()).toEqual(mockTestSessionWithId.id);
-  } else {
-    expect(result.testSessions).toEqual([]);
-  }
 };
 
 export const assertArrayResponseMatchesExpected = (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Remove test session field from class](https://www.notion.so/uwblueprintexecs/Remove-test-session-field-from-class-027bfac97d624aceba1ec37a203788a2?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove `testSessions` field from Class model since we populate this field in the resolver
* Update `createTestSession` logic to not add test session to class and only validate that the class exists and is active
* Fix unit tests to support new model
* Remove `ClassService` dependency from `TestSessionService`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify that you can see all assessments in teacher dashboard
2. Verify that you can see all assessments in assessments page
3. Verify that you can see all assessments in a classroom
4. Verify that creating a new test session works


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* No breaking changes


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
