### PR TITLE
fix: remove GraphQL upload limits

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -71,9 +71,9 @@ const runServer = async () => {
   app.use(cors(CORS_OPTIONS));
   app.use(
     await graphqlUploadExpress({
-      maxFileSize: 10 * 1024 * 1024, // 10 MB
-      maxFieldSize: 10 * 1024 * 1024, // 10 MB
-      maxFiles: 20,
+      maxFileSize: 5 * 1024 * 1024, // 5 MB
+      maxFieldSize: Infinity,
+      maxFiles: Infinity,
     }),
   );
   app.use(express.json());


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Remove limits for max field size and number of files


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Upload a file less than 5MB (5.4MB on Mac). This should be successful.
2. Upload a file more than 5MB (5.4MB on Mac). This should fail with an error message.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
