### PR TITLE
fix: expired refresh token issues

### DIFF
--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -233,6 +233,9 @@ class AuthService implements IAuthService {
 
       return firebaseUser.emailVerified && roles.has(userRole);
     } catch (error) {
+      Logger.error(
+        `Failed to verify caller. Reason = ${getErrorMessage(error)}`,
+      );
       return false;
     }
   }
@@ -256,6 +259,9 @@ class AuthService implements IAuthService {
         firebaseUser.emailVerified && String(tokenUserId) === requestedUserId
       );
     } catch (error) {
+      Logger.error(
+        `Failed to verify caller. Reason = ${getErrorMessage(error)}`,
+      );
       return false;
     }
   }
@@ -276,6 +282,9 @@ class AuthService implements IAuthService {
         firebaseUser.emailVerified && decodedIdToken.email === requestedEmail
       );
     } catch (error) {
+      Logger.error(
+        `Failed to verify caller. Reason = ${getErrorMessage(error)}`,
+      );
       return false;
     }
   }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
+import { onError } from "@apollo/client/link/error";
 import { createUploadLink } from "apollo-upload-client";
 
 import AuthAPIClient from "./APIClients/AuthAPIClient";
@@ -96,10 +97,24 @@ const authLink = setContext(async (_, { headers }) => {
   };
 });
 
+const authErrorLink = onError(({ graphQLErrors }) => {
+  if (graphQLErrors) {
+    let foundRefreshError = false;
+    graphQLErrors.forEach(({ extensions }) => {
+      if (extensions.code === "UNAUTHENTICATED") {
+        foundRefreshError = true;
+      }
+    });
+
+    if (foundRefreshError) {
+      attemptRefresh().catch(console.error);
+    }
+  }
+});
+
 const apolloClient = new ApolloClient({
   uri: `${process.env.REACT_APP_BACKEND_URL}`,
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  link: authLink.concat(link as any),
+  link: authErrorLink.concat(authLink.concat(link)),
   cache: new InMemoryCache(),
 });
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -98,17 +98,11 @@ const authLink = setContext(async (_, { headers }) => {
 });
 
 const authErrorLink = onError(({ graphQLErrors }) => {
-  if (graphQLErrors) {
-    let foundRefreshError = false;
-    graphQLErrors.forEach(({ extensions }) => {
-      if (extensions.code === "UNAUTHENTICATED") {
-        foundRefreshError = true;
-      }
-    });
-
-    if (foundRefreshError) {
-      attemptRefresh().catch(console.error);
-    }
+  const wasAuthError = !!graphQLErrors?.some(
+    ({ extensions }) => extensions.code === "UNAUTHENTICATED",
+  );
+  if (wasAuthError) {
+    attemptRefresh().catch(console.error);
   }
 });
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
n/a


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
In a previous PR, I implemented logic to automatically request a new session token if the current one has expired. That logic neglected to account for cases where the refresh token itself has been revoked, which can occur (for example) if a user resets their password. Implementation details:
- Add logging to backend to help with future debugging
- Add basic refresh-else-signout logic to failed requests


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
This is hard to test; basically you need an expired refresh token. You can probably just take my word that this works.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
