### PR TITLE
fix: keep dashboard add-class modal on same page

### DIFF
--- a/frontend/src/components/pages/teacher/ClassroomsPage.tsx
+++ b/frontend/src/components/pages/teacher/ClassroomsPage.tsx
@@ -14,9 +14,9 @@ import {
 } from "@chakra-ui/react";
 
 import checkFeatureFlag from "../../../checkFeatureFlag";
+import { classroomFormDefaultValues } from "../../../constants/ClassroomConstants";
 import * as Routes from "../../../constants/Routes";
 import AuthContext from "../../../contexts/AuthContext";
-import type { ClassroomForm } from "../../../types/ClassroomTypes";
 import {
   TabEnumClassroom,
   TABS_CLASSROOM,
@@ -37,12 +37,6 @@ const getLocationState = (
   isAddClassroomModalOpen: undefined,
   ...(typeof state === "object" ? state : {}),
 });
-
-const classroomFormDefaultValues: ClassroomForm = {
-  className: null,
-  startDate: null,
-  gradeLevel: null,
-};
 
 const ClassroomsPage = (): ReactElement => {
   const { state } = useLocation();

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/index.tsx
@@ -8,6 +8,7 @@ import { GET_CLASS_DETAILS_BY_ID } from "../../../../APIClients/queries/ClassQue
 import type { ClassTitleData } from "../../../../APIClients/types/ClassClientTypes";
 import type { Grade } from "../../../../APIClients/types/UserClientTypes";
 import { EditOutlineIcon } from "../../../../assets/icons";
+import { classroomFormDefaultValues } from "../../../../constants/ClassroomConstants";
 import * as Routes from "../../../../constants/Routes";
 import type {
   ClassroomForm,
@@ -68,12 +69,6 @@ const studentFormDefaultValues: StudentForm = {
   firstName: "",
   lastName: "",
   studentNumber: undefined,
-};
-
-const classroomFormDefaultValues: ClassroomForm = {
-  className: null,
-  startDate: null,
-  gradeLevel: null,
 };
 
 const getLocationState = (

--- a/frontend/src/components/pages/teacher/TeacherDashboardPage.tsx
+++ b/frontend/src/components/pages/teacher/TeacherDashboardPage.tsx
@@ -3,8 +3,8 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 import { HStack, Spacer, Text, useDisclosure, VStack } from "@chakra-ui/react";
 
+import { classroomFormDefaultValues } from "../../../constants/ClassroomConstants";
 import * as Routes from "../../../constants/Routes";
-import type { ClassroomForm } from "../../../types/ClassroomTypes";
 import HeaderWithButton from "../../common/HeaderWithButton";
 import RouterLink from "../../common/navigation/RouterLink";
 import SimplePopover from "../../common/popover/SimplePopover";
@@ -26,12 +26,6 @@ const SECTION_CONFIG = [
     headerGap: 0,
   },
 ];
-
-const classroomFormDefaultValues: ClassroomForm = {
-  className: null,
-  startDate: null,
-  gradeLevel: null,
-};
 
 const TeacherDashboardPage = (): React.ReactElement => {
   const {

--- a/frontend/src/components/pages/teacher/TeacherDashboardPage.tsx
+++ b/frontend/src/components/pages/teacher/TeacherDashboardPage.tsx
@@ -1,13 +1,16 @@
 import React from "react";
+import { FormProvider, useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
-import { HStack, Spacer, Text, VStack } from "@chakra-ui/react";
+import { HStack, Spacer, Text, useDisclosure, VStack } from "@chakra-ui/react";
 
 import * as Routes from "../../../constants/Routes";
+import type { ClassroomForm } from "../../../types/ClassroomTypes";
 import HeaderWithButton from "../../common/HeaderWithButton";
 import RouterLink from "../../common/navigation/RouterLink";
 import SimplePopover from "../../common/popover/SimplePopover";
 import AssessmentsSection from "../../teacher/dashboard/AssessmentsSection";
 import ClassroomsSection from "../../teacher/dashboard/ClassroomsSection";
+import AddOrEditClassroomModal from "../../teacher/student-management/classroom-summary/AddOrEditClassroomModal";
 
 const SECTION_CONFIG = [
   {
@@ -24,7 +27,18 @@ const SECTION_CONFIG = [
   },
 ];
 
+const classroomFormDefaultValues: ClassroomForm = {
+  className: null,
+  startDate: null,
+  gradeLevel: null,
+};
+
 const TeacherDashboardPage = (): React.ReactElement => {
+  const {
+    isOpen: isModalOpen,
+    onOpen: onModalOpen,
+    onClose: onModalClose,
+  } = useDisclosure();
   const history = useHistory();
 
   const popoverItems = [
@@ -34,12 +48,14 @@ const TeacherDashboardPage = (): React.ReactElement => {
     },
     {
       name: "Classroom",
-      onClick: () =>
-        history.push(Routes.CLASSROOMS_PAGE, {
-          isAddClassroomModalOpen: true,
-        }),
+      onClick: onModalOpen,
     },
   ];
+
+  const methods = useForm({
+    defaultValues: classroomFormDefaultValues,
+    mode: "onChange",
+  });
 
   return (
     <>
@@ -47,6 +63,9 @@ const TeacherDashboardPage = (): React.ReactElement => {
         button={<SimplePopover items={popoverItems} text="Add New" />}
         title="Dashboard"
       />
+      <FormProvider {...methods}>
+        <AddOrEditClassroomModal isOpen={isModalOpen} onClose={onModalClose} />
+      </FormProvider>
       <HStack align="start" gap={20} mt={9}>
         {SECTION_CONFIG.map(
           ({ title, viewAllRoute, bodyComponent, headerGap }) => (

--- a/frontend/src/constants/ClassroomConstants.ts
+++ b/frontend/src/constants/ClassroomConstants.ts
@@ -1,0 +1,7 @@
+import type { ClassroomForm } from "../types/ClassroomTypes";
+
+export const classroomFormDefaultValues: ClassroomForm = {
+  className: null,
+  startDate: null,
+  gradeLevel: null,
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add Class Within Dashboard Page](https://www.notion.so/uwblueprintexecs/Add-Class-Within-Dashboard-Page-9dceeec609814474b24d26890dcfc860)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Change dashboard add-class button to stay on same page
- Fix non-closing add- dashboard button


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Visit teacher dashboard
2. Click "add classroom"
3. Verify the popover closed
4. Fill out and submit the form
5. Verify you are on the dashboard page still and the class you created is now visible


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
