### PR TITLE
fix: remove "[COPY]" from unarchived test + no draft archival

### DIFF
--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -129,7 +129,7 @@ describe("mongo testService", (): void => {
     const unarchivedTest = await testService.unarchiveTest(test.id);
     assertResponseMatchesExpected(mockTestWithId, unarchivedTest, true);
     expect(test.id).not.toEqual(unarchivedTest.id);
-    expect(`${test.name} [COPY]`).toEqual(unarchivedTest.name);
+    expect(test.name).toEqual(unarchivedTest.name);
 
     const originalTest = await MgTest.findById(test.id);
     expect(originalTest?.status).toBe(AssessmentStatus.DELETED);

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -137,6 +137,7 @@ describe("mongo testService", (): void => {
 
   it("archiveTest", async () => {
     const test = await MgTest.create(mockTestWithId);
+    await testService.publishTest(test.id);
 
     const archivedTest = await testService.archiveTest(test.id);
     assertResponseMatchesExpected(mockArchivedTest, archivedTest);
@@ -188,7 +189,7 @@ describe("mongo testService", (): void => {
       await expect(async () => {
         await testService.archiveTest(notFoundId);
       }).rejects.toThrowError(
-        `Test with ID ${notFoundId} is not found or not in draft / published status`,
+        `Test with ID ${notFoundId} is not found or not in published status`,
       );
     });
   });
@@ -219,7 +220,7 @@ describe("mongo testService", (): void => {
       await expect(async () => {
         await testService.archiveTest(test.id);
       }).rejects.toThrowError(
-        `Test with ID ${test.id} is not found or not in draft / published status`,
+        `Test with ID ${test.id} is not found or not in published status`,
       );
     });
   });

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -127,6 +127,10 @@ class TestService implements ITestService {
         throw new Error(`Test ID ${id} not found`);
       }
 
+      if (oldTest.status !== AssessmentStatus.DRAFT) {
+        throw new Error(`Test with ID ${id} cannot be edited`);
+      }
+
       // Delete all images that are not in the new test
       const oldImages = oldTest.questions
         .flat()

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -336,7 +336,7 @@ class TestService implements ITestService {
       test = await MgTest.findOneAndUpdate(
         {
           _id: id,
-          status: { $in: [AssessmentStatus.DRAFT, AssessmentStatus.PUBLISHED] },
+          status: AssessmentStatus.PUBLISHED,
         },
         {
           $set: {
@@ -351,7 +351,7 @@ class TestService implements ITestService {
 
       if (!test) {
         throw new Error(
-          `Test with ID ${id} is not found or not in draft / published status`,
+          `Test with ID ${id} is not found or not in published status`,
         );
       }
     } catch (error: unknown) {

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -296,6 +296,10 @@ class TestService implements ITestService {
       if (test.status !== AssessmentStatus.ARCHIVED) {
         throw new Error(`Test with ID ${id} is not in archived status`);
       }
+
+      // We have to duplicate the test and soft-delete the archived one
+      // rather than just updating the status because old test sessions
+      // will still refer to the archived test in their session results
       unarchivedTest = await this.duplicateTest(id, false);
 
       try {

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -258,7 +258,7 @@ class TestService implements ITestService {
     return (await this.mapTestsToTestResponseDTOs([test]))[0];
   }
 
-  async duplicateTest(id: string): Promise<TestResponseDTO> {
+  async duplicateTest(id: string, renameTest = true): Promise<TestResponseDTO> {
     let test: Test | null;
 
     try {
@@ -268,7 +268,9 @@ class TestService implements ITestService {
       }
       // eslint-disable-next-line no-underscore-dangle
       test._id = new mongoose.Types.ObjectId();
-      test.name += " [COPY]";
+      if (renameTest) {
+        test.name += " [COPY]";
+      }
       test.isNew = true;
       test.status = AssessmentStatus.DRAFT;
       test.save();
@@ -294,7 +296,7 @@ class TestService implements ITestService {
       if (test.status !== AssessmentStatus.ARCHIVED) {
         throw new Error(`Test with ID ${id} is not in archived status`);
       }
-      unarchivedTest = await this.duplicateTest(id);
+      unarchivedTest = await this.duplicateTest(id, false);
 
       try {
         await this.deleteTest(id);

--- a/backend/services/interfaces/testService.ts
+++ b/backend/services/interfaces/testService.ts
@@ -103,7 +103,7 @@ export interface ITestService {
    * @returns a TestResponseDTO with the duplicated test
    * @throws Error if Test with given id not found
    */
-  duplicateTest(id: string): Promise<TestResponseDTO>;
+  duplicateTest(id: string, renameTest?: boolean): Promise<TestResponseDTO>;
 
   /**
    * unarchive a Test given the id

--- a/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
+++ b/frontend/src/components/admin/assessment-creation/AssessmentEditorHeader.tsx
@@ -26,7 +26,6 @@ import useActionFormHandler from "../../common/modal/useActionFormHandler";
 import BackButton from "../../common/navigation/BackButton";
 import Popover from "../../common/popover/Popover";
 import PopoverButton from "../../common/popover/PopoverButton";
-import ArchiveAssessmentModal from "../assessment-status/EditStatusModals/ArchiveAssessmentModal";
 import DeleteAssessmentModal from "../assessment-status/EditStatusModals/DeleteAssessmentModal";
 import PublishAssessmentModal from "../assessment-status/EditStatusModals/PublishAssessmentModal";
 
@@ -45,7 +44,6 @@ interface AssessmentEditorHeaderProps {
 const AssessmentEditorHeader = ({
   name,
   isEditing,
-  onConfirmArchive,
   onConfirmPublish,
   onDelete,
   onSave,
@@ -66,11 +64,6 @@ const AssessmentEditorHeader = ({
     onOpen: onDeleteModalOpen,
     isOpen: isDeleteModalOpen,
     onClose: onDeleteModalClose,
-  } = useDisclosure();
-  const {
-    onOpen: onArchiveModalOpen,
-    isOpen: isArchiveModalOpen,
-    onClose: onArchiveModalClose,
   } = useDisclosure();
 
   const onPreview = () => {
@@ -96,7 +89,6 @@ const AssessmentEditorHeader = ({
 
   // We don't need validation on these actions.
   const handleConfirmPublish = async () => onConfirmPublish(getValues());
-  const handleConfirmArchive = async () => onConfirmArchive(getValues());
   const handleDelete = async () => onDelete(getValues());
 
   return (
@@ -155,7 +147,6 @@ const AssessmentEditorHeader = ({
             {isEditing && (
               <Popover>
                 <VStack divider={<Divider />} spacing="0em">
-                  <PopoverButton name="Archive" onClick={onArchiveModalOpen} />
                   <PopoverButton name="Delete" onClick={onDeleteModalOpen} />
                 </VStack>
               </Popover>
@@ -167,11 +158,6 @@ const AssessmentEditorHeader = ({
         isOpen={isPublishModalOpen}
         onClose={onPublishModalClose}
         publishAssessment={handleConfirmPublish}
-      />
-      <ArchiveAssessmentModal
-        archiveAssessment={handleConfirmArchive}
-        isOpen={isArchiveModalOpen}
-        onClose={onArchiveModalClose}
       />
       <DeleteAssessmentModal
         deleteAssessment={handleDelete}

--- a/frontend/src/components/admin/assessment-status/EditStatusPopover.tsx
+++ b/frontend/src/components/admin/assessment-status/EditStatusPopover.tsx
@@ -33,8 +33,12 @@ const EditStatusPopover = ({
         <UnarchiveButton assessmentId={assessmentId} />
       ) : (
         <>
-          <ArchiveButton assessmentId={assessmentId} />
-          <Divider />
+          {assessmentStatus === Status.PUBLISHED && (
+            <>
+              <ArchiveButton assessmentId={assessmentId} />
+              <Divider />
+            </>
+          )}
           <DuplicateButton assessmentId={assessmentId} />
         </>
       )}

--- a/frontend/src/components/pages/admin/AssessmentEditorPage/index.tsx
+++ b/frontend/src/components/pages/admin/AssessmentEditorPage/index.tsx
@@ -5,7 +5,10 @@ import { Box } from "@chakra-ui/react";
 
 import { GET_TEST } from "../../../../APIClients/queries/TestQueries";
 import type { TestResponse } from "../../../../APIClients/types/TestClientTypes";
+import * as Routes from "../../../../constants/Routes";
+import { Status } from "../../../../types/AssessmentTypes";
 import { formatQuestionsResponse } from "../../../../utils/QuestionUtils";
+import RedirectTo from "../../../auth/RedirectTo";
 import QueryStateHandler from "../../../common/QueryStateHandler";
 
 import AssessmentEditor from "./AssessmentEditor";
@@ -36,6 +39,14 @@ const AssessmentEditorPage = () => {
       },
     [test],
   );
+
+  if (!!state?.status && state.status !== Status.DRAFT) {
+    return (
+      <RedirectTo
+        pathname={Routes.ASSESSMENT_EDITOR_PREVIEW_PAGE({ assessmentId })}
+      />
+    );
+  }
 
   return (
     <Box mx={4}>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix logic around test archiving](https://www.notion.so/uwblueprintexecs/Fix-logic-around-test-archiving-fd55e9a3e2894fd481be0f25d4cb2eb7)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
[NOTE: this has to get rebased on Joyce's PR before it will work properly.]

Two things:
 - Don't append "[COPY]" to the name of unarchived tests
 - Remove the ability to archive drafts, since that doesn't make any sense (as discussed on Slack)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Unarchive a test and verify the name is unchanged.
2. Find a draft assessment in the table and verify there is no "archive" option.
3. Open a draft assessment for editing and verify there is no "archive" option.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Any cases I missed?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
