### PR TITLE
fix: fix question number padding

### DIFF
--- a/frontend/src/components/student/QuestionNumber.tsx
+++ b/frontend/src/components/student/QuestionNumber.tsx
@@ -23,13 +23,15 @@ const QuestionNumber = ({
           fontSize="20px"
           icon={<CheckmarkIcon />}
           isActive
-          minWidth="3.7rem"
+          maxWidth="3.6rem"
+          minWidth="3.6rem"
           onClick={onClick}
           variant="primary"
         />
       ) : (
         <Button
-          minWidth="3.7rem"
+          maxWidth="3.6rem"
+          minWidth="3.6rem"
           onClick={onClick}
           variant={
             status === QuestionNumberTypes.CURRENT ? "primary" : "outline"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix question number padding](https://www.notion.so/uwblueprintexecs/Fix-question-number-padding-1b34e6dcd09f417a968ce14e02677ade?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set max width to fix the width of the button (min width is still needed to override default button styling)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify that the question boxes are the same width for all numbers
2. Verify that the width matches the Figma specs
<img width="187" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/8e33d2e4-ba58-4794-8819-c82cdc5d3cd3">
<img width="1438" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/285c7ab3-a364-454d-8c91-9f8cea05f731">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
