### PR TITLE
fix: add file upload validation for payload exceeded error

### DIFF
--- a/frontend/src/components/admin/question-creation/QuestionEditor.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionEditor.tsx
@@ -25,6 +25,7 @@ const QuestionEditor = (): React.ReactElement => {
     React.useState(false);
   const [showAddFractionModal, setShowAddFractionModal] = React.useState(false);
   const [showEditorError, setShowEditorError] = React.useState(false);
+  const [editorError, setEditorError] = React.useState("");
   const [showQuestionPreview, setShowQuestionPreview] = React.useState(false);
 
   return (
@@ -42,6 +43,8 @@ const QuestionEditor = (): React.ReactElement => {
         setShowAddFractionModal,
         showEditorError,
         setShowEditorError,
+        editorError,
+        setEditorError,
         showQuestionPreview,
         setShowQuestionPreview,
       }}

--- a/frontend/src/components/admin/question-creation/QuestionSidebarItem.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionSidebarItem.tsx
@@ -3,7 +3,7 @@ import { useDrag } from "react-dnd";
 import { Box, Icon, Text, Tooltip, VStack, WrapItem } from "@chakra-ui/react";
 import { v4 as uuidv4 } from "uuid";
 
-import editorTooltips from "../../../constants/QuestionConstants";
+import { editorTooltips } from "../../../constants/QuestionConstants";
 import QuestionEditorContext from "../../../contexts/QuestionEditorContext";
 import { DragTypes } from "../../../types/DragTypes";
 import type { QuestionElement } from "../../../types/QuestionTypes";

--- a/frontend/src/components/admin/question-creation/QuestionWorkspace.tsx
+++ b/frontend/src/components/admin/question-creation/QuestionWorkspace.tsx
@@ -10,7 +10,7 @@ import QuestionElementItem from "./QuestionElementItem";
 import WelcomeMessage from "./WelcomeMessage";
 
 const QuestionWorkspace = (): React.ReactElement => {
-  const { questionElements, showEditorError } = useContext(
+  const { questionElements, showEditorError, editorError } = useContext(
     QuestionEditorContext,
   );
   const [{ canDrop, isOver }, drop] = useDrop(() => ({
@@ -24,15 +24,12 @@ const QuestionWorkspace = (): React.ReactElement => {
 
   const isHovering = canDrop && isOver;
 
-  const emptyEditorError =
-    "Please add at least one question to the editor before saving";
-
   return (
     <Box ref={drop} flex="1" overflow="auto">
       <VStack align="left" margin="3em 5em">
         {showEditorError && (
           <Box paddingBottom="4">
-            <ErrorToast errorMessage={emptyEditorError} />
+            <ErrorToast errorMessage={editorError} />
           </Box>
         )}
         {!isHovering && !questionElements.length && <WelcomeMessage />}

--- a/frontend/src/components/common/form/ActionButton.tsx
+++ b/frontend/src/components/common/form/ActionButton.tsx
@@ -4,10 +4,6 @@ import { ApolloError } from "@apollo/client";
 import type { ButtonProps } from "@chakra-ui/react";
 import { Button } from "@chakra-ui/react";
 
-import {
-  MAX_FILE_SIZE_MB,
-  MAX_FILES,
-} from "../../../constants/QuestionConstants";
 import { FormValidationError } from "../../../utils/GeneralUtils";
 import useToast from "../info/useToast";
 
@@ -91,7 +87,7 @@ const ActionButton = <Default extends boolean = true>({
       const errorMessage =
         e instanceof ApolloError &&
         e.message == "Response not successful: Received status code 413"
-          ? `Total size of new files exceeds ${MAX_FILE_SIZE_MB}MB or total number of new files exceeds ${MAX_FILES}. Please try again with fewer / smaller image files.`
+          ? `Request is too large. Please try again with smaller / fewer image files.`
           : e instanceof FormValidationError
           ? e.message
           : nonValidationMessage;

--- a/frontend/src/components/common/form/ActionButton.tsx
+++ b/frontend/src/components/common/form/ActionButton.tsx
@@ -1,8 +1,13 @@
 import type { Dispatch, ReactElement, SetStateAction } from "react";
 import React, { useState } from "react";
+import { ApolloError } from "@apollo/client";
 import type { ButtonProps } from "@chakra-ui/react";
 import { Button } from "@chakra-ui/react";
 
+import {
+  MAX_FILE_SIZE_MB,
+  MAX_FILES,
+} from "../../../constants/QuestionConstants";
 import { FormValidationError } from "../../../utils/GeneralUtils";
 import useToast from "../info/useToast";
 
@@ -84,7 +89,12 @@ const ActionButton = <Default extends boolean = true>({
           : generateErrorMessage) ??
         "An error occurred. Please try again later.";
       const errorMessage =
-        e instanceof FormValidationError ? e.message : nonValidationMessage;
+        e instanceof ApolloError &&
+        e.message == "Response not successful: Received status code 413"
+          ? `Total size of new files exceeds ${MAX_FILE_SIZE_MB}MB or total number of new files exceeds ${MAX_FILES}. Please try again with fewer / smaller image files.`
+          : e instanceof FormValidationError
+          ? e.message
+          : nonValidationMessage;
       handleError(errorMessage);
     } finally {
       setLoading(false);

--- a/frontend/src/constants/QuestionConstants.ts
+++ b/frontend/src/constants/QuestionConstants.ts
@@ -1,4 +1,4 @@
-const editorTooltips = {
+export const editorTooltips = {
   QUESTION_TEXT: "This is question text",
   TEXT: "This is text",
   IMAGE: "This is an image",
@@ -10,4 +10,5 @@ const editorTooltips = {
   FRACTION: "Students will have to input a proper, improper, or mixed fraction",
 };
 
-export default editorTooltips;
+export const MAX_FILE_SIZE_MB = 10;
+export const MAX_FILES = 20;

--- a/frontend/src/contexts/QuestionEditorContext.ts
+++ b/frontend/src/contexts/QuestionEditorContext.ts
@@ -19,6 +19,8 @@ type QuestionEditorContextType = {
   setShowAddFractionModal: (_showAddFractionModal: boolean) => void;
   showEditorError: boolean;
   setShowEditorError: (_showEditorError: boolean) => void;
+  editorError: string;
+  setEditorError: (_editorError: string) => void;
   showQuestionPreview: boolean;
   setShowQuestionPreview: (_showQuestionPreview: boolean) => void;
 };
@@ -40,6 +42,8 @@ const QuestionEditorContext = createContext<QuestionEditorContextType>({
   setShowAddFractionModal: (_showAddFractionModal: boolean): void => {},
   showEditorError: false,
   setShowEditorError: (_showEditorError: boolean): void => {},
+  editorError: "",
+  setEditorError: (_editorError: string): void => {},
   showQuestionPreview: false,
   setShowQuestionPreview: (_showQuestionPreview: boolean): void => {},
 });


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add form validation to images](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add validation to assessment editor to handle `413` (Request entity too large) error 
* Add validation to question editor for the following image restrictions (set in [server.ts](https://github.com/uwblueprint/jump-math/blob/staging/backend/server.ts#L73)):
   * Max size of (new) files: 10MB
   * Max (new) files: 20


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Add new files that exceed 10MB in question editor. Check that the error message is displayed in the question editor.
2. Add new files that exceed 10MB in two separate questions. Check that the error message is displayed in the assessment editor.
3. Add new files that do not exceed 10MB and ensure save is successful
     * Note: even if images < 10MB, you may still get 413 error if rest of the form data exceeds 10MB 
5. Repeat 1 and 2 but to validate the number of files is exceeded. (Change `MAX_FILES` for testing purposes)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
