### PR TITLE
feat: add times to assessment date pickers

### DIFF
--- a/backend/services/implementations/testSessionService.ts
+++ b/backend/services/implementations/testSessionService.ts
@@ -364,7 +364,7 @@ class TestSessionService implements ITestSessionService {
             return (
               !updatableKeys.has(key) &&
               (currentValue instanceof Date
-                ? currentValue.getTime() !== newValue.getTime()
+                ? currentValue.getTime() !== new Date(newValue).getTime()
                 : currentValue?.toString() !== newValue)
             );
           },

--- a/frontend/src/components/common/form/DatePicker.tsx
+++ b/frontend/src/components/common/form/DatePicker.tsx
@@ -1,7 +1,26 @@
 import type { ReactElement } from "react";
-import React from "react";
+import React, { useMemo } from "react";
 import { SingleDatepicker } from "chakra-dayzed-datepicker";
+import type { PropsConfigs } from "chakra-dayzed-datepicker/dist/utils/commonTypes";
 import { format } from "date-fns";
+
+const DATEPICKER_CONFIGS = {
+  dayNames: "SMTWTFS".split(""),
+  monthNames: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "Auguest",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+};
 
 type DatePickerProps = {
   name?: string;
@@ -10,82 +29,76 @@ type DatePickerProps = {
   isDisabled?: boolean;
 };
 
+const getDatePickerStyles = (
+  value?: Date | null,
+  isDisabled?: boolean,
+): PropsConfigs => ({
+  dateNavBtnProps: {
+    fontWeight: 400,
+  },
+  dayOfMonthBtnProps: {
+    defaultBtnProps: {
+      width: "2rem",
+      color: "grey.400",
+      fontWeight: 400,
+      borderRadius: 20,
+      _hover: {
+        width: "2rem",
+        background: "blue.300",
+        color: "white",
+        bg: "blue.300",
+      },
+    },
+    selectedBtnProps: {
+      width: "2rem",
+      background: "blue.300",
+      borderRadius: 20,
+      color: "white",
+    },
+    todayBtnProps: {
+      width: "2rem",
+      borderColor: "grey.300",
+      borderRadius: 20,
+      borderWidth: "1px",
+      borderStyle: "solid",
+    },
+  },
+  inputProps: {
+    isDisabled,
+    type: "button",
+    cursor: "pointer",
+    "aria-label": "This is a date input, activate to open date picker",
+    textAlign: "left",
+    value: value ? format(value, "yyyy-MM-dd") : "Please choose a date",
+    color: value ? "grey.300" : "placeholder.300",
+    transition: "color 0s",
+  },
+  popoverCompProps: {
+    popoverContentProps: {
+      fontWeight: "400",
+      color: "grey.300",
+    },
+  },
+});
+
 const DatePicker = ({
   name,
   onChange,
   value,
   isDisabled = false,
 }: DatePickerProps): ReactElement => {
+  const styles = useMemo(
+    () => getDatePickerStyles(value, isDisabled),
+    [value, isDisabled],
+  );
+
   return (
     <SingleDatepicker
-      configs={{
-        dayNames: "SMTWTFS".split(""),
-        monthNames: [
-          "January",
-          "February",
-          "March",
-          "April",
-          "May",
-          "June",
-          "July",
-          "August",
-          "September",
-          "October",
-          "November",
-          "December",
-        ],
-      }}
+      configs={DATEPICKER_CONFIGS}
       date={value || undefined}
       name={name ?? "date-input"}
       onDateChange={(date) => onChange(date)}
-      propsConfigs={{
-        dateNavBtnProps: {
-          fontWeight: 400,
-        },
-        dayOfMonthBtnProps: {
-          defaultBtnProps: {
-            width: "2rem",
-            color: "grey.400",
-            fontWeight: 400,
-            borderRadius: 20,
-            _hover: {
-              width: "2rem",
-              background: "blue.300",
-              color: "white",
-              bg: "blue.300",
-            },
-          },
-          selectedBtnProps: {
-            width: "2rem",
-            background: "blue.300",
-            borderRadius: 20,
-            color: "white",
-          },
-          todayBtnProps: {
-            width: "2rem",
-            borderColor: "grey.300",
-            borderRadius: 20,
-            borderWidth: "1px",
-            borderStyle: "solid",
-          },
-        },
-        inputProps: {
-          isDisabled,
-          type: "button",
-          cursor: "pointer",
-          "aria-label": "This is a date input, activate to open date picker",
-          textAlign: "left",
-          value: value ? format(value, "yyyy-MM-dd") : "Please choose a date",
-          color: value ? "grey.300" : "placeholder.300",
-          transition: "color 0s",
-        },
-        popoverCompProps: {
-          popoverContentProps: {
-            fontWeight: "400",
-            color: "grey.300",
-          },
-        },
-      }}
+      propsConfigs={styles}
     />
   );
 };

--- a/frontend/src/components/common/form/DateTimePicker.tsx
+++ b/frontend/src/components/common/form/DateTimePicker.tsx
@@ -33,12 +33,12 @@ const DateTimePicker = ({
       onChange(combineDateAndTime(newDate, timeValue));
     }
 
-    // For some reason, the time picker doesn't focus properly if we click it
-    // while the date picker is open. This is a workaround to make sure the
-    // click happens after the date picker has started to close.
+    // For some reason, the time picker doesn't focus properly if we try to
+    // focus it while the date picker is open. This is a workaround to make
+    // sure the focus happens after the date picker has started to close.
     setTimeout(() => {
       timePickerRef.current?.click();
-    }, 0);
+    });
   };
 
   const handleTimeChange = (newTime: Date | null) => {

--- a/frontend/src/components/common/form/DateTimePicker.tsx
+++ b/frontend/src/components/common/form/DateTimePicker.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from "react";
+import React, { useRef, useState } from "react";
+import { HStack } from "@chakra-ui/react";
+
+import { combineDateAndTime } from "../../../utils/DateUtils";
+
+import DatePicker from "./DatePicker";
+import TimePicker from "./TimePicker";
+
+type DateTimePickerProps = {
+  name?: string;
+  onChange: (date: Date | null) => void;
+  value: Date | null | undefined;
+  isDisabled?: boolean;
+};
+
+const DateTimePicker = ({
+  isDisabled,
+  onChange,
+  value,
+  name,
+}: DateTimePickerProps): ReactElement => {
+  const timePickerRef = useRef<HTMLDivElement>(null);
+
+  const [internalDateValue, setInternalDateValue] = useState<Date | null>(null);
+  const [internalTimeValue, setInternalTimeValue] = useState<Date | null>(null);
+  const dateValue = value ?? internalDateValue;
+  const timeValue = value ?? internalTimeValue;
+
+  const handleDateChange = (newDate: Date | null) => {
+    setInternalDateValue(newDate);
+    if (timeValue && newDate) {
+      onChange(combineDateAndTime(newDate, timeValue));
+    }
+
+    // For some reason, the time picker doesn't focus properly if we click it
+    // while the date picker is open. This is a workaround to make sure the
+    // click happens after the date picker has started to close.
+    setTimeout(() => {
+      timePickerRef.current?.click();
+    }, 0);
+  };
+
+  const handleTimeChange = (newTime: Date | null) => {
+    setInternalTimeValue(newTime);
+    if (dateValue && newTime) {
+      onChange(combineDateAndTime(dateValue, newTime));
+    }
+  };
+
+  return (
+    <HStack gap={4}>
+      <DatePicker
+        isDisabled={isDisabled}
+        name={name}
+        onChange={handleDateChange}
+        value={dateValue ?? undefined}
+      />
+      <TimePicker
+        ref={timePickerRef}
+        isDisabled={isDisabled}
+        name={name}
+        onChange={handleTimeChange}
+        value={timeValue ?? undefined}
+      />
+    </HStack>
+  );
+};
+
+export default DateTimePicker;

--- a/frontend/src/components/common/form/TimePicker.tsx
+++ b/frontend/src/components/common/form/TimePicker.tsx
@@ -1,0 +1,216 @@
+import type { ForwardedRef, ReactElement } from "react";
+import React, { forwardRef, useRef } from "react";
+import { Box, Input, useMergeRefs } from "@chakra-ui/react";
+import type { ChakraStylesConfig, SelectInstance } from "chakra-react-select";
+
+import type { StringOption } from "../../../types/SelectInputTypes";
+
+import Select from "./Select";
+
+const MINUTE_OPTIONS: StringOption[] = [...Array(60).fill(null)].map(
+  (_, num) => ({
+    label: num.toString().padStart(2, "0"),
+    value: num.toString(),
+  }),
+);
+
+const HOUR_OPTIONS: StringOption[] = [...Array(24).fill(null)].map(
+  (_, num) => ({
+    label: num.toString().padStart(2, "0"),
+    value: num.toString(),
+  }),
+);
+
+const chakraStyles = (
+  align: "left" | "right",
+): ChakraStylesConfig<StringOption> => ({
+  control: (provided) => ({
+    ...provided,
+    background: "unset",
+    _hover: {
+      background: "unset",
+    },
+    _focusVisible: {
+      outline: "none",
+    },
+    border: "none",
+  }),
+  valueContainer: (provided) => ({
+    ...provided,
+    p: 0,
+    justifyContent: align === "left" ? "flex-start" : "flex-end",
+    _focusWithin: {
+      color: "rgba(255, 255, 255, 0.7)",
+    },
+    minW: "calc(2em)",
+  }),
+  inputContainer: (provided) => ({
+    ...provided,
+    p: "0.125rem",
+    m: 0,
+    borderRadius: 3,
+    _focusWithin: {
+      bg: "blue.500",
+    },
+    justifyContent: align === "left" ? "flex-start" : "flex-end",
+  }),
+  input: (provided) => ({
+    ...provided,
+    caretColor: "white",
+    color: "white",
+    textAlign: align,
+    cursor: "inherit",
+  }),
+  placeholder: (provided) => ({
+    ...provided,
+  }),
+  indicatorsContainer: (provided) => ({
+    ...provided,
+    display: "none",
+  }),
+  downChevron: (provided) => ({
+    ...provided,
+    display: "none",
+  }),
+  container: (provided) => ({
+    ...provided,
+    flex: 1,
+  }),
+  menu: (provided) => ({
+    ...provided,
+    w: 200,
+  }),
+});
+
+type TimePickerProps = {
+  name?: string;
+  value: Date | null | undefined;
+  defaultDay?: Date;
+  onChange: (date: Date) => void;
+  isDisabled?: boolean;
+  attachmentDirection?: "left" | "right";
+};
+
+const TimePicker = forwardRef(function TimePicker(
+  {
+    name,
+    value,
+    defaultDay,
+    onChange,
+    isDisabled,
+    attachmentDirection,
+  }: TimePickerProps,
+  ref: ForwardedRef<HTMLDivElement>,
+): ReactElement {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const mergedWrapperRef = useMergeRefs(wrapperRef, ref);
+  const hourInputRef = useRef<SelectInstance<StringOption>>(null);
+  const minuteInputRef = useRef<SelectInstance<StringOption>>(null);
+  const elementRef = useRef<HTMLButtonElement>(null);
+  const valueHours = value instanceof Date ? value.getHours() : null;
+  const valueMinutes = value instanceof Date ? value.getMinutes() : null;
+
+  return (
+    <Box>
+      <Input
+        ref={mergedWrapperRef}
+        _focusWithin={{
+          bg: "transparent",
+          borderColor: "blue.500",
+        }}
+        _invalid={{
+          borderLeftWidth: attachmentDirection === "left" ? 0 : undefined,
+          borderRightWidth: attachmentDirection === "right" ? 0 : undefined,
+          borderColor: "red.200",
+        }}
+        as="div"
+        borderLeftRadius={attachmentDirection === "left" ? 0 : undefined}
+        borderRightRadius={attachmentDirection === "right" ? 0 : undefined}
+        cursor="pointer"
+        isDisabled={isDisabled}
+        onClick={(e) => {
+          if (e.target === wrapperRef.current) {
+            hourInputRef.current?.focus();
+          }
+        }}
+        role="group"
+      >
+        <Box
+          _focusWithin={{
+            cursor: "text",
+          }}
+          alignItems="center"
+          display="inline-flex"
+          flexDir="row"
+          w="100%"
+        >
+          <Select<StringOption>
+            ref={hourInputRef}
+            chakraStyles={chakraStyles("right")}
+            isDisabled={isDisabled}
+            name={`${name}-hour`}
+            onChange={(option) => {
+              const hours = parseInt(option ?? "0", 10);
+              if (hours == valueHours) {
+                return;
+              }
+
+              const newValue = new Date(value ?? defaultDay ?? new Date());
+              newValue.setHours(hours);
+              newValue.setMinutes(valueMinutes ?? 0);
+              newValue.setSeconds(0);
+              newValue.setMilliseconds(0);
+              onChange(newValue);
+              minuteInputRef.current?.focus();
+            }}
+            onFocus={() => {
+              hourInputRef.current?.openMenu("first");
+            }}
+            options={HOUR_OPTIONS}
+            placeholder="00"
+            value={valueHours?.toString()}
+          />
+          <Box cursor="inherit" userSelect="none">
+            :
+          </Box>
+          <Select<StringOption>
+            ref={minuteInputRef}
+            chakraStyles={chakraStyles("left")}
+            isDisabled={isDisabled}
+            name={`${name}-minute`}
+            onChange={(option) => {
+              const minutes = parseInt(option ?? "0", 10);
+              if (minutes == valueMinutes) {
+                return;
+              }
+
+              const newValue = new Date(value ?? defaultDay ?? new Date());
+              newValue.setHours(valueHours ?? 0);
+              newValue.setMinutes(minutes);
+              newValue.setSeconds(0);
+              newValue.setMilliseconds(0);
+              onChange(newValue);
+              elementRef.current?.focus();
+            }}
+            onFocus={() => {
+              minuteInputRef.current?.openMenu("first");
+            }}
+            options={MINUTE_OPTIONS}
+            placeholder="00"
+            value={valueMinutes?.toString()}
+          />
+          <button
+            ref={elementRef}
+            aria-label="Open time input"
+            onClick={() => {
+              hourInputRef.current?.focus();
+            }}
+            tabIndex={-1}
+          />
+        </Box>
+      </Input>
+    </Box>
+  );
+});
+
+export default TimePicker;

--- a/frontend/src/components/common/form/TimePicker.tsx
+++ b/frontend/src/components/common/form/TimePicker.tsx
@@ -88,18 +88,10 @@ type TimePickerProps = {
   defaultDay?: Date;
   onChange: (date: Date) => void;
   isDisabled?: boolean;
-  attachmentDirection?: "left" | "right";
 };
 
 const TimePicker = forwardRef(function TimePicker(
-  {
-    name,
-    value,
-    defaultDay,
-    onChange,
-    isDisabled,
-    attachmentDirection,
-  }: TimePickerProps,
+  { name, value, defaultDay, onChange, isDisabled }: TimePickerProps,
   ref: ForwardedRef<HTMLDivElement>,
 ): ReactElement {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -119,13 +111,9 @@ const TimePicker = forwardRef(function TimePicker(
           borderColor: "blue.500",
         }}
         _invalid={{
-          borderLeftWidth: attachmentDirection === "left" ? 0 : undefined,
-          borderRightWidth: attachmentDirection === "right" ? 0 : undefined,
           borderColor: "red.200",
         }}
         as="div"
-        borderLeftRadius={attachmentDirection === "left" ? 0 : undefined}
-        borderRightRadius={attachmentDirection === "right" ? 0 : undefined}
         cursor="pointer"
         isDisabled={isDisabled}
         onClick={(e) => {

--- a/frontend/src/components/common/form/TimePicker.tsx
+++ b/frontend/src/components/common/form/TimePicker.tsx
@@ -152,7 +152,13 @@ const TimePicker = forwardRef(function TimePicker(
               minuteInputRef.current?.focus();
             }}
             onFocus={() => {
-              hourInputRef.current?.openMenu("first");
+              setTimeout(() => {
+                // For use with a date picker, our date picker will focus itself
+                // when it starts to close. This means that we might need to re-
+                // focus the hour input afterwards.
+                hourInputRef.current?.focus();
+                hourInputRef.current?.openMenu("first");
+              });
             }}
             options={HOUR_OPTIONS}
             placeholder="00"

--- a/frontend/src/components/common/form/TimePicker.tsx
+++ b/frontend/src/components/common/form/TimePicker.tsx
@@ -78,7 +78,7 @@ const chakraStyles = (
   }),
   menu: (provided) => ({
     ...provided,
-    w: 200,
+    w: 105,
   }),
 });
 

--- a/frontend/src/components/pages/ComponentLibrary.tsx
+++ b/frontend/src/components/pages/ComponentLibrary.tsx
@@ -9,6 +9,7 @@ import { QuestionElementType } from "../../types/QuestionTypes";
 import MultipleChoiceVisualizer from "../admin/assessment-visualization/question-elements/MultipleChoiceVisualizer";
 import MultiSelectVisualizer from "../admin/assessment-visualization/question-elements/MultiSelectVisualizer";
 import ShortAnswerVisualizer from "../admin/assessment-visualization/question-elements/ShortAnswerVisualizer";
+import TimePicker from "../common/form/TimePicker";
 import MultiOptionInput from "../common/question-elements/multi-option/MultiOptionInput";
 import ChartSection from "../data-visualization/ChartSection";
 import StatisticCard from "../data-visualization/StatisticCard";
@@ -116,8 +117,16 @@ const ComponentLibrary = (): React.ReactElement => {
   const [selectedStudentId, setSelectedStudentId] = useState<string>(
     MOCK_STUDENTS[0].id,
   );
+  const [selectedTime, setSelectedTime] = useState<Date>(new Date());
   return (
     <FormProvider {...methods}>
+      <Box w={300}>
+        <TimePicker
+          name="time-picker"
+          onChange={setSelectedTime}
+          value={selectedTime}
+        />
+      </Box>
       <CorrectedShortAnswer correctAnswer={1024} studentAnswer={1024} />
       <CorrectedShortAnswer correctAnswer={1024} studentAnswer={1023} />
       <CorrectedShortAnswer correctAnswer={1024} studentAnswer={undefined} />

--- a/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
+++ b/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
@@ -28,7 +28,7 @@ const DistributeAssessmentPage = (): React.ReactElement => {
   const { id: teacherId, school: schoolId } =
     (authenticatedUser as AuthenticatedTeacher) ?? {};
 
-  const [page, setPage] = useState(state?.endDate !== undefined ? 3 : 0);
+  const [page, setPage] = useState(state?.endDate !== undefined ? 3 : 2);
 
   const [testId, setTestId] = useState(state?.testId ?? "");
   const [testName, setTestName] = useState(state?.testName ?? "");

--- a/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
+++ b/frontend/src/components/pages/teacher/DistributeAssessmentPage.tsx
@@ -28,7 +28,7 @@ const DistributeAssessmentPage = (): React.ReactElement => {
   const { id: teacherId, school: schoolId } =
     (authenticatedUser as AuthenticatedTeacher) ?? {};
 
-  const [page, setPage] = useState(state?.endDate !== undefined ? 3 : 2);
+  const [page, setPage] = useState(state?.endDate !== undefined ? 3 : 0);
 
   const [testId, setTestId] = useState(state?.testId ?? "");
   const [testName, setTestName] = useState(state?.testName ?? "");

--- a/frontend/src/components/teacher/session-creation/steps/Review.tsx
+++ b/frontend/src/components/teacher/session-creation/steps/Review.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { HStack, Input, Text, Textarea, VStack } from "@chakra-ui/react";
 
-import { formatDate } from "../../../../utils/GeneralUtils";
+import { formatDateTime } from "../../../../utils/GeneralUtils";
 import DistributeAssessmentWrapper from "../DistributeAssessmentWrapper";
 import ReviewItem from "../ReviewItem";
 
@@ -50,7 +50,7 @@ const Review = ({
             value={
               <Input
                 isDisabled
-                value={startDate ? formatDate(startDate) : ""}
+                value={startDate ? formatDateTime(startDate) : ""}
                 width={80}
               />
             }
@@ -61,7 +61,7 @@ const Review = ({
             value={
               <Input
                 isDisabled
-                value={endDate ? formatDate(endDate) : ""}
+                value={endDate ? formatDateTime(endDate) : ""}
                 width={80}
               />
             }

--- a/frontend/src/utils/DateUtils.ts
+++ b/frontend/src/utils/DateUtils.ts
@@ -1,0 +1,7 @@
+import addDays from "date-fns/addDays";
+import addHours from "date-fns/addHours";
+import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
+
+export const getEarliestValidDate = (now: Date): Date => addHours(now, 1);
+export const combineDateAndTime = (date: Date, time: Date): Date =>
+  addDays(time, differenceInCalendarDays(date, time));

--- a/frontend/src/utils/GeneralUtils.ts
+++ b/frontend/src/utils/GeneralUtils.ts
@@ -1,4 +1,3 @@
-import { isSameDay } from "date-fns";
 import type { DocumentNode } from "graphql";
 import { getOperationAST } from "graphql";
 
@@ -80,11 +79,6 @@ export const stringToFloat = (input: string): number | undefined => {
 export const stringToInt = (input: string): number | undefined => {
   const value = parseInt(input);
   return Number.isNaN(value) ? undefined : value;
-};
-
-export const isPastDate = (input: Date) => {
-  const now = new Date();
-  return input < now && !isSameDay(input, now);
 };
 
 export const getLetterFromNumber = (number: number): string => {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add start / end time in test session](https://www.notion.so/uwblueprintexecs/Add-start-end-time-in-test-session-b09c7292d57c43a0a9fd271a82f5dd02)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
times! Add times to assessment date pickers. Classroom picker to follow.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a new assessment (as a teacher) and set a time.
2. Edit an assessment and view/set the time.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
