### PR TITLE
feat: add logic for image reference counting

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -3,6 +3,8 @@
  * https://jestjs.io/docs/configuration
  */
 
+import { MOCK_FIREBASE_STORAGE_DEFAULT_BUCKET } from "./testUtils/imageUpload";
+
 export default {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
@@ -204,3 +206,7 @@ export default {
   // Increases timeout to let tests run
   testTimeout: 1000000,
 };
+
+process.env = Object.assign(process.env, {
+  FIREBASE_STORAGE_DEFAULT_BUCKET: MOCK_FIREBASE_STORAGE_DEFAULT_BUCKET,
+});

--- a/backend/models/imageCount.model.ts
+++ b/backend/models/imageCount.model.ts
@@ -1,0 +1,27 @@
+import type { Document } from "mongoose";
+import mongoose, { Schema } from "mongoose";
+
+/**
+ * This document contains information about a single image.
+ */
+export interface ImageCount extends Document {
+  /** the unique identifier for the image */
+  id: string;
+  /** the unique file path of the image */
+  filePath: string;
+  /** the number of tests that reference this image */
+  referenceCount: number;
+}
+
+const ImageCountSchema: Schema = new Schema({
+  filePath: {
+    type: String,
+    required: true,
+  },
+  referenceCount: {
+    type: Number,
+    required: true,
+  },
+});
+
+export default mongoose.model<ImageCount>("ImageCount", ImageCountSchema);

--- a/backend/services/implementations/__tests__/imageCountService.test.ts
+++ b/backend/services/implementations/__tests__/imageCountService.test.ts
@@ -1,0 +1,43 @@
+import db from "../../../testUtils/testDb";
+import ImageCountService from "../imageCountService";
+
+describe("mongo imageCountService", (): void => {
+  let imageCountService: ImageCountService;
+
+  beforeAll(async () => {
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  beforeEach(async () => {
+    imageCountService = new ImageCountService();
+  });
+
+  afterEach(async () => {
+    await db.clear();
+  });
+
+  it("initialize count", async () => {
+    const referenceCount = await imageCountService.initializeCount("test path");
+    expect(referenceCount).toEqual(1);
+  });
+
+  it("increment count", async () => {
+    await imageCountService.initializeCount("test path");
+    const referenceCount = await imageCountService.incrementCount("test path");
+    expect(referenceCount).toEqual(2);
+  });
+
+  it("decrement count", async () => {
+    await imageCountService.initializeCount("test path");
+    const referenceCount = await imageCountService.decrementCount("test path");
+    expect(referenceCount).toEqual(0);
+
+    await expect(async () => {
+      await imageCountService.decrementCount("test path");
+    }).rejects.toThrowError(`Image test path not found`);
+  });
+});

--- a/backend/services/implementations/__tests__/imageUploadService.test.ts
+++ b/backend/services/implementations/__tests__/imageUploadService.test.ts
@@ -97,7 +97,7 @@ describe("mongo imageUploadService", (): void => {
     });
     expect(referenceCount?.referenceCount).toEqual(1);
 
-    // delete same image and check that the reference count is 0
+    // delete same image and check that the image is deleted
     res = await imageUploadService.deleteImage(uploadedImage);
     assertResponseMatchesExpected(res);
     referenceCount = await MgImageCount.findOne({

--- a/backend/services/implementations/__tests__/testService.test.ts
+++ b/backend/services/implementations/__tests__/testService.test.ts
@@ -38,6 +38,9 @@ describe("mongo testService", (): void => {
     testService.imageUploadService.uploadImage = jest
       .fn()
       .mockReturnValue(imageMetadata);
+    testService.imageUploadService.incrementImageCount = jest
+      .fn()
+      .mockReturnValue(imageMetadata);
     testService.imageUploadService.getImage = jest
       .fn()
       .mockReturnValue(imageMetadata);
@@ -117,6 +120,13 @@ describe("mongo testService", (): void => {
     expect(test.id).not.toEqual(duplicateTest.id);
     expect(`${test.name} [COPY]`).toEqual(duplicateTest.name);
 
+    expect(
+      testService.imageUploadService.incrementImageCount,
+    ).toHaveBeenCalledWith(imageMetadata);
+    expect(
+      testService.imageUploadService.incrementImageCount,
+    ).toHaveBeenCalledTimes(1);
+
     const originalTest = await testService.getTestById(test.id);
     assertResponseMatchesExpected(mockPublishedTest, originalTest);
     expect(test.id).toEqual(originalTest.id);
@@ -130,6 +140,13 @@ describe("mongo testService", (): void => {
     assertResponseMatchesExpected(mockTestWithId, unarchivedTest, true);
     expect(test.id).not.toEqual(unarchivedTest.id);
     expect(`${test.name} [COPY]`).toEqual(unarchivedTest.name);
+
+    expect(
+      testService.imageUploadService.incrementImageCount,
+    ).toHaveBeenCalledWith(imageMetadata);
+    expect(
+      testService.imageUploadService.incrementImageCount,
+    ).toHaveBeenCalledTimes(1);
 
     const originalTest = await MgTest.findById(test.id);
     expect(originalTest?.status).toBe(AssessmentStatus.DELETED);

--- a/backend/services/implementations/imageCountService.ts
+++ b/backend/services/implementations/imageCountService.ts
@@ -1,0 +1,70 @@
+import MgImage from "../../models/imageCount.model";
+import { getErrorMessage } from "../../utilities/errorUtils";
+import logger from "../../utilities/logger";
+import type IImageCountService from "../interfaces/imageCountService";
+
+const Logger = logger(__filename);
+
+class ImageCountService implements IImageCountService {
+  /* eslint-disable class-methods-use-this */
+  async initializeCount(filePath: string): Promise<number> {
+    try {
+      const image = new MgImage({
+        filePath,
+        referenceCount: 1,
+      });
+      await image.save();
+      return image.referenceCount;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to increment count. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async incrementCount(filePath: string): Promise<number> {
+    try {
+      const image = await MgImage.findOneAndUpdate(
+        { filePath },
+        { $inc: { referenceCount: 1 } },
+        { new: true },
+      );
+      if (!image) {
+        throw new Error(`Image ${filePath} not found`);
+      }
+      return image.referenceCount;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to increment count. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  async decrementCount(filePath: string): Promise<number> {
+    try {
+      const image = await MgImage.findOneAndUpdate(
+        { filePath, referenceCount: { $gt: 0 } },
+        { $inc: { referenceCount: -1 } },
+        { new: true },
+      );
+      if (!image) {
+        throw new Error(`Image ${filePath} not found`);
+      }
+
+      if (image.referenceCount === 0) {
+        await MgImage.deleteOne({ filePath });
+      }
+
+      return image.referenceCount;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to decrement count. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default ImageCountService;

--- a/backend/services/implementations/testService.ts
+++ b/backend/services/implementations/testService.ts
@@ -271,14 +271,15 @@ class TestService implements ITestService {
       if (!test) {
         throw new Error(`Test ID ${id} not found`);
       }
+
+      await this.incrementImageCounts(test.questions);
+
       // eslint-disable-next-line no-underscore-dangle
       test._id = new mongoose.Types.ObjectId();
       test.name += " [COPY]";
       test.isNew = true;
       test.status = AssessmentStatus.DRAFT;
-      test.save();
-
-      await this.incrementImageCounts(test.questions);
+      await test.save();
     } catch (error: unknown) {
       Logger.error(
         `Failed to duplicate test with ID ${id}. Reason = ${getErrorMessage(

--- a/backend/services/interfaces/imageCountService.ts
+++ b/backend/services/interfaces/imageCountService.ts
@@ -1,0 +1,24 @@
+interface IImageCountService {
+  /**
+   * Initializes the reference count of an image
+   * @param filePath file path of the image
+   * @returns a reference count
+   */
+  initializeCount(filePath: string): Promise<number>;
+
+  /**
+   * Increments the reference count of an image
+   * @param filePath file path of the image
+   * @returns a reference count
+   */
+  incrementCount(filePath: string): Promise<number>;
+
+  /**
+   * Decrements the reference count of an image
+   * @param filePath file path of the image
+   * @returns a reference count
+   */
+  decrementCount(filePath: string): Promise<number>;
+}
+
+export default IImageCountService;

--- a/backend/services/interfaces/imageUploadService.ts
+++ b/backend/services/interfaces/imageUploadService.ts
@@ -12,6 +12,13 @@ interface IImageUploadService {
   uploadImage(image: ImageMetadataRequest): Promise<ImageMetadata>;
 
   /**
+   * Increment the reference count of an image
+   * @param image the image to increment
+   * @returns a url and file path for the requested image
+   */
+  incrementImageCount(image: ImageMetadata): Promise<ImageMetadata>;
+
+  /**
    * Get an image stored in Firebase
    * @param file the file path to get
    * @returns a url and file path for the requested image

--- a/backend/testUtils/imageUpload.ts
+++ b/backend/testUtils/imageUpload.ts
@@ -7,9 +7,10 @@ import type {
   ImageMetadataRequest,
 } from "../types/questionMetadataTypes";
 
+export const MOCK_FIREBASE_STORAGE_DEFAULT_BUCKET = "test-url";
 export const filename = "test.png";
 export const uploadDir = "test-bucket";
-export const signedUrl = `https://storage.googleapis.com/jump-math-98edf.appspot.com/${uploadDir}/${filename}`;
+export const signedUrl = `https://storage.googleapis.com/${MOCK_FIREBASE_STORAGE_DEFAULT_BUCKET}/${uploadDir}/${filename}`;
 export const invalidImageType = "text/plain";
 
 const createReadStream = (): ReadStream =>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add Reference Counting to Images](https://www.notion.so/uwblueprintexecs/Add-Reference-Counting-to-Images-b20aa3d9a1694844945e4de8180f23b3?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add `ImageCount` model, interface, implementation, and unit tests
* Update ImageUploadService
   * Initialize count on image creation 
   * Decrement count on delete, and delete image only if count is 0
   * Add `incrementImageCount` function for test service
   * Increment count on upload of existing image (i.e. filePath exists)
* Update TestService
   * Increment image count on duplicate test

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a test with an image. Check that the reference count is 1 and the image is uploaded to GCP.
   <img width="612" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/70693134-75d8-4c79-9278-c6b9212a7b12">

2. Duplicate a test. Check that the reference count is 2. Check that the same image is still in GCP and there is no new upload.
   <img width="619" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/467832bf-1e48-4a4d-b009-46165f717310">

3. Delete the duplicate test. Check that the reference count is 1. Check that the same image is still in GCP.
   <img width="612" alt="image" src="https://github.com/uwblueprint/jump-math/assets/69697180/24df2407-0a14-4403-9f31-8bcab0d0b3e6">

4. Delete the original test. Check that the record is deleted from the DB. Check that the image is deleted from GCP.



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
