### PR TITLE
fix: stale data issues in assessment editor

### DIFF
--- a/frontend/src/components/admin/question-creation/question-elements/modals/fraction/FractionModal.tsx
+++ b/frontend/src/components/admin/question-creation/question-elements/modals/fraction/FractionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FormControl, FormErrorMessage, FormLabel } from "@chakra-ui/react";
 
 import type { FractionMetadata } from "../../../../../../types/QuestionMetadataTypes";
@@ -32,29 +32,20 @@ const FractionModal = ({
   const [denominator, setDenominator] = useState<string>("");
   const [error, setError] = useState(false);
 
-  const resetFieldValues = useCallback(() => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     setWholeNumber(String(data?.wholeNumber ?? ""));
     setNumerator(String(data?.numerator ?? ""));
     setDenominator(String(data?.denominator ?? ""));
-  }, [data]);
-
-  useEffect(() => {
-    resetFieldValues();
-  }, [resetFieldValues]);
+  }, [data, isOpen]);
 
   const handleClose = () => {
-    resetFieldValues();
     setError(false);
     onClose();
   };
-
-  const handleBack =
-    onBack &&
-    (() => {
-      resetFieldValues();
-      setError(false);
-      onBack();
-    });
 
   const handleConfirm = () => {
     const castedWholeNumber =
@@ -81,7 +72,7 @@ const FractionModal = ({
       cancelButtonText={onBack ? "Back" : "Cancel"}
       header="Create fraction question"
       isOpen={isOpen}
-      onBack={handleBack}
+      onBack={onBack}
       onClose={handleClose}
       onSubmit={handleConfirm}
       showDefaultToasts={false}

--- a/frontend/src/components/admin/question-creation/question-elements/modals/multi-option/MultiOptionModal.tsx
+++ b/frontend/src/components/admin/question-creation/question-elements/modals/multi-option/MultiOptionModal.tsx
@@ -34,20 +34,22 @@ const MultiOptionModal = ({
   const [noCorrectOptionError, setNoCorrectOptionError] = useState(false);
   const [emptyOptionError, setEmptyOptionError] = useState(false);
 
-  useEffect(() => {
-    setOptionCount(data ? data.options.length : 0);
-    setOptions(data ? data.options : []);
-  }, [data]);
-
   const resetErrors = () => {
     setOptionCountError(false);
     setNoCorrectOptionError(false);
     setEmptyOptionError(false);
   };
 
-  const handleClose = () => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     setOptionCount(data ? data.options.length : 0);
     setOptions(data ? data.options : []);
+  }, [data, isOpen]);
+
+  const handleClose = () => {
     resetErrors();
     onClose();
   };

--- a/frontend/src/components/admin/question-creation/question-elements/modals/short-answer/ShortAnswerModal.tsx
+++ b/frontend/src/components/admin/question-creation/question-elements/modals/short-answer/ShortAnswerModal.tsx
@@ -31,24 +31,26 @@ const ShortAnswerModal = ({
   const [error, setError] = useState(false);
 
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     setAnswer(data == null ? "" : String(data));
-  }, [data]);
+  }, [data, isOpen]);
+
+  const handleClose = () => {
+    setError(false);
+    onClose();
+  };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setAnswer(event.target.value);
-  };
-
-  const handleClose = () => {
-    setAnswer(data == null ? "" : String(data));
-    setError(false);
-    onClose();
   };
 
   const handleConfirm = () => {
     const castedAnswer = stringToFloat(answer);
     if (typeof castedAnswer !== "undefined") {
       onConfirm({ answer: castedAnswer });
-      handleClose();
     } else {
       setError(true);
       throw new FormValidationError("One or more fields are invalid");


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix stale data issue in the question editor](https://www.notion.so/uwblueprintexecs/Fix-stale-data-issue-in-the-question-editor-33edff105c54424b8b4718f098fc676d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The various question editor modals were resetting their data on exit, rather than on enter. This caused a bunch of staleness issues where the modals would reset to the previous value of the data, causing the modal to display out-of-date data the next time it was shown. The fix is to make all these modals reset their data when they open to the freshest data available.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Add a component to a question.
2. Click edit, make a change, then click "Confirm".
3. Edit the same component and verify that your edits show.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
