### PR TITLE
feat: update back button in assessment and question editor

### DIFF
--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -100,7 +100,9 @@ const AssessmentEditorHeader = ({
       >
         <Flex minWidth="max-content">
           <HStack alignItems="start" spacing={6}>
-            <BackButton />
+            <Text as="h1" color="blue.300" textStyle="header4">
+              <BackButton />
+            </Text>
             <VStack align="left">
               <Text textStyle="subtitle1">{name || "Untitled Assessment"}</Text>
               <Text textStyle="smallerParagraph">

--- a/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
@@ -14,12 +14,7 @@ import {
   Wrap,
 } from "@chakra-ui/react";
 
-import {
-  ArrowBackOutlineIcon,
-  ImageIcon,
-  QuestionIcon,
-  TextIcon,
-} from "../../../assets/icons";
+import { ImageIcon, QuestionIcon, TextIcon } from "../../../assets/icons";
 import confirmUnsavedChangesText from "../../../constants/GeneralConstants";
 import typeToIconMetadata from "../../../constants/StudentAssessmentConstants";
 import AssessmentContext from "../../../contexts/AssessmentContext";
@@ -28,6 +23,7 @@ import {
   QuestionElementType,
   ResponseElementType,
 } from "../../../types/QuestionTypes";
+import BackButton from "../../common/navigation/BackButton";
 
 import SaveQuestionEditorButton from "./question-elements/SaveQuestionEditorButton";
 import QuestionSidebarItem from "./QuestionSidebarItem";
@@ -101,18 +97,11 @@ const QuestionSidebar = (): React.ReactElement => {
       sx={{ position: "sticky", top: "0", bottom: "0" }}
     >
       <Stack w="22vw">
-        <Box justifyContent="flex-start" paddingLeft="0">
-          <Button
-            leftIcon={<ArrowBackOutlineIcon />}
-            onClick={confirmCloseQuestionEditor}
-            size="sm"
-            variant="tertiary"
-          >
-            Back
-          </Button>
-        </Box>
-        <Text color="blue.300" textStyle="header4">
-          Create Question
+        <Text as="h1" color="blue.300" textStyle="header4">
+          <BackButton onClick={confirmCloseQuestionEditor} />
+          <Box as="span" ml={6}>
+            Create Question
+          </Box>
         </Text>
         <Accordion allowMultiple defaultIndex={[0, 1]} paddingTop="1em">
           {renderAccordionItem([

--- a/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
@@ -99,7 +99,7 @@ const QuestionSidebar = (): React.ReactElement => {
       <Stack w="22vw">
         <Text as="h1" color="blue.300" display="flex" textStyle="header4">
           <BackButton onClick={confirmCloseQuestionEditor} />
-          <Box as="span" ml={6}>
+          <Box as="span" ml={2}>
             Create Question
           </Box>
         </Text>

--- a/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
@@ -97,7 +97,7 @@ const QuestionSidebar = (): React.ReactElement => {
       sx={{ position: "sticky", top: "0", bottom: "0" }}
     >
       <Stack w="22vw">
-        <Text as="h1" color="blue.300" textStyle="header4">
+        <Text as="h1" color="blue.300" display="flex" textStyle="header4">
           <BackButton onClick={confirmCloseQuestionEditor} />
           <Box as="span" ml={6}>
             Create Question

--- a/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionSidebar.tsx
@@ -99,7 +99,7 @@ const QuestionSidebar = (): React.ReactElement => {
       <Stack w="22vw">
         <Text as="h1" color="blue.300" display="flex" textStyle="header4">
           <BackButton onClick={confirmCloseQuestionEditor} />
-          <Box as="span" ml={2}>
+          <Box as="span" ml={3}>
             Create Question
           </Box>
         </Text>

--- a/frontend/src/components/common/navigation/BackButton.tsx
+++ b/frontend/src/components/common/navigation/BackButton.tsx
@@ -7,19 +7,25 @@ import { ArrowBackOutlineIcon } from "../../../assets/icons";
 interface BackButtonProps {
   size?: string;
   text?: string;
+  onClick?: () => void;
   returnTo?: string;
 }
 
 const BackButton = ({
+  onClick,
   returnTo,
-  size = "sm",
-  text = "Back",
+  size = "xl",
+  text = "",
 }: BackButtonProps): React.ReactElement => {
   const history = useHistory();
   return (
     <Button
       leftIcon={text ? <ArrowBackOutlineIcon /> : undefined}
-      onClick={() => (returnTo ? history.push(returnTo) : history.goBack())}
+      onClick={
+        onClick
+          ? onClick
+          : () => (returnTo ? history.push(returnTo) : history.goBack())
+      }
       size={size}
       variant="tertiary"
     >

--- a/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
+++ b/frontend/src/components/pages/teacher/DisplayAssessmentResultsPage/index.tsx
@@ -82,7 +82,7 @@ const DisplayAssessmentResults = () => {
   return (
     <Flex direction="column" gap={8}>
       <Text as="h1" color="blue.300" textStyle="header4">
-        <BackButton returnTo={returnTo} size="xl" text="" />
+        <BackButton returnTo={returnTo} />
         <Skeleton as="span" isLoaded={!!displayTitle} ml={6}>
           <Box as="span">{displayTitle ?? "Loading..."}</Box>
         </Skeleton>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update Assessment / Question Editor Back Button](https://www.notion.so/uwblueprintexecs/Update-Assessment-Question-Editor-Back-Button-cd885fa463bd4292a7329cc25fe24424?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Change back button in assessment and question editor to large variant

![image](https://github.com/uwblueprint/jump-math/assets/69697180/e3a0a9dd-d4be-473b-8972-443dd44d5a60)
![image](https://github.com/uwblueprint/jump-math/assets/69697180/83c7213f-5d09-4000-bc38-ba1e49d6932b)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Visit assessment / question editor page and verify that it looks as expected


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
