### PR TITLE
fix: popovers should auto-close from class cards

### DIFF
--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -84,12 +84,6 @@ const AssessmentEditorHeader = ({
   const handleDelete = handleSubmit(onDelete, onError);
   const handleCloseEditor = () => history.goBack();
 
-  const {
-    onOpen: onOpenPopover,
-    isOpen: popoverIsOpen,
-    onClose: onClosePopover,
-  } = useDisclosure();
-
   return (
     <>
       <Box
@@ -138,28 +132,12 @@ const AssessmentEditorHeader = ({
             >
               Publish
             </ActionButton>
-            <Popover
-              isOpen={popoverIsOpen}
-              onClose={onClosePopover}
-              onOpen={onOpenPopover}
-            >
+            <Popover>
               <VStack divider={<Divider />} spacing="0em">
                 {isEditing && (
-                  <PopoverButton
-                    name="Archive"
-                    onClick={() => {
-                      onClosePopover();
-                      onArchiveModalOpen();
-                    }}
-                  />
+                  <PopoverButton name="Archive" onClick={onArchiveModalOpen} />
                 )}
-                <PopoverButton
-                  name="Delete"
-                  onClick={() => {
-                    onClosePopover();
-                    onDeleteModalOpen();
-                  }}
-                />
+                <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
               </VStack>
             </Popover>
           </HStack>

--- a/frontend/src/components/admin/assessment-status/EditStatusPopover.tsx
+++ b/frontend/src/components/admin/assessment-status/EditStatusPopover.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Divider, useDisclosure, VStack } from "@chakra-ui/react";
+import { Divider, VStack } from "@chakra-ui/react";
 
 import { Status } from "../../../types/AssessmentTypes";
 import Popover from "../../common/popover/Popover";
@@ -19,31 +19,28 @@ interface EditStatusPopoverProps {
 const EditStatusPopover = ({
   assessmentId,
   assessmentStatus,
-}: EditStatusPopoverProps): React.ReactElement => {
-  const { onOpen, isOpen, onClose } = useDisclosure();
-  return (
-    <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
-      <VStack divider={<Divider />} spacing="0em">
-        {assessmentStatus === Status.DRAFT && (
-          <>
-            <PublishButton assessmentId={assessmentId} />
-            <Divider />
-            <EditButton assessmentId={assessmentId} />
-          </>
-        )}
-        {assessmentStatus === Status.ARCHIVED ? (
-          <UnarchiveButton assessmentId={assessmentId} />
-        ) : (
-          <>
-            <ArchiveButton assessmentId={assessmentId} />
-            <Divider />
-            <DuplicateButton assessmentId={assessmentId} />
-          </>
-        )}
-        <DeleteButton assessmentId={assessmentId} />
-      </VStack>
-    </Popover>
-  );
-};
+}: EditStatusPopoverProps): React.ReactElement => (
+  <Popover>
+    <VStack divider={<Divider />} spacing="0em">
+      {assessmentStatus === Status.DRAFT && (
+        <>
+          <PublishButton assessmentId={assessmentId} />
+          <Divider />
+          <EditButton assessmentId={assessmentId} />
+        </>
+      )}
+      {assessmentStatus === Status.ARCHIVED ? (
+        <UnarchiveButton assessmentId={assessmentId} />
+      ) : (
+        <>
+          <ArchiveButton assessmentId={assessmentId} />
+          <Divider />
+          <DuplicateButton assessmentId={assessmentId} />
+        </>
+      )}
+      <DeleteButton assessmentId={assessmentId} />
+    </VStack>
+  </Popover>
+);
 
 export default EditStatusPopover;

--- a/frontend/src/components/common/popover/Popover.tsx
+++ b/frontend/src/components/common/popover/Popover.tsx
@@ -9,6 +9,8 @@ import {
 
 import { MoreVerticalOutlineIcon } from "../../../assets/icons";
 
+import { PopoverContext } from "./PopoverContext";
+
 interface PopoverProps {
   children: React.ReactNode;
   onOpen: () => void;
@@ -50,7 +52,9 @@ const Popover = ({
         overflow="hidden"
         width="100%"
       >
-        <PopoverBody>{children}</PopoverBody>
+        <PopoverContext.Provider value={{ onClose }}>
+          <PopoverBody>{children}</PopoverBody>
+        </PopoverContext.Provider>
       </PopoverContent>
     </ChakraPopover>
   );

--- a/frontend/src/components/common/popover/Popover.tsx
+++ b/frontend/src/components/common/popover/Popover.tsx
@@ -5,6 +5,7 @@ import {
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
+  useDisclosure,
 } from "@chakra-ui/react";
 
 import { MoreVerticalOutlineIcon } from "../../../assets/icons";
@@ -13,21 +14,17 @@ import { PopoverContext } from "./PopoverContext";
 
 interface PopoverProps {
   children: React.ReactNode;
-  onOpen: () => void;
-  isOpen: boolean;
-  onClose: () => void;
   placement?: "bottom" | "right";
   trigger?: React.ReactElement;
 }
 
 const Popover = ({
   children,
-  onOpen,
-  isOpen,
-  onClose,
   placement = "right",
   trigger,
 }: PopoverProps): React.ReactElement => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   const triggerButton = trigger ?? (
     <IconButton
       aria-label="Show more"

--- a/frontend/src/components/common/popover/PopoverButton.tsx
+++ b/frontend/src/components/common/popover/PopoverButton.tsx
@@ -1,21 +1,32 @@
-import React, { type ReactElement } from "react";
+import React, { type ReactElement, useContext } from "react";
 
 import type { ActionButtonProps } from "../form/ActionButton";
 import ActionButton from "../form/ActionButton";
+
+import { PopoverContext } from "./PopoverContext";
 
 type PopoverButtonProps = ActionButtonProps<false> & {
   name: string;
 };
 const PopoverButton = ({
   name,
+  onClick,
   ...props
 }: PopoverButtonProps): ReactElement => {
+  const { onClose } = useContext(PopoverContext);
+
+  const handleClick = async () => {
+    await onClick();
+    onClose();
+  };
+
   return (
     <ActionButton
       color="black"
       fontSize="18px"
       fontWeight="0"
       minWidth="200%"
+      onClick={handleClick}
       showDefaultToasts={false}
       size="md"
       textAlign="left"

--- a/frontend/src/components/common/popover/PopoverContext.ts
+++ b/frontend/src/components/common/popover/PopoverContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export interface PopoverContextType {
+  onClose: () => void;
+}
+
+export const PopoverContext = createContext<PopoverContextType>({
+  onClose: () => {},
+});

--- a/frontend/src/components/common/popover/SimplePopover.tsx
+++ b/frontend/src/components/common/popover/SimplePopover.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Divider, useDisclosure, VStack } from "@chakra-ui/react";
+import { Button, Divider, VStack } from "@chakra-ui/react";
 
 import { PlusOutlineIcon } from "../../../assets/icons";
 
@@ -12,38 +12,31 @@ type SimplePopoverProps = {
   items: { name: string; onClick: () => void }[];
 };
 
-const SimplePopover = ({ isDisabled, text, items }: SimplePopoverProps) => {
-  const { isOpen, onClose, onOpen } = useDisclosure();
-
-  return (
-    <Popover
-      isOpen={isOpen}
-      onClose={onClose}
-      onOpen={onOpen}
-      placement="bottom"
-      trigger={
-        <Button
-          isDisabled={isDisabled}
-          minW={0}
-          rightIcon={<PlusOutlineIcon />}
-          variant="primary"
-        >
-          {text}
-        </Button>
-      }
-    >
-      <VStack divider={<Divider />} spacing={0}>
-        {items.map((item) => (
-          <PopoverButton
-            key={item.name}
-            aria-label={`Add ${item.name.toLowerCase()}`}
-            name={item.name}
-            onClick={item.onClick}
-          />
-        ))}
-      </VStack>
-    </Popover>
-  );
-};
+const SimplePopover = ({ isDisabled, text, items }: SimplePopoverProps) => (
+  <Popover
+    placement="bottom"
+    trigger={
+      <Button
+        isDisabled={isDisabled}
+        minW={0}
+        rightIcon={<PlusOutlineIcon />}
+        variant="primary"
+      >
+        {text}
+      </Button>
+    }
+  >
+    <VStack divider={<Divider />} spacing={0}>
+      {items.map((item) => (
+        <PopoverButton
+          key={item.name}
+          aria-label={`Add ${item.name.toLowerCase()}`}
+          name={item.name}
+          onClick={item.onClick}
+        />
+      ))}
+    </VStack>
+  </Popover>
+);
 
 export default SimplePopover;

--- a/frontend/src/components/teacher/student-management/classroom-summary/ClassroomPopover.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/ClassroomPopover.tsx
@@ -26,11 +26,6 @@ const ClassroomPopover = ({
   isArchived,
 }: ClassroomPopoverProps): ReactElement => {
   const {
-    isOpen: isPopoverOpen,
-    onOpen: onPopoverOpen,
-    onClose: onPopoverClose,
-  } = useDisclosure();
-  const {
     isOpen: isEditModalOpen,
     onOpen: onEditModalOpen,
     onClose: onEditModalClose,
@@ -61,11 +56,7 @@ const ClassroomPopover = ({
 
   return (
     <>
-      <Popover
-        isOpen={isPopoverOpen}
-        onClose={onPopoverClose}
-        onOpen={onPopoverOpen}
-      >
+      <Popover>
         <VStack divider={<Divider />} spacing={0}>
           {!isArchived && (
             <PopoverButton name="Edit" onClick={onEditModalOpen} />

--- a/frontend/src/components/teacher/student-management/view-students/StudentListPopover.tsx
+++ b/frontend/src/components/teacher/student-management/view-students/StudentListPopover.tsx
@@ -50,7 +50,6 @@ const StudentListPopover = ({
     studentFormMethods,
   ]);
 
-  const { onOpen, isOpen, onClose } = useDisclosure();
   const {
     isOpen: isUpdateModalOpen,
     onClose: closeUpdateModal,
@@ -64,7 +63,7 @@ const StudentListPopover = ({
 
   return (
     <>
-      <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
+      <Popover>
         <VStack divider={<Divider />} spacing={0}>
           <PopoverButton name="Edit" onClick={openUpdateModal} />
           <PopoverButton name="Delete" onClick={openDeleteModal} />

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -21,11 +21,6 @@ const TestSessionListItemPopover = ({
   testSessionEditingData,
 }: TestSessionPopoverProps): ReactElement => {
   const {
-    isOpen: isPopoverOpen,
-    onOpen: onPopoverOpen,
-    onClose: onPopoverClose,
-  } = useDisclosure();
-  const {
     isOpen: isDeleteModalOpen,
     onOpen: openDeleteModal,
     onClose: onDeleteModalClose,
@@ -43,11 +38,7 @@ const TestSessionListItemPopover = ({
   };
 
   return (
-    <Popover
-      isOpen={isPopoverOpen}
-      onClose={onPopoverClose}
-      onOpen={onPopoverOpen}
-    >
+    <Popover>
       <VStack divider={<Divider />} spacing={0}>
         <PopoverButton name="Edit" onClick={onEditTestSession} />
         {testSessionEditingData.status === TestSessionStatus.UPCOMING && (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix “sticky” popover menus](https://www.notion.so/uwblueprintexecs/Fix-sticky-popover-menus-867473d16e954442aba2c5a84bf14105)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Seemed like the link overlay for classroom cards was somehow interfering with the popover behaviour. Manually closing the popover afterwards seemed to fix things.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click the popover on a class card.
2. Exit the resulting modal.
3. Verify that the popover closes automatically.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
