### PR TITLE
feat: better assessment editor loading state

### DIFF
--- a/frontend/src/APIClients/mutations/TestMutations.ts
+++ b/frontend/src/APIClients/mutations/TestMutations.ts
@@ -42,6 +42,44 @@ export const CREATE_NEW_TEST = gql`
   mutation CreateTest($test: TestRequestDTO!) {
     createTest(test: $test) {
       id
+      name
+      questions {
+        type
+        metadata {
+          ... on QuestionTextMetadata {
+            questionText
+          }
+          ... on TextMetadata {
+            text
+          }
+          ... on ImageMetadata {
+            filePath
+            url
+          }
+          ... on MultipleChoiceMetadata {
+            options
+            answerIndex
+          }
+          ... on MultiSelectMetadata {
+            options
+            answerIndices
+          }
+          ... on ShortAnswerMetadata {
+            answer
+          }
+          ... on FractionMetadata {
+            wholeNumber
+            numerator
+            denominator
+          }
+        }
+      }
+      grade
+      assessmentType
+      curriculumCountry
+      curriculumRegion
+      status
+      updatedAt
     }
   }
 `;
@@ -50,6 +88,44 @@ export const UPDATE_TEST = gql`
   mutation UpdateTest($id: ID!, $test: TestRequestDTO!) {
     updateTest(id: $id, test: $test) {
       id
+      name
+      questions {
+        type
+        metadata {
+          ... on QuestionTextMetadata {
+            questionText
+          }
+          ... on TextMetadata {
+            text
+          }
+          ... on ImageMetadata {
+            filePath
+            url
+          }
+          ... on MultipleChoiceMetadata {
+            options
+            answerIndex
+          }
+          ... on MultiSelectMetadata {
+            options
+            answerIndices
+          }
+          ... on ShortAnswerMetadata {
+            answer
+          }
+          ... on FractionMetadata {
+            wholeNumber
+            numerator
+            denominator
+          }
+        }
+      }
+      grade
+      assessmentType
+      curriculumCountry
+      curriculumRegion
+      status
+      updatedAt
     }
   }
 `;

--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import type { SubmitHandler, UseFormHandleSubmit } from "react-hook-form";
+import { type SubmitHandler, useFormContext } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 import {
   Box,
@@ -22,6 +22,7 @@ import {
 import AssessmentContext from "../../../contexts/AssessmentContext";
 import { formatDate, getCurrentDate } from "../../../utils/GeneralUtils";
 import ActionButton from "../../common/form/ActionButton";
+import useActionFormHandler from "../../common/modal/useActionFormHandler";
 import BackButton from "../../common/navigation/BackButton";
 import Popover from "../../common/popover/Popover";
 import PopoverButton from "../../common/popover/PopoverButton";
@@ -31,20 +32,18 @@ import PublishAssessmentModal from "../assessment-status/EditStatusModals/Publis
 
 interface AssessmentEditorHeaderProps {
   name: string;
-  handleSubmit: UseFormHandleSubmit<TestRequest>;
   isEditing: boolean;
   onConfirmArchive: SubmitHandler<TestRequest>;
   onConfirmPublish: SubmitHandler<TestRequest>;
   onDelete: SubmitHandler<TestRequest>;
   onSave: SubmitHandler<TestRequest>;
-  onError: () => void;
+  onError: (message: string) => void;
   validateForm: () => void;
   updatedAt?: string;
 }
 
 const AssessmentEditorHeader = ({
   name,
-  handleSubmit,
   isEditing,
   onConfirmArchive,
   onConfirmPublish,
@@ -77,11 +76,16 @@ const AssessmentEditorHeader = ({
     onPublishModalOpen();
   };
 
-  const handleSave = handleSubmit(onSave, onError);
-  const handlePublish = handleSubmit(onPublish, onError);
-  const handleConfirmPublish = handleSubmit(onConfirmPublish, onError);
-  const handleConfirmArchive = handleSubmit(onConfirmArchive, onError);
-  const handleDelete = handleSubmit(onDelete, onError);
+  const { getValues } = useFormContext<TestRequest>();
+
+  // We need validation on these actions.
+  const handleSave = useActionFormHandler(onSave);
+  const handlePublish = useActionFormHandler(onPublish);
+  const handleConfirmPublish = useActionFormHandler(onConfirmPublish);
+
+  // We don't need validation on these actions.
+  const handleConfirmArchive = async () => onConfirmArchive(getValues());
+  const handleDelete = async () => onDelete(getValues());
   const handleCloseEditor = () => history.goBack();
 
   return (
@@ -121,6 +125,7 @@ const AssessmentEditorHeader = ({
               messageOnSuccess="Assessment saved."
               minWidth="10"
               onClick={handleSave}
+              onError={onError}
               variant="secondary"
             >
               Save
@@ -129,19 +134,20 @@ const AssessmentEditorHeader = ({
               leftIcon={<TextOutlineIcon />}
               minWidth="10"
               onClick={handlePublish}
+              onError={onError}
               showDefaultToasts={false}
               variant="primary"
             >
               Publish
             </ActionButton>
-            {isEditing && (
-              <Popover>
-                <VStack divider={<Divider />} spacing="0em">
+            <Popover>
+              <VStack divider={<Divider />} spacing="0em">
+                {isEditing && (
                   <PopoverButton name="Archive" onClick={onArchiveModalOpen} />
-                  <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
-                </VStack>
-              </Popover>
-            )}
+                )}
+                <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
+              </VStack>
+            </Popover>
           </HStack>
         </Flex>
       </Box>

--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -134,14 +134,14 @@ const AssessmentEditorHeader = ({
             >
               Publish
             </ActionButton>
-            <Popover>
-              <VStack divider={<Divider />} spacing="0em">
-                {isEditing && (
+            {isEditing && (
+              <Popover>
+                <VStack divider={<Divider />} spacing="0em">
                   <PopoverButton name="Archive" onClick={onArchiveModalOpen} />
-                )}
-                <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
-              </VStack>
-            </Popover>
+                  <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
+                </VStack>
+              </Popover>
+            )}
           </HStack>
         </Flex>
       </Box>

--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { type SubmitHandler, useFormContext } from "react-hook-form";
-import { useHistory } from "react-router-dom";
 import {
   Box,
   Button,
@@ -53,7 +52,6 @@ const AssessmentEditorHeader = ({
   validateForm,
   updatedAt,
 }: AssessmentEditorHeaderProps): React.ReactElement => {
-  const history = useHistory();
   const { setShowAssessmentPreview } = useContext(AssessmentContext);
   const {
     onOpen: onPublishModalOpen,
@@ -86,7 +84,6 @@ const AssessmentEditorHeader = ({
   // We don't need validation on these actions.
   const handleConfirmArchive = async () => onConfirmArchive(getValues());
   const handleDelete = async () => onDelete(getValues());
-  const handleCloseEditor = () => history.goBack();
 
   return (
     <>
@@ -140,14 +137,14 @@ const AssessmentEditorHeader = ({
             >
               Publish
             </ActionButton>
-            <Popover>
-              <VStack divider={<Divider />} spacing="0em">
-                {isEditing && (
+            {isEditing && (
+              <Popover>
+                <VStack divider={<Divider />} spacing="0em">
                   <PopoverButton name="Archive" onClick={onArchiveModalOpen} />
-                )}
-                <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
-              </VStack>
-            </Popover>
+                  <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
+                </VStack>
+              </Popover>
+            )}
           </HStack>
         </Flex>
       </Box>
@@ -162,7 +159,7 @@ const AssessmentEditorHeader = ({
         onClose={onArchiveModalClose}
       />
       <DeleteAssessmentModal
-        deleteAssessment={isEditing ? handleDelete : handleCloseEditor}
+        deleteAssessment={handleDelete}
         isOpen={isDeleteModalOpen}
         onClose={onDeleteModalClose}
       />

--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -79,9 +79,9 @@ const AssessmentEditorHeader = ({
   // We need validation on these actions.
   const handleSave = useActionFormHandler(onSave);
   const handlePublish = useActionFormHandler(onPublish);
-  const handleConfirmPublish = useActionFormHandler(onConfirmPublish);
 
   // We don't need validation on these actions.
+  const handleConfirmPublish = async () => onConfirmPublish(getValues());
   const handleConfirmArchive = async () => onConfirmArchive(getValues());
   const handleDelete = async () => onDelete(getValues());
 

--- a/frontend/src/components/common/form/ActionButton.tsx
+++ b/frontend/src/components/common/form/ActionButton.tsx
@@ -72,6 +72,10 @@ const ActionButton = <Default extends boolean = true>({
       }
       onAfterSuccess?.();
     } catch (e) {
+      if (!onError && e instanceof FormValidationError) {
+        return;
+      }
+
       const errorMessage =
         e instanceof FormValidationError
           ? e.message

--- a/frontend/src/components/common/form/ActionButton.tsx
+++ b/frontend/src/components/common/form/ActionButton.tsx
@@ -57,12 +57,14 @@ const ActionButton = <Default extends boolean = true>({
   const [isLoading, setLoading] = useState(false);
 
   const handleError =
-    onError ?? ((message: string) => showToast({ message, status: "error" }));
+    onError ??
+    ((message: string) => message && showToast({ message, status: "error" }));
 
   const handleClick = async () => {
     setLoading(true);
     controlledSetLoading?.(true);
     try {
+      handleError("");
       await onClick();
       if (showDefaultToasts || messageOnSuccess) {
         showToast({
@@ -76,15 +78,14 @@ const ActionButton = <Default extends boolean = true>({
         return;
       }
 
-      const errorMessage =
-        e instanceof FormValidationError
-          ? e.message
-          : "An error occurred. Please try again later.";
-      handleError(
+      const nonValidationMessage =
         (typeof generateErrorMessage === "function"
           ? generateErrorMessage(e)
-          : generateErrorMessage) ?? errorMessage,
-      );
+          : generateErrorMessage) ??
+        "An error occurred. Please try again later.";
+      const errorMessage =
+        e instanceof FormValidationError ? e.message : nonValidationMessage;
+      handleError(errorMessage);
     } finally {
       setLoading(false);
       controlledSetLoading?.(false);

--- a/frontend/src/components/common/modal/useActionFormHandler.tsx
+++ b/frontend/src/components/common/modal/useActionFormHandler.tsx
@@ -1,14 +1,13 @@
-import type { FieldValues } from "react-hook-form";
-import { useFormContext } from "react-hook-form";
+import { type FieldValues, useFormContext } from "react-hook-form";
 
 import { FormValidationError } from "../../../utils/GeneralUtils";
 
-const useModalFormHandler = <Values extends FieldValues>(
+const useActionFormHandler = <Values extends FieldValues>(
   onSave: (values: Values) => void,
+  onError?: (error: unknown) => void,
 ) => {
-  const { handleSubmit, formState } = useFormContext<Values>();
-
-  const trySave = handleSubmit(onSave);
+  const { formState, handleSubmit } = useFormContext<Values>();
+  const trySave = handleSubmit(onSave, onError);
 
   // We need to extract this value to trigger a re-render when the formState changes.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -26,4 +25,4 @@ const useModalFormHandler = <Values extends FieldValues>(
   return handleSave;
 };
 
-export default useModalFormHandler;
+export default useActionFormHandler;

--- a/frontend/src/components/common/navigation/useReloadPrompt.ts
+++ b/frontend/src/components/common/navigation/useReloadPrompt.ts
@@ -1,19 +1,21 @@
 import { useEffect } from "react";
 
-const beforeUnloadListener = (event: BeforeUnloadEvent) => {
-  event.preventDefault();
-  return (event.returnValue = "");
-};
-
-const useReloadPrompt = () => {
+const useReloadPrompt = (when?: boolean) => {
   useEffect(() => {
+    const beforeUnloadListener = (event: BeforeUnloadEvent) => {
+      if (!when) return;
+
+      event.preventDefault();
+      return (event.returnValue = "");
+    };
+
     addEventListener("beforeunload", beforeUnloadListener, { capture: true });
     return () => {
       removeEventListener("beforeunload", beforeUnloadListener, {
         capture: true,
       });
     };
-  }, []);
+  }, [when]);
 };
 
 export default useReloadPrompt;

--- a/frontend/src/components/common/navigation/useReloadPrompt.ts
+++ b/frontend/src/components/common/navigation/useReloadPrompt.ts
@@ -2,9 +2,9 @@ import { useEffect } from "react";
 
 const useReloadPrompt = (when?: boolean) => {
   useEffect(() => {
-    const beforeUnloadListener = (event: BeforeUnloadEvent) => {
-      if (!when) return;
+    if (!when) return;
 
+    const beforeUnloadListener = (event: BeforeUnloadEvent) => {
       event.preventDefault();
       return (event.returnValue = "");
     };

--- a/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
@@ -42,7 +42,6 @@ const AssessmentEditorPage = (): React.ReactElement => {
   const [showQuestionEditor, setShowQuestionEditor] = useState(false);
   const [editorQuestion, setEditorQuestion] = useState<Question | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
-  const [completedForm, setCompletedForm] = useState(false);
   const [showAssessmentPreview, setShowAssessmentPreview] = useState(false);
 
   const [createTest, { loading: loadingCreate }] = useMutation<{
@@ -64,11 +63,13 @@ const AssessmentEditorPage = (): React.ReactElement => {
   const {
     handleSubmit,
     register,
-    formState: { errors },
+    formState: { errors, isDirty },
     control,
     setValue,
+    getValues,
     watch,
     clearErrors,
+    reset: resetForm,
   } = useForm<TestRequest, unknown>({
     defaultValues: {
       name: state?.name,
@@ -99,6 +100,10 @@ const AssessmentEditorPage = (): React.ReactElement => {
     }
   }, [questions, errorMessage]);
 
+  const resetDefaultValues = () => {
+    resetForm(getValues());
+  };
+
   const validateForm = () => {
     if (questions.length === 0) {
       setErrorMessage(noQuestionError);
@@ -113,7 +118,6 @@ const AssessmentEditorPage = (): React.ReactElement => {
         test,
       },
     });
-    setCompletedForm(true);
     history.push(ASSESSMENTS_PAGE);
   };
 
@@ -129,8 +133,7 @@ const AssessmentEditorPage = (): React.ReactElement => {
         test,
       },
     });
-
-    setCompletedForm(true);
+    resetDefaultValues();
   };
 
   const onDeleteTest = async () => {
@@ -181,7 +184,7 @@ const AssessmentEditorPage = (): React.ReactElement => {
 
   return (
     <>
-      <Prompt message={confirmUnsavedChangesText} when={!completedForm} />
+      <Prompt message={confirmUnsavedChangesText} when={isDirty} />
       <DndProvider backend={HTML5Backend}>
         <AssessmentContext.Provider
           value={{

--- a/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
@@ -43,6 +43,7 @@ const AssessmentEditorPage = (): React.ReactElement => {
   const [editorQuestion, setEditorQuestion] = useState<Question | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
   const [showAssessmentPreview, setShowAssessmentPreview] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
 
   const [createTest, { loading: loadingCreate }] = useMutation<{
     createTest: { createTest: { id: string } };
@@ -63,7 +64,7 @@ const AssessmentEditorPage = (): React.ReactElement => {
   const {
     handleSubmit,
     register,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty: isFormDirty },
     control,
     setValue,
     getValues,
@@ -81,6 +82,7 @@ const AssessmentEditorPage = (): React.ReactElement => {
       curriculumRegion: state?.curriculumRegion,
     },
   });
+  const isDirty = !isDeleted && (isFormDirty || questions !== state?.questions);
 
   const assessmentName = state?.name;
   const isExisting = !!state;
@@ -118,7 +120,6 @@ const AssessmentEditorPage = (): React.ReactElement => {
         test,
       },
     });
-    history.push(ASSESSMENTS_PAGE);
   };
 
   const onUpdateTest = async (test: TestRequest) => {
@@ -141,8 +142,13 @@ const AssessmentEditorPage = (): React.ReactElement => {
       throw new FormValidationError("Assessment ID not found");
     }
     await deleteTest();
-    history.push(ASSESSMENTS_PAGE);
+    setIsDeleted(true);
   };
+  useEffect(() => {
+    if (isDeleted) {
+      history.push(ASSESSMENTS_PAGE);
+    }
+  }, [isDeleted, history]);
 
   const onSave: SubmitHandler<TestRequest> = (data) =>
     onCreateTest({

--- a/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import type { SubmitHandler } from "react-hook-form";
-import { useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { Prompt, useHistory, useLocation } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { Box, Divider, VStack } from "@chakra-ui/react";
@@ -70,8 +70,8 @@ const AssessmentEditorPage = (): React.ReactElement => {
 
   const isLoading = loadingCreate || loadingUpdate || loadingDelete;
 
+  const methods = useForm<TestRequest>();
   const {
-    handleSubmit,
     register,
     formState: { errors, isDirty: isFormDirty },
     control,
@@ -79,7 +79,7 @@ const AssessmentEditorPage = (): React.ReactElement => {
     watch,
     clearErrors,
     reset: resetForm,
-  } = useForm<TestRequest>();
+  } = methods;
   useEffect(() => {
     if (state) {
       resetForm({
@@ -197,10 +197,6 @@ const AssessmentEditorPage = (): React.ReactElement => {
       questions: formatQuestionsRequest(questions),
     });
 
-  const onError = () => {
-    setErrorMessage("Please resolve all issues before publishing or saving");
-  };
-
   useReloadPrompt(isDirty);
   useEffect(() => {
     if (redirectTo) {
@@ -229,52 +225,53 @@ const AssessmentEditorPage = (): React.ReactElement => {
             setShowAssessmentPreview,
           }}
         >
-          {showQuestionEditor && <QuestionEditor />}
-          {showAssessmentPreview && <AssessmentPreview />}
-          {!showQuestionEditor && !showAssessmentPreview && (
-            <VStack spacing="8" width="100%">
-              <AssessmentEditorHeader
-                handleSubmit={handleSubmit}
-                isEditing={isExisting}
-                name={watch("name")}
-                onConfirmArchive={onArchive}
-                onConfirmPublish={onPublish}
-                onDelete={onDeleteTest}
-                onError={onError}
-                onSave={onSave}
-                updatedAt={state?.updatedAt}
-                validateForm={validateForm}
-              />
-              <VStack pos="relative" spacing="8" width="92%">
-                <Box
-                  bg="white"
-                  bottom={0}
-                  height="100%"
-                  left={0}
-                  opacity={isLoading ? 0.7 : 0}
-                  pointerEvents={isLoading ? "all" : "none"}
-                  pos="absolute"
-                  right={0}
-                  top={0}
-                  transition="opacity 0.2s ease-in-out"
-                  width="100%"
-                  zIndex={1}
+          <FormProvider {...methods}>
+            {showQuestionEditor && <QuestionEditor />}
+            {showAssessmentPreview && <AssessmentPreview />}
+            {!showQuestionEditor && !showAssessmentPreview && (
+              <VStack spacing="8" width="100%">
+                <AssessmentEditorHeader
+                  isEditing={isExisting}
+                  name={watch("name")}
+                  onConfirmArchive={onArchive}
+                  onConfirmPublish={onPublish}
+                  onDelete={onDeleteTest}
+                  onError={setErrorMessage}
+                  onSave={onSave}
+                  updatedAt={state?.updatedAt}
+                  validateForm={validateForm}
                 />
+                <VStack pos="relative" spacing="8" width="92%">
+                  <Box
+                    bg="white"
+                    bottom={0}
+                    height="100%"
+                    left={0}
+                    opacity={isLoading ? 0.7 : 0}
+                    pointerEvents={isLoading ? "all" : "none"}
+                    pos="absolute"
+                    right={0}
+                    top={0}
+                    transition="opacity 0.2s ease-in-out"
+                    width="100%"
+                    zIndex={1}
+                  />
 
-                <BasicInformation
-                  clearErrors={clearErrors}
-                  control={control}
-                  errorMessage={errorMessage}
-                  errors={errors}
-                  register={register}
-                  setValue={setValue}
-                  watch={watch}
-                />
-                <Divider />
-                <AssessmentQuestions />
+                  <BasicInformation
+                    clearErrors={clearErrors}
+                    control={control}
+                    errorMessage={errorMessage}
+                    errors={errors}
+                    register={register}
+                    setValue={setValue}
+                    watch={watch}
+                  />
+                  <Divider />
+                  <AssessmentQuestions />
+                </VStack>
               </VStack>
-            </VStack>
-          )}
+            )}
+          </FormProvider>
         </AssessmentContext.Provider>
       </DndProvider>
     </>

--- a/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentEditorPage.tsx
@@ -5,7 +5,7 @@ import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { Prompt, useHistory, useLocation } from "react-router-dom";
 import { useMutation } from "@apollo/client";
-import { Divider, VStack } from "@chakra-ui/react";
+import { Box, Divider, VStack } from "@chakra-ui/react";
 
 import {
   CREATE_NEW_TEST,
@@ -29,7 +29,6 @@ import AssessmentQuestions from "../../admin/assessment-creation/AssessmentQuest
 import BasicInformation from "../../admin/assessment-creation/BasicInformation";
 import QuestionEditor from "../../admin/question-creation/QuestionEditor";
 import usePageTitle from "../../auth/usePageTitle";
-import LoadingState from "../../common/info/LoadingState";
 import useReloadPrompt from "../../common/navigation/useReloadPrompt";
 
 const AssessmentEditorPage = (): React.ReactElement => {
@@ -59,6 +58,8 @@ const AssessmentEditorPage = (): React.ReactElement => {
   }>(DELETE_TEST, {
     variables: { id: state?.id },
   });
+
+  const isLoading = loadingCreate || loadingUpdate || loadingDelete;
 
   const {
     handleSubmit,
@@ -130,7 +131,6 @@ const AssessmentEditorPage = (): React.ReactElement => {
     });
 
     setCompletedForm(true);
-    history.push(ASSESSMENTS_PAGE);
   };
 
   const onDeleteTest = async () => {
@@ -179,9 +179,6 @@ const AssessmentEditorPage = (): React.ReactElement => {
     setErrorMessage("Please resolve all issues before publishing or saving");
   };
 
-  if (loadingCreate || loadingUpdate || loadingDelete)
-    return <LoadingState fullPage />;
-
   return (
     <>
       <Prompt message={confirmUnsavedChangesText} when={!completedForm} />
@@ -214,7 +211,22 @@ const AssessmentEditorPage = (): React.ReactElement => {
                 updatedAt={state?.updatedAt}
                 validateForm={validateForm}
               />
-              <VStack spacing="8" width="92%">
+              <VStack pos="relative" spacing="8" width="92%">
+                <Box
+                  bg="white"
+                  bottom={0}
+                  height="100%"
+                  left={0}
+                  opacity={isLoading ? 0.7 : 0}
+                  pointerEvents={isLoading ? "all" : "none"}
+                  pos="absolute"
+                  right={0}
+                  top={0}
+                  transition="opacity 0.2s ease-in-out"
+                  width="100%"
+                  zIndex={1}
+                />
+
                 <BasicInformation
                   clearErrors={clearErrors}
                   control={control}

--- a/frontend/src/components/teacher/student-management/AddOrEditStudentModal.tsx
+++ b/frontend/src/components/teacher/student-management/AddOrEditStudentModal.tsx
@@ -19,7 +19,7 @@ import type { StudentForm } from "../../../types/ClassroomTypes";
 import { FormValidationError, getQueryName } from "../../../utils/GeneralUtils";
 import InlineFormError from "../../common/form/InlineFormError";
 import Modal from "../../common/modal/Modal";
-import useModalFormHandler from "../../common/modal/useModalFormHandler";
+import useActionFormHandler from "../../common/modal/useActionFormHandler";
 
 type AddOrEditStudentModalProps = {
   onClose: () => void;
@@ -58,7 +58,7 @@ const AddOrEditStudentModal = ({
     onClose();
   };
 
-  const handleSave = useModalFormHandler((student) =>
+  const handleSave = useActionFormHandler((student) =>
     upsertStudent({
       variables: {
         classId,

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -30,7 +30,7 @@ import ControlledDatePicker from "../../../common/form/ControlledDatePicker";
 import ControlledSelect from "../../../common/form/ControlledSelect";
 import InlineFormError from "../../../common/form/InlineFormError";
 import Modal from "../../../common/modal/Modal";
-import useModalFormHandler from "../../../common/modal/useModalFormHandler";
+import useActionFormHandler from "../../../common/modal/useActionFormHandler";
 
 type AddOrEditClassroomModalProps = {
   onClose: () => void;
@@ -74,7 +74,7 @@ const AddOrEditClassroomModal = ({
     onClose();
   };
 
-  const handleSave = useModalFormHandler((data) =>
+  const handleSave = useActionFormHandler((data) =>
     upsertClass({
       variables: {
         classroomId,


### PR DESCRIPTION

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Improve save behaviour on admin assessments](https://www.notion.so/uwblueprintexecs/Improve-save-behaviour-on-admin-assessments-1dc65e756a794d4bafdab43b80bac0ff)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Add full-page whiteout instead of loading spinner
- Handle reload-prompt properly


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open an assessment in the editor
2. Click back and verify there is no prompt
3. Open it again
4. Edit something
5. Click back and verify there is a prompt and hit cancel
6. Click save
7. Verify there is a full-screen whiteout box and you can't click any elements
8. After saving finishes, click back
9. Verify there is no prompt
10. Repeat the edit-save cycle once more
11. This time, instead of clicking back, edit a field again
12. Click back and verify you see a prompt again


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
