### PR TITLE
feat: delete images on test edit

### DIFF
--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -15,6 +15,10 @@ import {
   mockPublishedTest,
   mockTestArray,
   mockTestWithId2,
+  newImage,
+  savedImage,
+  questionsRequest,
+  questions,
 } from "../../../testUtils/tests";
 import type { TestResponseDTO } from "../../interfaces/testService";
 
@@ -37,6 +41,9 @@ describe("mongo testService", (): void => {
     testService.imageUploadService.getImage = jest
       .fn()
       .mockReturnValue(imageMetadata);
+    testService.imageUploadService.deleteImage = jest
+      .fn()
+      .mockReturnValue(imageMetadata);
   });
 
   afterEach(async () => {
@@ -56,11 +63,25 @@ describe("mongo testService", (): void => {
 
   it("updateTest", async () => {
     // insert test into database
-    const createdTest = await MgTest.create(mockTestWithId);
+    const uploadedImages = [questions[0], [savedImage]];
+    const createdTest = await MgTest.create({
+      ...mockTestWithId,
+      questions: uploadedImages,
+    });
 
     // update test and assert
-    const res = await testService.updateTest(createdTest.id, mockTestRequest2);
-    assertResponseMatchesExpected(mockTestWithId2, res);
+    const res = await testService.updateTest(createdTest.id, {
+      ...mockTestRequest2,
+      questions: [questionsRequest[0], [newImage]],
+    });
+    expect(testService.imageUploadService.deleteImage).toHaveBeenCalled();
+    assertResponseMatchesExpected(
+      {
+        ...mockTestWithId2,
+        questions: uploadedImages,
+      },
+      res,
+    );
   });
 
   it("getTestById", async () => {

--- a/backend/services/implementations/imageUploadService.ts
+++ b/backend/services/implementations/imageUploadService.ts
@@ -116,7 +116,7 @@ class ImageUploadService implements IImageUploadService {
       return image;
     } catch (error: unknown) {
       Logger.error(
-        `Failed to get delete image for filePath: ${
+        `Failed to delete image for filePath: ${
           image.filePath
         }. Reason = ${getErrorMessage(error)}`,
       );

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -147,13 +147,7 @@ class TestService implements ITestService {
           !newImageUrls.has((oldImage.metadata as ImageMetadata).url),
       );
 
-      await Promise.all(
-        imagesToDelete.map(async (image) => {
-          await this.imageUploadService.deleteImage(
-            image.metadata as ImageMetadata,
-          );
-        }),
-      );
+      await this.deleteImages([imagesToDelete]);
 
       questions = await this.uploadImages(test.questions);
       updatedTest = await MgTest.findByIdAndUpdate(

--- a/backend/testUtils/tests.ts
+++ b/backend/testUtils/tests.ts
@@ -108,6 +108,16 @@ export const imageMetadata: ImageMetadata = {
   filePath: "assessment-images/test.png",
 };
 
+export const savedImage = {
+  type: QuestionComponentType.IMAGE,
+  metadata: imageMetadata,
+};
+
+export const newImage = {
+  type: QuestionComponentType.IMAGE,
+  metadata: imageUpload,
+};
+
 export const questions: Array<Array<QuestionComponent>> =
   getQuestions(imageMetadata);
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete image on edit assessment](https://www.notion.so/uwblueprintexecs/Delete-image-on-edit-assessment-05b039fe20d54b25ac27698edc3231bc?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Delete image from GCP if image was deleted in a test edit. This includes:
   * Image component removed entirely
   * Image replaced with new image
* If the image was unchanged or reordered, no deletion should occur.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Delete an image from a test. Verify that it is deleted in GCP.
2. Replace an image from a test. Verify that the original image is deleted from GCP.
3. Edit a test without editing an image. Verify that the image is still in GCP.
4. Reorder an image. Verify that the image is still in GCP.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
