### PR TITLE
Add classroom timepicker

### DIFF
--- a/frontend/src/components/common/form/ControlledDateTimePicker.tsx
+++ b/frontend/src/components/common/form/ControlledDateTimePicker.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import React from "react";
 import { Controller } from "react-hook-form";
 
-import DatePicker from "./DatePicker";
+import DateTimePicker from "./DateTimePicker";
 
 type ControlledDatePickerProps = {
   name?: string;
@@ -11,7 +11,7 @@ type ControlledDatePickerProps = {
   additionalRules?: Record<string, unknown>;
 };
 
-const ControlledDatePicker = ({
+const ControlledDateTimePicker = ({
   name: fieldName,
   isDisabled,
   isRequired,
@@ -21,7 +21,7 @@ const ControlledDatePicker = ({
     <Controller
       name={fieldName || "date-input"}
       render={({ field: { onChange, onBlur, value, name } }) => (
-        <DatePicker
+        <DateTimePicker
           isDisabled={isDisabled}
           name={name}
           onChange={(date) => {
@@ -45,4 +45,4 @@ const ControlledDatePicker = ({
   );
 };
 
-export default ControlledDatePicker;
+export default ControlledDateTimePicker;

--- a/frontend/src/components/common/form/DatePicker.tsx
+++ b/frontend/src/components/common/form/DatePicker.tsx
@@ -69,7 +69,7 @@ const getDatePickerStyles = (
     cursor: "pointer",
     "aria-label": "This is a date input, activate to open date picker",
     textAlign: "left",
-    value: value ? format(value, "yyyy-MM-dd") : "Please choose a date",
+    value: value ? format(value, "yyyy-MM-dd") : "Choose a date",
     color: value ? "grey.300" : "placeholder.300",
     transition: "color 0s",
   },

--- a/frontend/src/components/common/form/TimePicker.tsx
+++ b/frontend/src/components/common/form/TimePicker.tsx
@@ -34,6 +34,9 @@ const chakraStyles = (
       outline: "none",
     },
     border: "none",
+    _disabled: {
+      opacity: 1,
+    },
   }),
   valueContainer: (provided) => ({
     ...provided,

--- a/frontend/src/components/teacher/session-creation/steps/AddInformation.tsx
+++ b/frontend/src/components/teacher/session-creation/steps/AddInformation.tsx
@@ -75,7 +75,7 @@ const AddInformation = ({
       >
         <HStack alignItems="flex-start" gap="15" pt="4">
           <FormControl isInvalid={!!invalidStartDate} isRequired>
-            <FormLabel color="blue.300">Start date</FormLabel>
+            <FormLabel color="blue.300">Start Date</FormLabel>
             <DateTimePicker
               isDisabled={isEditDisabled}
               name="startDate"
@@ -92,7 +92,7 @@ const AddInformation = ({
         </HStack>
         <HStack alignItems="flex-start" gap="15" pt="4">
           <FormControl isInvalid={!!invalidEndDate} isRequired>
-            <FormLabel color="blue.300">End date</FormLabel>
+            <FormLabel color="blue.300">End Date</FormLabel>
             <DateTimePicker
               name="endDate"
               onChange={(newDate: Date | null) => {

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -107,7 +107,7 @@ const AddOrEditClassroomModal = ({
         submitButtonText="Save"
         variant="large"
       >
-        <HStack direction="row" mt={6}>
+        <HStack direction="row" mt={6} spacing={8}>
           <VStack align="left" direction="column" width="320px">
             <FormControl isInvalid={!!errors.className} isRequired>
               <FormLabel color="blue.300">Class Name</FormLabel>

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -112,7 +112,7 @@ const AddOrEditClassroomModal = ({
             <FormControl isInvalid={!!errors.className} isRequired>
               <FormLabel color="blue.300">Class Name</FormLabel>
               <Input
-                placeholder="Type in Class Name"
+                placeholder="Type in class name"
                 type="text"
                 {...register("className", {
                   required: { value: true, message: "This field is required." },
@@ -160,7 +160,7 @@ const AddOrEditClassroomModal = ({
                 isRequired
                 name="gradeLevel"
                 options={gradeOptions}
-                placeholder="Choose a Grade Level"
+                placeholder="Choose a grade level"
               />
               <InlineFormError error={errors.gradeLevel} />
             </FormControl>

--- a/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
+++ b/frontend/src/components/teacher/student-management/classroom-summary/AddOrEditClassroomModal.tsx
@@ -26,7 +26,7 @@ import {
   FormValidationError,
   getQueryName,
 } from "../../../../utils/GeneralUtils";
-import ControlledDatePicker from "../../../common/form/ControlledDatePicker";
+import ControlledDateTimePicker from "../../../common/form/ControlledDateTimePicker";
 import ControlledSelect from "../../../common/form/ControlledSelect";
 import InlineFormError from "../../../common/form/InlineFormError";
 import Modal from "../../../common/modal/Modal";
@@ -127,7 +127,7 @@ const AddOrEditClassroomModal = ({
           <VStack align="left" direction="column" width="320px">
             <FormControl isInvalid={!!errors.startDate} isRequired>
               <FormLabel color="blue.300">Start Date</FormLabel>
-              <ControlledDatePicker
+              <ControlledDateTimePicker
                 additionalRules={
                   isEditing
                     ? {}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add start / end time in classrooms](https://www.notion.so/uwblueprintexecs/Add-start-end-time-in-classrooms-dfa987cf06384dcd8cdc28333270bd36)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Update the date picker in the classroom modal to be a DateTimePicker. This PR also includes a bunch of minor UI fixes related to this change; have a look at the commits for a full list.

<img width="1206" alt="image" src="https://github.com/uwblueprint/jump-math/assets/9922514/35c59b49-0f7c-4825-ba15-ee93ea99a87a">
<img width="1179" alt="image" src="https://github.com/uwblueprint/jump-math/assets/9922514/ba68cbbd-6a9e-4136-94a4-cdf841ebf18a">



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open the add classroom modal.
2. Validate the time looks good and validation still occurs.
3. Save a classroom and verify editing still works.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
