### PR TITLE
fix: show search filters unconditionally

### DIFF
--- a/frontend/src/components/admin/user-management/admin/AdminTab.tsx
+++ b/frontend/src/components/admin/user-management/admin/AdminTab.tsx
@@ -11,7 +11,7 @@ interface AdminTabProps<SortPropTypes extends readonly string[]> {
   searchBarComponent: React.ReactElement<SearchBarProps>;
   UserTable: React.ReactElement<AdminUser[] | TeacherUser[]>;
   search: string;
-  searchLength: number;
+  resultsLength: number;
 }
 
 export interface AdminTableProps {
@@ -26,7 +26,7 @@ const AdminTab = <SortPropTypes extends readonly string[]>({
   searchBarComponent,
   UserTable,
   search,
-  searchLength,
+  resultsLength,
 }: AdminTabProps<SortPropTypes>): React.ReactElement => {
   return (
     <>
@@ -37,10 +37,14 @@ const AdminTab = <SortPropTypes extends readonly string[]>({
         </HStack>
         {search && (
           <Text color="grey.300" fontSize="16px" width="100%">
-            Showing {searchLength} results for &quot;{search}&quot;
+            Showing {resultsLength} results for &quot;{search}&quot;
           </Text>
         )}
-        {searchLength !== 0 ? UserTable : <NoResultsTableState items="users" />}
+        {resultsLength !== 0 ? (
+          UserTable
+        ) : (
+          <NoResultsTableState items="users" />
+        )}
       </VStack>
     </>
   );

--- a/frontend/src/components/common/table/SearchableTablePage.tsx
+++ b/frontend/src/components/common/table/SearchableTablePage.tsx
@@ -37,13 +37,11 @@ const SearchableTablePage = <T, SortPropTypes extends readonly string[]>({
   return (
     <>
       <VStack pt={4} spacing={6} w="full">
-        {searchLength !== 0 && (
-          <HStack width="100%">
-            {searchBarComponent}
-            {sortMenuComponent}
-            {filterMenuComponent}
-          </HStack>
-        )}
+        <HStack width="100%">
+          {searchBarComponent}
+          {sortMenuComponent}
+          {filterMenuComponent}
+        </HStack>
         {search && (
           <Text color="grey.300" fontSize="16px" width="100%">
             Showing {searchLength} results for &quot;

--- a/frontend/src/components/common/table/SearchableTablePage.tsx
+++ b/frontend/src/components/common/table/SearchableTablePage.tsx
@@ -14,7 +14,7 @@ interface SearchableTablePageProps<T, SortPropTypes extends readonly string[]> {
   searchBarComponent: React.ReactElement<SearchBarProps>;
   tableComponent: React.ReactElement<T[]>;
   search: string;
-  searchLength: number;
+  resultsLength: number;
   nameOfTableItems: string;
 }
 
@@ -26,7 +26,7 @@ const SearchableTablePage = <T, SortPropTypes extends readonly string[]>({
   searchBarComponent,
   tableComponent,
   search,
-  searchLength,
+  resultsLength,
   nameOfTableItems,
 }: SearchableTablePageProps<T, SortPropTypes>): React.ReactElement => {
   const emptyResults = noResults ? (
@@ -44,11 +44,11 @@ const SearchableTablePage = <T, SortPropTypes extends readonly string[]>({
         </HStack>
         {search && (
           <Text color="grey.300" fontSize="16px" width="100%">
-            Showing {searchLength} results for &quot;
+            Showing {resultsLength} results for &quot;
             {search}&quot;
           </Text>
         )}
-        {searchLength !== 0 ? tableComponent : emptyResults}
+        {resultsLength !== 0 ? tableComponent : emptyResults}
       </VStack>
     </>
   );

--- a/frontend/src/components/pages/admin/DisplayAssessmentsPage.tsx
+++ b/frontend/src/components/pages/admin/DisplayAssessmentsPage.tsx
@@ -111,9 +111,9 @@ const DisplayAssessmentsPage = (): React.ReactElement => {
           nameOfTableItems="assessments"
           noResults={isEmpty}
           noResultsComponent={<EmptyTestsMessage />}
+          resultsLength={assessments.length}
           search={search}
           searchBarComponent={<SearchBar onSearch={setSearch} />}
-          searchLength={assessments.length}
           sortMenuComponent={
             <SortMenu
               initialSortOrder="descending"

--- a/frontend/src/components/pages/admin/UsersPage.tsx
+++ b/frontend/src/components/pages/admin/UsersPage.tsx
@@ -107,9 +107,9 @@ const UsersPage = (): React.ReactElement => {
           <TabPanels>
             <TabPanel padding="0">
               <AdminTab
+                resultsLength={admins.length}
                 search={search}
                 searchBarComponent={<SearchBar onSearch={setSearch} />}
-                searchLength={admins.length}
                 sortMenuComponent={
                   <SortMenu
                     labels={["name", "email"]}
@@ -123,9 +123,9 @@ const UsersPage = (): React.ReactElement => {
             </TabPanel>
             <TabPanel padding="0">
               <AdminTab
+                resultsLength={teachers.length}
                 search={search}
                 searchBarComponent={<SearchBar onSearch={setSearch} />}
-                searchLength={teachers.length}
                 sortMenuComponent={
                   <SortMenu
                     labels={["name", "email", "school"]}

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomAssessmentsPage.tsx
@@ -108,9 +108,9 @@ const DisplayClassroomAssessmentsPage = () => {
             isActive={data?.class.isActive}
           />
         }
+        resultsLength={paginatedData.length}
         search={search}
         searchBarComponent={<SearchBar onSearch={setSearch} />}
-        searchLength={paginatedData.length}
         sortMenuComponent={
           <SortMenu
             initialSortOrder={sortOrder}

--- a/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomStudentsPage.tsx
+++ b/frontend/src/components/pages/teacher/DisplayClassroomPage/DisplayClassroomStudentsPage.tsx
@@ -60,9 +60,9 @@ const DisplayClassroomStudentsPage = ({
             onClick={onCreateStudent}
           />
         }
+        resultsLength={students.length}
         search={search}
         searchBarComponent={<SearchBar onSearch={setSearch} />}
-        searchLength={students.length}
         sortMenuComponent={
           <SortMenu
             initialSortOrder="descending"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix Search Bar For Empty Results](https://www.notion.so/uwblueprintexecs/Fix-Search-Bar-For-Empty-Results-13196df0a76747f4b63036a6e29fbb59?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
<img width="989" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/ae7cac5e-39c2-411f-ab00-ba8fd895990f">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
