### PR TITLE
fix: fix test session list item UI

### DIFF
--- a/frontend/src/components/common/navigation/RouterTabs.tsx
+++ b/frontend/src/components/common/navigation/RouterTabs.tsx
@@ -60,7 +60,7 @@ const RouterTabs = ({ routes }: RouterTabsProps) => {
         </TabList>
         <TabPanels>
           {routes.map(({ path, Component, element }) => (
-            <TabPanel key={path} p={0} pt={8}>
+            <TabPanel key={path} p={0}>
               {Component ? <Component /> : element}
             </TabPanel>
           ))}

--- a/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/DisplayAssessmentResultsByStudentPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/DisplayAssessmentResultsByStudentPage.tsx
@@ -74,7 +74,7 @@ const DisplayAssessmentResultsByStudentPage = () => {
     studentIdToResultsMap[selectedStudentId] ?? {};
 
   return (
-    <Flex gap={14} h="calc(100vh - 235px)">
+    <Flex gap={14} h="calc(100vh - 235px)" pt={4}>
       <StudentList
         selectedStudentId={selectedStudentId}
         setSelectedStudentId={setSelectedStudentId}

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
@@ -76,6 +76,7 @@ const DisplayClassroomAssessmentsPage = () => {
       {paginatedData?.map((session) => (
         <TestSessionListItem
           key={session.testSessionId}
+          inClassroomPage
           isReadOnly={!data?.class.isActive}
           session={{
             ...session,

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -11,7 +11,6 @@ import Copyable from "../../common/Copyable";
 import TestSessionListItemBody from "./TestSessionListItemBody";
 import TestSessionListItemPopover from "./TestSessionListItemPopover";
 import TestSessionListItemStatistics from "./TestSessionListItemStatistics";
-import TestSessionListItemStatusTag from "./TestSessionListItemStatusTag";
 
 export type TestSessionListItemProps = {
   session: TestSessionEditingData & {
@@ -36,6 +35,7 @@ const TestSessionListItem = ({
   const history = useHistory();
   const { testSessionId, classroomName, testName, status } = session;
   const { targetDate, accessCode, ...testSessionEditingData } = session;
+  const isPast = status === TestSessionStatus.PAST;
 
   const formattedAccessCode = `${accessCode.slice(
     0,
@@ -56,23 +56,26 @@ const TestSessionListItem = ({
       },
     );
 
-  return status === TestSessionStatus.PAST ? (
+  return (
     <Tooltip
       bg="blue.300"
       borderRadius={4}
       hasArrow
+      isDisabled={!isPast}
       label="Click to view statistics of this assessment and each student's performance."
       p={2}
       placement="bottom"
     >
       <HStack
-        _hover={{ bg: "grey.100" }}
-        as="button"
-        borderRadius={16}
         gap={6}
-        onClick={onViewStatistics}
         p={4}
         w="100%"
+        {...(isPast && {
+          _hover: { bg: "grey.100" },
+          as: "button",
+          borderRadius: 16,
+          onClick: onViewStatistics,
+        })}
       >
         <TestSessionListItemBody
           classroomName={classroomName}
@@ -82,31 +85,24 @@ const TestSessionListItem = ({
           testName={testName}
         />
         <Spacer />
-        {stats && <TestSessionListItemStatistics stats={stats} />}
+        {isPast ? (
+          stats && <TestSessionListItemStatistics stats={stats} />
+        ) : (
+          <>
+            <Copyable
+              displayedValue={formattedAccessCode}
+              label="Access Code"
+              value={accessCode}
+            />
+            {!isReadOnly && (
+              <TestSessionListItemPopover
+                testSessionEditingData={testSessionEditingData}
+              />
+            )}
+          </>
+        )}
       </HStack>
     </Tooltip>
-  ) : (
-    <HStack gap={6} p={4} w="100%">
-      <TestSessionListItemBody
-        classroomName={classroomName}
-        inClassroomPage={inClassroomPage}
-        status={status}
-        targetDate={targetDate}
-        testName={testName}
-      />
-      <Copyable
-        displayedValue={formattedAccessCode}
-        label="Access Code"
-        value={accessCode}
-      />
-      <Spacer />
-      {inClassroomPage && <TestSessionListItemStatusTag status={status} />}
-      {!isReadOnly && (
-        <TestSessionListItemPopover
-          testSessionEditingData={testSessionEditingData}
-        />
-      )}
-    </HStack>
   );
 };
 

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItem.tsx
@@ -1,26 +1,17 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
-import {
-  Box,
-  HStack,
-  Spacer,
-  Tag,
-  TagLabel,
-  TagLeftIcon,
-  Text,
-  Tooltip,
-  VStack,
-} from "@chakra-ui/react";
+import { HStack, Spacer, Tooltip } from "@chakra-ui/react";
 
 import type { TestSessionEditingData } from "../../../APIClients/types/TestSessionClientTypes";
-import { BookIcon } from "../../../assets/icons";
 import * as Routes from "../../../constants/Routes";
 import type { TestSessionItemStats } from "../../../types/TestSessionTypes";
 import { TestSessionStatus } from "../../../types/TestSessionTypes";
-import { formatDate, titleCase } from "../../../utils/GeneralUtils";
 import Copyable from "../../common/Copyable";
 
+import TestSessionListItemBody from "./TestSessionListItemBody";
 import TestSessionListItemPopover from "./TestSessionListItemPopover";
+import TestSessionListItemStatistics from "./TestSessionListItemStatistics";
+import TestSessionListItemStatusTag from "./TestSessionListItemStatusTag";
 
 export type TestSessionListItemProps = {
   session: TestSessionEditingData & {
@@ -31,29 +22,16 @@ export type TestSessionListItemProps = {
   };
   isReadOnly?: boolean;
   stats?: TestSessionItemStats;
+  inClassroomPage?: boolean;
 };
 
-const STATUS_LABELS = {
-  ACTIVE: "Until",
-  UPCOMING: "Scheduled",
-  PAST: "Assigned",
-};
-const STATUS_BACKGROUND_COLORS = {
-  ACTIVE: "green.50",
-  UPCOMING: "yellow.50",
-  PAST: "grey.100",
-};
-const STATUS_COLORS = {
-  ACTIVE: "green.400",
-  UPCOMING: "yellow.300",
-  PAST: "grey.400",
-};
 const ACCESS_CODE_GROUP_SIZE = 3;
 
 const TestSessionListItem = ({
   session,
   isReadOnly = false,
   stats,
+  inClassroomPage = false,
 }: TestSessionListItemProps): React.ReactElement => {
   const history = useHistory();
   const { testSessionId, classroomName, testName, status } = session;
@@ -64,152 +42,69 @@ const TestSessionListItem = ({
     ACCESS_CODE_GROUP_SIZE,
   )} ${accessCode.slice(ACCESS_CODE_GROUP_SIZE)}`;
 
-  return (
-    <HStack
-      _hover={{
-        bg: status === TestSessionStatus.PAST ? "grey.100" : undefined,
-      }}
-      borderRadius={16}
-      gap={0}
-      pr={4}
-      w="100%"
+  const onViewStatistics = () =>
+    history.push(
+      Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE({
+        sessionId: testSessionId,
+      }),
+      {
+        returnTo: {
+          pathname: history.location.pathname,
+          state: history.location.state,
+        },
+        sessionTitle: testName,
+      },
+    );
+
+  return status === TestSessionStatus.PAST ? (
+    <Tooltip
+      bg="blue.300"
+      borderRadius={4}
+      hasArrow
+      label="Click to view statistics of this assessment and each student's performance."
+      p={2}
+      placement="bottom"
     >
-      <Tooltip
-        bg="blue.300"
-        borderRadius={4}
-        hasArrow
-        isDisabled={status !== TestSessionStatus.PAST}
-        label="Click to view statistics of this assessment and each student's performance."
-        p={2}
-        placement="bottom"
+      <HStack
+        _hover={{ bg: "grey.100" }}
+        as="button"
+        borderRadius={16}
+        gap={6}
+        onClick={onViewStatistics}
+        p={4}
+        w="100%"
       >
-        <HStack
-          as={status === TestSessionStatus.PAST ? "button" : undefined}
-          flex={1}
-          gap={4}
-          onClick={() =>
-            status === TestSessionStatus.PAST &&
-            history.push(
-              Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE({
-                sessionId: testSessionId,
-              }),
-              {
-                returnTo: {
-                  pathname: history.location.pathname,
-                  state: history.location.state,
-                },
-                sessionTitle: testName,
-              },
-            )
-          }
-          p={4}
-          pr={0}
-          w="100%"
-        >
-          {classroomName != null && (
-            <Tooltip
-              bg="blue.300"
-              borderRadius={4}
-              hasArrow
-              label={classroomName}
-              p={2}
-              placement="left"
-            >
-              <Tag
-                bg="blue.50"
-                borderRadius="full"
-                maxWidth={40}
-                overflow="hidden"
-                size="lg"
-              >
-                <TagLeftIcon
-                  aria-hidden="true"
-                  as={BookIcon}
-                  color="blue.300"
-                />
-                <TagLabel>
-                  <Text
-                    color="blue.300"
-                    overflow="hidden"
-                    textOverflow="ellipsis"
-                    textStyle="smallerParagraph"
-                    whiteSpace="nowrap"
-                  >
-                    {classroomName}
-                  </Text>
-                </TagLabel>
-              </Tag>
-            </Tooltip>
-          )}
-          <VStack align="start">
-            <Text
-              color={
-                status === TestSessionStatus.PAST ? "grey.300" : "blue.300"
-              }
-              textStyle="subtitle2"
-            >
-              {testName}
-            </Text>
-            <Text
-              color={
-                status === TestSessionStatus.PAST ? "grey.200" : "blue.200"
-              }
-              textStyle="mobileParagraph"
-            >
-              {STATUS_LABELS[status]} {formatDate(targetDate)}
-            </Text>
-          </VStack>
-          {status !== TestSessionStatus.PAST && (
-            <Copyable
-              displayedValue={formattedAccessCode}
-              label="Access Code"
-              value={accessCode}
-            />
-          )}
-          <Spacer />
-          {stats && (
-            <>
-              <Text color="grey.300" textStyle="mobileParagraph">
-                Mean: {stats.mean}%
-              </Text>
-              <Text color="grey.300" textStyle="mobileParagraph">
-                Median: {stats.median}%
-              </Text>
-              <Text color="grey.300" textStyle="mobileParagraph">
-                Completion Rate: {stats.completionRate}%
-              </Text>
-              <Text color="grey.300" textStyle="mobileParagraph">
-                Submissions: {stats.submissions}
-              </Text>
-            </>
-          )}
-          {status !== TestSessionStatus.PAST && classroomName == null && (
-            <Tag
-              bg={STATUS_BACKGROUND_COLORS[status]}
-              borderRadius="full"
-              maxWidth={40}
-              overflow="hidden"
-              size="lg"
-            >
-              <Text
-                color={STATUS_COLORS[status]}
-                overflow="hidden"
-                textOverflow="ellipsis"
-                textStyle="smallerParagraph"
-                whiteSpace="nowrap"
-              >
-                {titleCase(status)}
-              </Text>
-            </Tag>
-          )}
-        </HStack>
-      </Tooltip>
-      {status !== TestSessionStatus.PAST && !isReadOnly && (
-        <Box ml={1}>
-          <TestSessionListItemPopover
-            testSessionEditingData={testSessionEditingData}
-          />
-        </Box>
+        <TestSessionListItemBody
+          classroomName={classroomName}
+          inClassroomPage={inClassroomPage}
+          status={status}
+          targetDate={targetDate}
+          testName={testName}
+        />
+        <Spacer />
+        {stats && <TestSessionListItemStatistics stats={stats} />}
+      </HStack>
+    </Tooltip>
+  ) : (
+    <HStack gap={6} p={4} w="100%">
+      <TestSessionListItemBody
+        classroomName={classroomName}
+        inClassroomPage={inClassroomPage}
+        status={status}
+        targetDate={targetDate}
+        testName={testName}
+      />
+      <Copyable
+        displayedValue={formattedAccessCode}
+        label="Access Code"
+        value={accessCode}
+      />
+      <Spacer />
+      {inClassroomPage && <TestSessionListItemStatusTag status={status} />}
+      {!isReadOnly && (
+        <TestSessionListItemPopover
+          testSessionEditingData={testSessionEditingData}
+        />
       )}
     </HStack>
   );

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemBody.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemBody.tsx
@@ -35,16 +35,11 @@ const TestSessionListItemBody = ({
         <TestSessionListItemClassNameTag classroomName={classroomName} />
       )}
       <VStack align="start">
-        <Text
-          color={isPast ? "grey.300" : "blue.300"}
-          noOfLines={1}
-          textStyle="subtitle2"
-        >
+        <Text color={isPast ? "grey.300" : "blue.300"} textStyle="subtitle2">
           {testName}
         </Text>
         <Text
           color={isPast ? "grey.200" : "blue.200"}
-          noOfLines={1}
           textStyle="mobileParagraph"
         >
           {STATUS_LABELS[status]} {formatDate(targetDate)}

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemBody.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemBody.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Text, VStack } from "@chakra-ui/react";
+
+import { TestSessionStatus } from "../../../types/TestSessionTypes";
+import { formatDate } from "../../../utils/GeneralUtils";
+
+import TestSessionListItemClassNameTag from "./TestSessionListItemClassNameTag";
+
+const STATUS_LABELS = {
+  ACTIVE: "Until",
+  UPCOMING: "Scheduled",
+  PAST: "Assigned",
+};
+
+const TestSessionListItemBody = ({
+  inClassroomPage,
+  classroomName,
+  status,
+  testName,
+  targetDate,
+}: {
+  inClassroomPage: boolean;
+  classroomName: string;
+  status: TestSessionStatus;
+  testName: string;
+  targetDate: Date;
+}): React.ReactElement => {
+  return (
+    <>
+      {!inClassroomPage && (
+        <TestSessionListItemClassNameTag classroomName={classroomName} />
+      )}
+      <VStack align="start">
+        <Text
+          color={status === TestSessionStatus.PAST ? "grey.300" : "blue.300"}
+          noOfLines={1}
+          textStyle="subtitle2"
+        >
+          {testName}
+        </Text>
+        <Text
+          color={status === TestSessionStatus.PAST ? "grey.200" : "blue.200"}
+          noOfLines={1}
+          textStyle="mobileParagraph"
+        >
+          {STATUS_LABELS[status]} {formatDate(targetDate)}
+        </Text>
+      </VStack>
+    </>
+  );
+};
+
+export default TestSessionListItemBody;

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemBody.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemBody.tsx
@@ -5,6 +5,7 @@ import { TestSessionStatus } from "../../../types/TestSessionTypes";
 import { formatDate } from "../../../utils/GeneralUtils";
 
 import TestSessionListItemClassNameTag from "./TestSessionListItemClassNameTag";
+import TestSessionListItemStatusTag from "./TestSessionListItemStatusTag";
 
 const STATUS_LABELS = {
   ACTIVE: "Until",
@@ -25,21 +26,24 @@ const TestSessionListItemBody = ({
   testName: string;
   targetDate: Date;
 }): React.ReactElement => {
+  const isPast = status === TestSessionStatus.PAST;
   return (
     <>
-      {!inClassroomPage && (
+      {inClassroomPage ? (
+        !isPast && <TestSessionListItemStatusTag status={status} />
+      ) : (
         <TestSessionListItemClassNameTag classroomName={classroomName} />
       )}
       <VStack align="start">
         <Text
-          color={status === TestSessionStatus.PAST ? "grey.300" : "blue.300"}
+          color={isPast ? "grey.300" : "blue.300"}
           noOfLines={1}
           textStyle="subtitle2"
         >
           {testName}
         </Text>
         <Text
-          color={status === TestSessionStatus.PAST ? "grey.200" : "blue.200"}
+          color={isPast ? "grey.200" : "blue.200"}
           noOfLines={1}
           textStyle="mobileParagraph"
         >

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemClassNameTag.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemClassNameTag.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Tag, TagLabel, TagLeftIcon, Text, Tooltip } from "@chakra-ui/react";
+
+import { BookIcon } from "../../../assets/icons";
+
+const TestSessionListItemClassNameTag = ({
+  classroomName,
+}: {
+  classroomName: string;
+}): React.ReactElement => {
+  return (
+    <Tooltip
+      bg="blue.300"
+      borderRadius={4}
+      hasArrow
+      label={classroomName}
+      p={2}
+      placement="left"
+    >
+      <Tag
+        bg="blue.50"
+        borderRadius="full"
+        maxWidth={36}
+        overflow="hidden"
+        size="lg"
+      >
+        <TagLeftIcon aria-hidden="true" as={BookIcon} color="blue.300" />
+        <TagLabel>
+          <Text
+            color="blue.300"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            textStyle="smallerParagraph"
+            whiteSpace="nowrap"
+          >
+            {classroomName}
+          </Text>
+        </TagLabel>
+      </Tag>
+    </Tooltip>
+  );
+};
+
+export default TestSessionListItemClassNameTag;

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemStatistics.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemStatistics.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Text } from "@chakra-ui/react";
+
+import type { TestSessionItemStats } from "../../../types/TestSessionTypes";
+
+const TestSessionListItemStatistics = ({
+  stats,
+}: {
+  stats: TestSessionItemStats;
+}): React.ReactElement => {
+  return (
+    <>
+      <Text color="grey.300" textStyle="mobileParagraph">
+        Mean: {stats.mean}%
+      </Text>
+      <Text color="grey.300" textStyle="mobileParagraph">
+        Median: {stats.median}%
+      </Text>
+      <Text color="grey.300" textStyle="mobileParagraph">
+        Completion Rate: {stats.completionRate}%
+      </Text>
+      <Text color="grey.300" textStyle="mobileParagraph">
+        Submissions: {stats.submissions}
+      </Text>
+    </>
+  );
+};
+
+export default TestSessionListItemStatistics;

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemStatusTag.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemStatusTag.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Tag, Text } from "@chakra-ui/react";
+
+import type { TestSessionStatus } from "../../../types/TestSessionTypes";
+import { titleCase } from "../../../utils/GeneralUtils";
+
+const STATUS_BACKGROUND_COLORS = {
+  ACTIVE: "green.50",
+  UPCOMING: "yellow.50",
+  PAST: "grey.100",
+};
+const STATUS_COLORS = {
+  ACTIVE: "green.400",
+  UPCOMING: "yellow.300",
+  PAST: "grey.400",
+};
+
+const TestSessionListItemStatusTag = ({
+  status,
+}: {
+  status: TestSessionStatus;
+}): React.ReactElement => {
+  return (
+    <Tag
+      bg={STATUS_BACKGROUND_COLORS[status]}
+      borderRadius="full"
+      maxWidth={40}
+      overflow="hidden"
+      size="lg"
+    >
+      <Text
+        color={STATUS_COLORS[status]}
+        overflow="hidden"
+        textOverflow="ellipsis"
+        textStyle="smallerParagraph"
+        whiteSpace="nowrap"
+      >
+        {titleCase(status)}
+      </Text>
+    </Tag>
+  );
+};
+
+export default TestSessionListItemStatusTag;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix Assessments Card UI](https://www.notion.so/uwblueprintexecs/Fix-Assessments-Card-UI-a6f22565aabf47cbbade174833195694?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove extra padding above tab panels
* Fix bug to not show classname tag / show status tag when inside Classroom Page (bug introduced in this PR https://github.com/uwblueprint/jump-math/pull/568)
* Reduce width of classname tag (from 40 to 36)
* ~~Limit number of lines to 1 for text~~
* Refactored `TestSessionListItem` by extracting components for readability


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
<img width="695" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/1577c436-1e1f-4f82-8f76-b1724c6563b8">

<img width="623" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/4212de6a-2bfa-46c1-85be-06be2737af73">

<img width="1423" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/17c7a92e-2d10-431f-ba8e-9948b3fa9055">

<img width="1438" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/18cd557a-7675-43ef-b102-62e4b39d0ebb">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* No breaking changes


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
