### PR TITLE
feat: preview assessment from teacher dashboard

### DIFF
--- a/frontend/src/assets/icons.tsx
+++ b/frontend/src/assets/icons.tsx
@@ -425,8 +425,8 @@ export const SaveOutlineIcon = (): React.ReactElement => (
   </Icon>
 );
 
-export const EyeOutlineIcon = (): React.ReactElement => (
-  <Icon viewBox="0 0 24 24">
+export const EyeOutlineIcon = (props: IconProps): React.ReactElement => (
+  <Icon viewBox="0 0 24 24" {...props}>
     <rect height="24" opacity="0" width="24" />
     <path
       d="M21.87 11.5c-.64-1.11-4.16-6.68-10.14-6.5-5.53.14-8.73 5-9.6 6.5a1 1 0 0 0 0 1c.63 1.09 4 6.5 9.89 6.5h.25c5.53-.14 8.74-5 9.6-6.5a1 1 0 0 0 0-1zM12.22 17c-4.31.1-7.12-3.59-8-5 1-1.61 3.61-4.9 7.61-5 4.29-.11 7.11 3.59 8 5-1.03 1.61-3.61 4.9-7.61 5z"

--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -76,7 +76,7 @@ const AssessmentEditorHeader = ({
   const onPreview = () => {
     validateForm();
     disableEditorPrompt(history.push)(
-      Routes.ASSESSMENT_PREVIEW_PAGE({
+      Routes.ADMIN_ASSESSMENT_PREVIEW_PAGE({
         assessmentId,
       }),
     );

--- a/frontend/src/components/admin/assessment-status/EditStatusButtons/PreviewButton.tsx
+++ b/frontend/src/components/admin/assessment-status/EditStatusButtons/PreviewButton.tsx
@@ -28,7 +28,7 @@ const PreviewButton = ({
       onClick={async () => {
         if (data) {
           history.push({
-            pathname: Routes.ASSESSMENT_PREVIEW_PAGE({ assessmentId }),
+            pathname: Routes.ADMIN_ASSESSMENT_PREVIEW_PAGE({ assessmentId }),
             state: data.test,
           });
         } else {

--- a/frontend/src/components/pages/admin/AdminRouting.tsx
+++ b/frontend/src/components/pages/admin/AdminRouting.tsx
@@ -36,7 +36,7 @@ const AdminRouting = (): React.ReactElement => {
       />
       <PrivateRoute
         component={AssessmentPreviewPage}
-        path={Routes.ASSESSMENT_PREVIEW_PAGE({
+        path={Routes.ADMIN_ASSESSMENT_PREVIEW_PAGE({
           assessmentId: ":assessmentId",
         })}
         roles={["Admin"]}

--- a/frontend/src/components/pages/admin/AdminRouting.tsx
+++ b/frontend/src/components/pages/admin/AdminRouting.tsx
@@ -7,10 +7,10 @@ import type Page from "../../../types/PageTypes";
 import PrivateRoute from "../../auth/PrivateRoute";
 import RedirectTo from "../../auth/RedirectTo";
 import Navbar from "../../common/navigation/Navbar";
+import AssessmentPreviewPage from "../common/AssessmentPreviewPage";
 import NotFound from "../NotFound";
 
 import AssessmentEditorPage from "./AssessmentEditorPage";
-import AssessmentPreviewPage from "./AssessmentPreviewPage";
 import DisplayAssessmentsPage from "./DisplayAssessmentsPage";
 import UsersPage from "./UsersPage";
 

--- a/frontend/src/components/pages/admin/AssessmentPreviewPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentPreviewPage.tsx
@@ -13,7 +13,7 @@ import QueryStateHandler from "../../common/QueryStateHandler";
 import AssessmentExperience from "../../student/AssessmentExperience";
 
 const AssessmentPreviewPage = () => {
-  // TODO: move to common folder
+  // TODO: move to different folder
   const history = useHistory();
 
   // Data could come from the previous page.
@@ -42,6 +42,7 @@ const AssessmentPreviewPage = () => {
     [test],
   );
 
+  // TODO: fix for teacher dashboard
   const assessmentName = state?.name;
   usePageTitle(`Previewing "${assessmentName}`);
 

--- a/frontend/src/components/pages/admin/AssessmentPreviewPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentPreviewPage.tsx
@@ -13,6 +13,7 @@ import QueryStateHandler from "../../common/QueryStateHandler";
 import AssessmentExperience from "../../student/AssessmentExperience";
 
 const AssessmentPreviewPage = () => {
+  // TODO: move to common folder
   const history = useHistory();
 
   // Data could come from the previous page.

--- a/frontend/src/components/pages/admin/AssessmentPreviewPage.tsx
+++ b/frontend/src/components/pages/admin/AssessmentPreviewPage.tsx
@@ -42,7 +42,6 @@ const AssessmentPreviewPage = () => {
     [test],
   );
 
-  // TODO: fix for teacher dashboard
   const assessmentName = state?.name;
   usePageTitle(`Previewing "${assessmentName}`);
 

--- a/frontend/src/components/pages/common/AssessmentPreviewPage.tsx
+++ b/frontend/src/components/pages/common/AssessmentPreviewPage.tsx
@@ -13,7 +13,6 @@ import QueryStateHandler from "../../common/QueryStateHandler";
 import AssessmentExperience from "../../student/AssessmentExperience";
 
 const AssessmentPreviewPage = () => {
-  // TODO: move to different folder
   const history = useHistory();
 
   // Data could come from the previous page.

--- a/frontend/src/components/pages/teacher/TeacherRouting.tsx
+++ b/frontend/src/components/pages/teacher/TeacherRouting.tsx
@@ -7,7 +7,7 @@ import type Page from "../../../types/PageTypes";
 import PrivateRoute from "../../auth/PrivateRoute";
 import RedirectTo from "../../auth/RedirectTo";
 import Navbar from "../../common/navigation/Navbar";
-import AssessmentPreviewPage from "../admin/AssessmentPreviewPage";
+import AssessmentPreviewPage from "../common/AssessmentPreviewPage";
 import NotFound from "../NotFound";
 
 import ClassroomsPage from "./ClassroomsPage";

--- a/frontend/src/components/pages/teacher/TeacherRouting.tsx
+++ b/frontend/src/components/pages/teacher/TeacherRouting.tsx
@@ -7,6 +7,7 @@ import type Page from "../../../types/PageTypes";
 import PrivateRoute from "../../auth/PrivateRoute";
 import RedirectTo from "../../auth/RedirectTo";
 import Navbar from "../../common/navigation/Navbar";
+import AssessmentPreviewPage from "../admin/AssessmentPreviewPage";
 import NotFound from "../NotFound";
 
 import ClassroomsPage from "./ClassroomsPage";
@@ -27,6 +28,13 @@ const TeacherRouting = (): React.ReactElement => {
     <VStack align="left" flex="1" height="100vh">
       <Switch>
         <Route path={Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE()} />
+        <PrivateRoute
+          component={AssessmentPreviewPage}
+          path={Routes.TEACHER_ASSESSMENT_PREVIEW_PAGE({
+            assessmentId: ":assessmentId",
+          })}
+          roles={["Teacher"]}
+        />
         <Route path="*">
           <Navbar pages={pages} />
         </Route>

--- a/frontend/src/components/pages/teacher/TeacherRouting.tsx
+++ b/frontend/src/components/pages/teacher/TeacherRouting.tsx
@@ -34,6 +34,7 @@ const TeacherRouting = (): React.ReactElement => {
             assessmentId: ":assessmentId",
           })}
           roles={["Teacher"]}
+          title="Preview Assessment"
         />
         <Route path="*">
           <Navbar pages={pages} />

--- a/frontend/src/components/pages/teacher/TeacherRouting.tsx
+++ b/frontend/src/components/pages/teacher/TeacherRouting.tsx
@@ -28,64 +28,62 @@ const TeacherRouting = (): React.ReactElement => {
     <VStack align="left" flex="1" height="100vh">
       <Switch>
         <Route path={Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE()} />
-        <PrivateRoute
+        <Route
           component={AssessmentPreviewPage}
           path={Routes.TEACHER_ASSESSMENT_PREVIEW_PAGE({
             assessmentId: ":assessmentId",
           })}
-          roles={["Teacher"]}
-          title="Preview Assessment"
         />
         <Route path="*">
           <Navbar pages={pages} />
+          <Flex flex="1" flexDirection="column" padding="1.5em 2em 2em 2em">
+            <Switch>
+              <PrivateRoute
+                component={DisplayAssessmentResults}
+                path={Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE()}
+                roles={["Teacher"]}
+                title="Assessment Results"
+              />
+              <PrivateRoute
+                component={TeacherDashboardPage}
+                exact
+                path={Routes.TEACHER_DASHBOARD_PAGE}
+                roles={["Teacher"]}
+                title="Dashboard"
+              />
+              <PrivateRoute
+                component={DistributeAssessmentPage}
+                exact
+                path={Routes.DISTRIBUTE_ASSESSMENT_PAGE}
+                roles={["Teacher"]}
+                title="Distribute Assessment"
+              />
+              <PrivateRoute
+                component={DisplayAssessmentsPage}
+                path={Routes.DISPLAY_ASSESSMENTS_PAGE}
+                roles={["Teacher"]}
+                title="Assessments"
+              />
+              <PrivateRoute
+                component={ClassroomsPage}
+                exact
+                path={Routes.CLASSROOMS_PAGE}
+                roles={["Teacher"]}
+                title="Classrooms"
+              />
+              <PrivateRoute
+                component={DisplayClassroomPage}
+                path={Routes.DISPLAY_CLASSROOM_PAGE()}
+                roles={["Teacher"]}
+              />
+              <Route exact path={Routes.TEACHER_LANDING_PAGE}>
+                <RedirectTo pathname={Routes.TEACHER_DASHBOARD_PAGE} />
+              </Route>
+              <Route component={NotFound} exact path="*" />
+            </Switch>
+          </Flex>
         </Route>
       </Switch>
-      <Flex flex="1" flexDirection="column" padding="1.5em 2em 2em 2em">
-        <Switch>
-          <PrivateRoute
-            component={DisplayAssessmentResults}
-            path={Routes.DISPLAY_ASSESSMENT_RESULTS_PAGE()}
-            roles={["Teacher"]}
-            title="Assessment Results"
-          />
-          <PrivateRoute
-            component={TeacherDashboardPage}
-            exact
-            path={Routes.TEACHER_DASHBOARD_PAGE}
-            roles={["Teacher"]}
-            title="Dashboard"
-          />
-          <PrivateRoute
-            component={DistributeAssessmentPage}
-            exact
-            path={Routes.DISTRIBUTE_ASSESSMENT_PAGE}
-            roles={["Teacher"]}
-            title="Distribute Assessment"
-          />
-          <PrivateRoute
-            component={DisplayAssessmentsPage}
-            path={Routes.DISPLAY_ASSESSMENTS_PAGE}
-            roles={["Teacher"]}
-            title="Assessments"
-          />
-          <PrivateRoute
-            component={ClassroomsPage}
-            exact
-            path={Routes.CLASSROOMS_PAGE}
-            roles={["Teacher"]}
-            title="Classrooms"
-          />
-          <PrivateRoute
-            component={DisplayClassroomPage}
-            path={Routes.DISPLAY_CLASSROOM_PAGE()}
-            roles={["Teacher"]}
-          />
-          <Route exact path={Routes.TEACHER_LANDING_PAGE}>
-            <RedirectTo pathname={Routes.TEACHER_DASHBOARD_PAGE} />
-          </Route>
-          <Route component={NotFound} exact path="*" />
-        </Switch>
-      </Flex>
     </VStack>
   );
 };

--- a/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
+++ b/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
@@ -40,12 +40,12 @@ const AssessmentsTable = ({
   isDisabled = false,
 }: AssessmentsTableProps): React.ReactElement => {
   const history = useHistory();
+  const { showToast } = useToast();
 
   const [previewAssessmentQuery] = useLazyQuery<{
     test: TestResponse;
   }>(GET_TEST);
 
-  const { showToast } = useToast();
   const previewAssessment = async (assessmentId: string) => {
     const { data } = await previewAssessmentQuery({
       variables: { id: assessmentId },

--- a/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
+++ b/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
@@ -41,13 +41,13 @@ const AssessmentsTable = ({
 }: AssessmentsTableProps): React.ReactElement => {
   const history = useHistory();
 
-  const [previewAssessment] = useLazyQuery<{
+  const [previewAssessmentQuery] = useLazyQuery<{
     test: TestResponse;
   }>(GET_TEST);
 
   const { showToast } = useToast();
-  const onPreviewClick = async (assessmentId: string) => {
-    const { data } = await previewAssessment({
+  const previewAssessment = async (assessmentId: string) => {
+    const { data } = await previewAssessmentQuery({
       variables: { id: assessmentId },
     });
     if (data) {
@@ -88,10 +88,9 @@ const AssessmentsTable = ({
       <ActionButton
         aria-label="preview-assessment"
         leftIcon={<EyeOutlineIcon boxSize={5} />}
-        onClick={() => onPreviewClick(assessment.id)}
+        onClick={() => previewAssessment(assessment.id)}
         showDefaultToasts={false}
         size="sm"
-        variant="tertiary"
       />
     ),
     onClick: () => {

--- a/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
+++ b/frontend/src/components/teacher/session-creation/AssessmentsTable.tsx
@@ -1,9 +1,17 @@
 import React from "react";
+import { useHistory } from "react-router-dom";
+import { useLazyQuery } from "@apollo/client";
 import { Radio, RadioGroup, Text } from "@chakra-ui/react";
 
+import { GET_TEST } from "../../../APIClients/queries/TestQueries";
+import type { TestResponse } from "../../../APIClients/types/TestClientTypes";
 import type { Grade } from "../../../APIClients/types/UserClientTypes";
+import { EyeOutlineIcon } from "../../../assets/icons";
+import * as Routes from "../../../constants/Routes";
 import type { UseCase } from "../../../types/AssessmentTypes";
 import { removeUnderscore, titleCase } from "../../../utils/GeneralUtils";
+import ActionButton from "../../common/form/ActionButton";
+import useToast from "../../common/info/useToast";
 import type { TableRow } from "../../common/table/Table";
 import { Table } from "../../common/table/Table";
 
@@ -31,6 +39,33 @@ const AssessmentsTable = ({
   setTestName,
   isDisabled = false,
 }: AssessmentsTableProps): React.ReactElement => {
+  const history = useHistory();
+
+  const [previewAssessment] = useLazyQuery<{
+    test: TestResponse;
+  }>(GET_TEST);
+
+  const { showToast } = useToast();
+  const onPreviewClick = async (assessmentId: string) => {
+    const { data } = await previewAssessment({
+      variables: { id: assessmentId },
+    });
+    if (data) {
+      history.push({
+        pathname: Routes.TEACHER_ASSESSMENT_PREVIEW_PAGE({
+          assessmentId,
+        }),
+        state: data.test,
+      });
+    } else {
+      showToast({
+        message:
+          "This assessment cannot be previewed at this time. Please try again.",
+        status: "error",
+      });
+    }
+  };
+
   const headers = ["", "Name", "Grade", "Type", "Country", "Region"];
   const rows: TableRow[] = assessments.map((assessment, i) => ({
     id: assessment.id,
@@ -49,6 +84,16 @@ const AssessmentsTable = ({
       assessment.curriculumCountry,
       assessment.curriculumRegion,
     ],
+    menu: (
+      <ActionButton
+        aria-label="preview-assessment"
+        leftIcon={<EyeOutlineIcon boxSize={5} />}
+        onClick={() => onPreviewClick(assessment.id)}
+        showDefaultToasts={false}
+        size="sm"
+        variant="tertiary"
+      />
+    ),
     onClick: () => {
       setTestId(assessment.id);
       if (setTestName) {

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from "react";
 import { useHistory } from "react-router-dom";
-import { useMutation, useQuery } from "@apollo/client";
+import { useLazyQuery, useMutation } from "@apollo/client";
 import { Divider, useDisclosure, VStack } from "@chakra-ui/react";
 
 import { DELETE_TEST_SESSION } from "../../../APIClients/mutations/TestSessionMutations";
@@ -29,8 +29,8 @@ const TestSessionListItemPopover = ({
     onOpen: openDeleteModal,
     onClose: onDeleteModalClose,
   } = useDisclosure();
-
   const history = useHistory();
+  const { showToast } = useToast();
 
   const [deleteTestSession] = useMutation(DELETE_TEST_SESSION, {
     variables: { id: session.testSessionId },
@@ -41,13 +41,14 @@ const TestSessionListItemPopover = ({
     history.push(Routes.DISTRIBUTE_ASSESSMENT_PAGE, session);
   };
 
-  const { data } = useQuery<{ test: TestResponse }>(GET_TEST, {
-    fetchPolicy: "cache-and-network",
-    variables: { id: session.testId },
-  });
-  const { showToast } = useToast();
+  const [previewTest] = useLazyQuery<{
+    test: TestResponse;
+  }>(GET_TEST);
 
-  const onPreview = async () => {
+  const onPreviewTest = async () => {
+    const { data } = await previewTest({
+      variables: { id: session.testId },
+    });
     if (data) {
       history.push({
         pathname: Routes.TEACHER_ASSESSMENT_PREVIEW_PAGE({
@@ -72,7 +73,7 @@ const TestSessionListItemPopover = ({
           <>
             <PopoverButton name="Delete" onClick={openDeleteModal} />
             <Divider />
-            <PopoverButton name="Preview" onClick={onPreview} />
+            <PopoverButton name="Preview" onClick={onPreviewTest} />
           </>
         )}
       </VStack>

--- a/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
+++ b/frontend/src/components/teacher/view-sessions/TestSessionListItemPopover.tsx
@@ -1,14 +1,17 @@
 import React, { type ReactElement } from "react";
 import { useHistory } from "react-router-dom";
-import { useMutation } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client";
 import { Divider, useDisclosure, VStack } from "@chakra-ui/react";
 
 import { DELETE_TEST_SESSION } from "../../../APIClients/mutations/TestSessionMutations";
+import { GET_TEST } from "../../../APIClients/queries/TestQueries";
 import { GET_TEST_SESSIONS_BY_TEACHER_ID } from "../../../APIClients/queries/TestSessionQueries";
+import type { TestResponse } from "../../../APIClients/types/TestClientTypes";
 import * as Routes from "../../../constants/Routes";
 import { TestSessionStatus } from "../../../types/TestSessionTypes";
 import { getQueryName } from "../../../utils/GeneralUtils";
 import DeleteAssessmentModal from "../../admin/assessment-status/EditStatusModals/DeleteAssessmentModal";
+import useToast from "../../common/info/useToast";
 import Popover from "../../common/popover/Popover";
 import PopoverButton from "../../common/popover/PopoverButton";
 
@@ -38,12 +41,39 @@ const TestSessionListItemPopover = ({
     history.push(Routes.DISTRIBUTE_ASSESSMENT_PAGE, session);
   };
 
+  const { data } = useQuery<{ test: TestResponse }>(GET_TEST, {
+    fetchPolicy: "cache-and-network",
+    variables: { id: session.testId },
+  });
+  const { showToast } = useToast();
+
+  const onPreview = async () => {
+    if (data) {
+      history.push({
+        pathname: Routes.TEACHER_ASSESSMENT_PREVIEW_PAGE({
+          assessmentId: session.testId,
+        }),
+        state: data.test,
+      });
+    } else {
+      showToast({
+        message:
+          "This assessment cannot be previewed at this time. Please try again.",
+        status: "error",
+      });
+    }
+  };
+
   return (
     <Popover>
       <VStack divider={<Divider />} spacing={0}>
         <PopoverButton name="Edit" onClick={onEditTestSession} />
         {session.status !== TestSessionStatus.PAST && (
-          <PopoverButton name="Delete" onClick={openDeleteModal} />
+          <>
+            <PopoverButton name="Delete" onClick={openDeleteModal} />
+            <Divider />
+            <PopoverButton name="Preview" onClick={onPreview} />
+          </>
         )}
       </VStack>
       <DeleteAssessmentModal

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -81,6 +81,11 @@ export const DISPLAY_CLASSROOM_ASSESSMENTS_PAGE = ({
 export const DISPLAY_CLASSROOM_STUDENTS_PAGE = ({
   classroomId = ":classroomId",
 } = {}) => `/teacher/classrooms/${classroomId}/students`;
+export const TEACHER_ASSESSMENT_PREVIEW_PAGE = ({
+  assessmentId,
+}: {
+  assessmentId?: string;
+}) => "/teacher/assessment-preview/" + assessmentId;
 
 // Private Student Routes
 export const STUDENT_LANDING_PAGE = "/student";

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -50,7 +50,7 @@ export const ASSESSMENT_EDITOR_QUESTION_PREVIEW_PAGE = ({
   ASSESSMENT_EDITOR_QUESTION_EDITOR_BASE({ assessmentId, questionIndex }) +
   "/preview";
 
-export const ASSESSMENT_PREVIEW_PAGE = ({
+export const ADMIN_ASSESSMENT_PREVIEW_PAGE = ({
   assessmentId,
 }: {
   assessmentId?: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Preview Assessment screen in Teacher Dashboard](https://www.notion.so/uwblueprintexecs/Preview-Assessment-screen-in-Teacher-Dashboard-e2ac3599ef2d42419f4279d445294bbf?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Preview assessment from `TestSessionListItem`
* Preview assessment from **Distribute Assessment** page